### PR TITLE
Support for fetching additional global security states, guarded by a permission check granted for apps signed with known certdigests

### DIFF
--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -2817,6 +2817,13 @@
     <permission android:name="android.permission.READ_OEM_UNLOCK_STATE"
         android:protectionLevel="signature|privileged" />
 
+    <!-- Allows reading additional security state information, such as OEM unlock state,
+         along with added security state downstream.
+         @hide <p>Not for use by third-party applications. -->
+    <permission android:name="android.permission.READ_ADDITIONAL_SECURITY_STATE"
+        android:protectionLevel="internal|knownSigner"
+        android:knownCerts="@array/read_additional_security_state_known_signers" />
+
     <!-- @hide Allows enabling/disabling OEM unlock
    <p>Not for use by third-party applications. -->
     <permission android:name="android.permission.OEM_UNLOCK_STATE"

--- a/core/res/res/values/config_ext.xml
+++ b/core/res/res/values/config_ext.xml
@@ -38,4 +38,14 @@
 
     <string name="config_first_party_app_source_package_name">app.grapheneos.apps</string>
     <java-symbol type="string" name="config_first_party_app_source_package_name" />
+
+    <!-- Certificate digests for trusted apps that will be allowed to obtain the knownSigner
+         read additional security state permission.
+         The digest should be computed over the DER encoding of the trusted certificate
+         using the SHA-256 digest algorithm. -->
+    <string-array name="read_additional_security_state_known_signers">
+        <!-- bundled Auditor app certdigest -->
+        <item>990e04f0864b19f14f84e0e432f7a393f297ab105a22c1e1b10b442a4a62c42c</item>
+    </string-array>
+    <java-symbol type="array" name="read_additional_security_state_known_signers" />
 </resources>

--- a/services/core/java/com/android/server/SecurityStateManagerService.java
+++ b/services/core/java/com/android/server/SecurityStateManagerService.java
@@ -75,7 +75,8 @@ public class SecurityStateManagerService extends ISecurityStateManager.Stub {
     private String getSpl(String packageName) {
         if (!TextUtils.isEmpty(packageName)) {
             try {
-                return mPackageManager.getPackageInfo(packageName, 0 /* flags */).versionName;
+                final int callingUser = android.os.Binder.getCallingUserHandle().getIdentifier();
+                return mPackageManager.getPackageInfoAsUser(packageName, 0 /* flags */, callingUser).versionName;
             } catch (PackageManager.NameNotFoundException e) {
                 Slog.e(TAG, TextUtils.formatSimple("Failed to get SPL for package %s.",
                         packageName), e);

--- a/services/core/java/com/android/server/SecurityStateManagerService.java
+++ b/services/core/java/com/android/server/SecurityStateManagerService.java
@@ -69,6 +69,7 @@ public class SecurityStateManagerService extends ISecurityStateManager.Stub {
         globalSecurityState.putString(KEY_KERNEL_VERSION, getKernelVersion());
         addWebViewPackages(globalSecurityState);
         addSecurityStatePackages(globalSecurityState);
+        SecurityStateManagerServiceExt.appendSecurityStateExt(mContext, globalSecurityState);
         return globalSecurityState;
     }
 

--- a/services/core/java/com/android/server/SecurityStateManagerServiceExt.java
+++ b/services/core/java/com/android/server/SecurityStateManagerServiceExt.java
@@ -1,0 +1,80 @@
+package com.android.server;
+
+import android.Manifest;
+import android.annotation.NonNull;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.ext.settings.ExtSettings;
+import android.ext.settings.UsbPortSecurity;
+import android.os.Binder;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.service.oemlock.OemLockManager;
+
+import com.android.server.pm.UserManagerInternal;
+
+public class SecurityStateManagerServiceExt {
+
+    // Copy the keys for apps fetching the extra security state values.
+    private static final String SECURITY_STATE_EXT_KEY = "android.ext.SECURITY_STATE_EXT";
+
+    private static final String AUTO_REBOOT_TIMEOUT_KEY = "android.ext.AUTO_REBOOT_TIMEOUT";
+    private static final String USB_PORT_SECURITY_MODE_KEY = "android.ext.USB_PORT_SECURITY_MODE";
+    private static final String OEM_UNLOCK_ALLOWED_KEY = "android.ext.OEM_UNLOCK_ALLOWED";
+    private static final String USER_COUNT_KEY = "android.ext.USER_COUNT";
+
+    static void appendSecurityStateExt(@NonNull Context ctx, @NonNull Bundle securityState) {
+        final int callingUid = Binder.getCallingUid();
+        final int callingUserId = UserHandle.getUserId(callingUid);
+        if (ctx.checkCallingPermission(
+                Manifest.permission.READ_ADDITIONAL_SECURITY_STATE)
+                != PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+
+        Bundle securityStateExt = new Bundle();
+
+        {
+            // For future reference where autoreboot is unsupported on certain build configurations,
+            // such as microdroid builds.
+            final boolean isAutoRebootTimeoutSupported = true;
+            if (isAutoRebootTimeoutSupported) {
+                int autoRebootTimeoutMillis = ExtSettings.AUTO_REBOOT_TIMEOUT.get(ctx);
+                securityStateExt.putInt(AUTO_REBOOT_TIMEOUT_KEY, autoRebootTimeoutMillis);
+            }
+        }
+
+        {
+            boolean isUsbPortSecuritySupported = ctx.getResources().getBoolean(
+                    com.android.internal.R.bool.config_usbPortSecuritySupported);
+            if (isUsbPortSecuritySupported) {
+                int usbSecurityStateMode = UsbPortSecurity.MODE_SETTING.get(ctx);
+                securityStateExt.putInt(USB_PORT_SECURITY_MODE_KEY, usbSecurityStateMode);
+            }
+        }
+
+        {
+            UserManagerInternal userManagerInternal = LocalServices.getService(UserManagerInternal.class);
+            if (userManagerInternal != null) {
+                var users = userManagerInternal.getUsers(true, true, true);
+                int userCount = users.size();
+                securityStateExt.putInt(USER_COUNT_KEY, userCount);
+            }
+        }
+
+        {
+            long token = Binder.clearCallingIdentity();
+            try {
+                OemLockManager oemLockManager = ctx.getSystemService(OemLockManager.class);
+                if (oemLockManager != null) {
+                    boolean isOemUnlockAllowed = oemLockManager.isOemUnlockAllowedByUser();
+                    securityStateExt.putBoolean(OEM_UNLOCK_ALLOWED_KEY, isOemUnlockAllowed);
+                }
+            } finally {
+                Binder.restoreCallingIdentity(token);
+            }
+        }
+
+        securityState.putBundle(SECURITY_STATE_EXT_KEY, securityStateExt);
+    }
+}

--- a/services/core/java/com/android/server/SecurityStateManagerServiceExt.java
+++ b/services/core/java/com/android/server/SecurityStateManagerServiceExt.java
@@ -9,7 +9,6 @@ import android.ext.settings.UsbPortSecurity;
 import android.os.Binder;
 import android.os.Bundle;
 import android.os.UserHandle;
-import android.service.oemlock.OemLockManager;
 
 import com.android.server.pm.UserManagerInternal;
 
@@ -20,7 +19,6 @@ public class SecurityStateManagerServiceExt {
 
     private static final String AUTO_REBOOT_TIMEOUT_KEY = "android.ext.AUTO_REBOOT_TIMEOUT";
     private static final String USB_PORT_SECURITY_MODE_KEY = "android.ext.USB_PORT_SECURITY_MODE";
-    private static final String OEM_UNLOCK_ALLOWED_KEY = "android.ext.OEM_UNLOCK_ALLOWED";
     private static final String USER_COUNT_KEY = "android.ext.USER_COUNT";
 
     static void appendSecurityStateExt(@NonNull Context ctx, @NonNull Bundle securityState) {
@@ -59,19 +57,6 @@ public class SecurityStateManagerServiceExt {
                 var users = userManagerInternal.getUsers(true, true, true);
                 int userCount = users.size();
                 securityStateExt.putInt(USER_COUNT_KEY, userCount);
-            }
-        }
-
-        {
-            long token = Binder.clearCallingIdentity();
-            try {
-                OemLockManager oemLockManager = ctx.getSystemService(OemLockManager.class);
-                if (oemLockManager != null) {
-                    boolean isOemUnlockAllowed = oemLockManager.isOemUnlockAllowedByUser();
-                    securityStateExt.putBoolean(OEM_UNLOCK_ALLOWED_KEY, isOemUnlockAllowed);
-                }
-            } finally {
-                Binder.restoreCallingIdentity(token);
             }
         }
 


### PR DESCRIPTION
This adds support for fetching added security state, such as USB-C settings and Auto reboot timeout value, guarded by a permission only granted for apps signed with appropriate keys.