### PR TITLE
improve reliability and error reporting in USB-C port control feature

### DIFF
--- a/core/java/android/hardware/usb/UsbManager.java
+++ b/core/java/android/hardware/usb/UsbManager.java
@@ -1620,6 +1620,12 @@ public class UsbManager {
     }
 
     /** @hide */
+    public static final int SET_PORT_SECURITY_STATE_RESULT_CODE_FRAMEWORK_EXCEPTION = 100; // lower values are reserved for IUsbExt error codes
+    /** @hide */
+    public static final String SET_PORT_SECURITY_STATE_EXCEPTION_KEY = "exception";
+
+    /** @hide */
+    @RequiresPermission(Manifest.permission.MANAGE_USB)
     public void setPortSecurityState(@NonNull UsbPort port,
             @android.hardware.usb.ext.PortSecurityState int state,
             @NonNull android.os.ResultReceiver statusCallback) {

--- a/core/java/android/os/Bundle.java
+++ b/core/java/android/os/Bundle.java
@@ -1422,6 +1422,16 @@ public final class Bundle extends BaseBundle implements Cloneable, Parcelable {
     }
 
     /**
+     * Same as {@link #toString()}, but unparcels the internal map if it isn't unparcelled already,
+     * which ensures that the internal map contents are included in the result.
+     * @hide
+     */
+    public String toStringDeep() {
+        unparcel();
+        return toString();
+    }
+
+    /**
      * @hide
      */
     public synchronized String toShortString() {

--- a/core/res/res/values/string_ext.xml
+++ b/core/res/res/values/string_ext.xml
@@ -52,4 +52,7 @@
     <string name="notif_storage_dcl_title">%1$s tried to perform DCL via storage</string>
     <java-symbol type="string" name="notif_storage_dcl_title" />
 
+    <string name="usb_port_security_error_title">USB-C port security feature has malfunctioned</string>
+    <java-symbol type="string" name="usb_port_security_error_title" />
+
 </resources>

--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -2357,6 +2357,7 @@ public class ActivityManagerService extends IActivityManager.Stub
             } else if (phase == PHASE_THIRD_PARTY_APPS_CAN_START) {
                 mService.mPackageWatchdog.onPackagesReady();
                 mService.scheduleHomeTimeout();
+                com.android.server.ext.SystemJournalNotif.onSystemServerInited();
             }
         }
 

--- a/services/core/java/com/android/server/ext/DropBoxMonitor.java
+++ b/services/core/java/com/android/server/ext/DropBoxMonitor.java
@@ -294,7 +294,7 @@ public class DropBoxMonitor {
             i.putExtra(LogViewerApp.EXTRA_ERROR_TYPE, "fsck_error");
             i.putExtra(LogViewerApp.EXTRA_SHOW_REPORT_BUTTON, true);
 
-            SystemJournalNotif.showGeneric(context, e.getTimeMillis(), context.getString(R.string.fsck_error_notif_title), i);
+            SystemJournalNotif.show(context, e.getTimeMillis(), context.getString(R.string.fsck_error_notif_title), i);
         }
     }
 

--- a/services/core/java/com/android/server/ext/SystemErrorNotification.java
+++ b/services/core/java/com/android/server/ext/SystemErrorNotification.java
@@ -1,0 +1,37 @@
+package com.android.server.ext;
+
+import android.annotation.CurrentTimeMillisLong;
+import android.annotation.Nullable;
+import android.content.Context;
+import android.content.Intent;
+import android.ext.LogViewerApp;
+import android.util.Slog;
+
+public class SystemErrorNotification {
+    static final String TAG = SystemErrorNotification.class.getSimpleName();
+
+    public @CurrentTimeMillisLong long when = System.currentTimeMillis();
+    public final String type;
+    public final String title;
+    public final String message;
+    public boolean showReportButton = true;
+
+    public SystemErrorNotification(String type, String message) {
+        this(type, type, message);
+    }
+
+    public SystemErrorNotification(String type, String title, String message) {
+        this.type = type;
+        this.title = title;
+        this.message = message;
+    }
+
+    public void show(@Nullable Context ctx) {
+        var i = LogViewerApp.createBaseErrorReportIntent(message);
+        i.putExtra(Intent.EXTRA_TITLE, title);
+        i.putExtra(LogViewerApp.EXTRA_ERROR_TYPE, type);
+        i.putExtra(LogViewerApp.EXTRA_SHOW_REPORT_BUTTON, showReportButton);
+        Slog.e(TAG, type + ", title: " + title + ", message: " + message);
+        SystemJournalNotif.show(ctx, when, title, i);
+    }
+}

--- a/services/core/java/com/android/server/ext/SystemJournalNotif.java
+++ b/services/core/java/com/android/server/ext/SystemJournalNotif.java
@@ -2,19 +2,24 @@ package com.android.server.ext;
 
 import android.annotation.CurrentTimeMillisLong;
 import android.app.ActivityManager;
+import android.app.ActivityThread;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.ext.LogViewerApp;
+import android.os.Handler;
 import android.os.UserHandle;
 
 import com.android.internal.R;
 import com.android.internal.messages.nano.SystemMessageProto;
 import com.android.internal.notification.SystemNotificationChannels;
+import com.android.internal.os.BackgroundThread;
 
-class SystemJournalNotif {
+import java.util.ArrayList;
+
+public class SystemJournalNotif {
 
     static void showCrash(Context ctx, String progName, String errorReport,
                           @CurrentTimeMillisLong long crashTimestamp, boolean showReportButton) {
@@ -22,10 +27,26 @@ class SystemJournalNotif {
         i.putExtra(Intent.EXTRA_TITLE, progName + " crash");
         i.putExtra(LogViewerApp.EXTRA_SHOW_REPORT_BUTTON, showReportButton);
 
-        showGeneric(ctx, crashTimestamp, ctx.getString(R.string.process_crash_notif_title, progName), i);
+        show(ctx, crashTimestamp, ctx.getString(R.string.process_crash_notif_title, progName), i);
     }
 
-    static void showGeneric(Context ctx, @CurrentTimeMillisLong long when, String notifTitle, Intent mainIntent) {
+    // If ctx is null then default system context will be used as a fallback
+    static void show(@Nullable Context ctx, @CurrentTimeMillisLong long when, String notifTitle, Intent mainIntent) {
+        synchronized (pendingActions) {
+            if (!isSystemServerInited) {
+                // NotificationManagerService isn't ready yet, delay this notification until after
+                // system_server init completion
+                pendingActions.add(() -> showInner(ctx, when, notifTitle, mainIntent));
+                return;
+            }
+        }
+        showInner(ctx, when, notifTitle, mainIntent);
+    }
+
+    private static void showInner(@Nullable Context ctx, @CurrentTimeMillisLong long when, String notifTitle, Intent mainIntent) {
+        if (ctx == null) {
+            ctx = ActivityThread.currentActivityThread().getSystemContext();
+        }
         var b = new Notification.Builder(ctx, SystemNotificationChannels.SYSTEM_JOURNAL);
         b.setSmallIcon(R.drawable.ic_error);
         b.setContentTitle(notifTitle);
@@ -38,12 +59,27 @@ class SystemJournalNotif {
 
         var pi = PendingIntent.getActivityAsUser(ctx, 0, mainIntent,
                 PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_ONE_SHOT, null, user);
-
         b.setContentIntent(pi);
 
         var nm = ctx.getSystemService(NotificationManager.class);
-
         nm.notifyAsUser(null, createNotifId(), b.build(), user);
+    }
+
+    private static final ArrayList<Runnable> pendingActions = new ArrayList<>();
+    // protected by lock of pendingActions object
+    private static boolean isSystemServerInited;
+
+    public static void onSystemServerInited() {
+        final Runnable[] actions;
+        synchronized (pendingActions) {
+            isSystemServerInited = true;
+            actions = pendingActions.toArray(new Runnable[0]);
+            pendingActions.clear();
+        }
+        Handler bgHandler = BackgroundThread.getHandler();
+        for (int i = 0; i < actions.length; ++i) {
+            bgHandler.post(actions[i]);
+        }
     }
 
     private static int notifIdSrc = SystemMessageProto.SystemMessage.NOTE_SYSTEM_JOURNAL_BASE;

--- a/services/core/java/com/android/server/policy/keyguard/UsbPortSecurityHooks.java
+++ b/services/core/java/com/android/server/policy/keyguard/UsbPortSecurityHooks.java
@@ -11,6 +11,7 @@ import android.hardware.usb.UsbPort;
 import android.hardware.usb.UsbPortStatus;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.HandlerThread;
 import android.os.ResultReceiver;
 import android.os.UserHandle;
 import android.util.Slog;
@@ -28,11 +29,15 @@ public class UsbPortSecurityHooks {
     private static UsbPortSecurityHooks INSTANCE;
 
     private final Context context;
-    private final Handler handler = BackgroundThread.getHandler();
+    private final Handler handler;
     private final UsbManager usbManager;
 
     private UsbPortSecurityHooks(Context ctx) {
         this.context = ctx;
+        // use a dedicated thread to guarantee that the callbacks do not stall
+        var ht = new HandlerThread(TAG);
+        ht.start();
+        this.handler = ht.getThreadHandler();
         this.usbManager = Objects.requireNonNull(ctx.getSystemService(UsbManager.class));
     }
 

--- a/services/usb/java/com/android/server/usb/hal/port/UsbPortAidl.java
+++ b/services/usb/java/com/android/server/usb/hal/port/UsbPortAidl.java
@@ -144,6 +144,7 @@ public final class UsbPortAidl implements UsbPortHal {
     public void serviceDied() {
         logAndPrint(Log.ERROR, mPw, "Usb AIDL hal service died");
         synchronized (mLock) {
+            mBinder = null;
             mProxy = null;
         }
         connectToProxy(null);
@@ -461,7 +462,11 @@ public final class UsbPortAidl implements UsbPortHal {
     public void setPortSecurityState(String portName,
                                      @android.hardware.usb.ext.PortSecurityState int state,
                                      android.os.ResultReceiver callback) {
-        UsbPortAidlExt.setPortSecurityState(mBinder, portName, state, callback);
+        IBinder usbHal;
+        synchronized (mLock) {
+            usbHal = mBinder;
+        }
+        UsbPortAidlExt.setPortSecurityState(usbHal, portName, state, callback);
     }
 
     private static class HALCallback extends IUsbCallback.Stub {

--- a/services/usb/java/com/android/server/usb/hal/port/UsbPortAidl.java
+++ b/services/usb/java/com/android/server/usb/hal/port/UsbPortAidl.java
@@ -40,8 +40,6 @@ import android.hardware.usb.AltModeData;
 import android.hardware.usb.AltModeData.DisplayPortAltModeData;
 import android.hardware.usb.DisplayPortAltModePinAssignment;
 import android.hardware.usb.flags.Flags;
-import android.hardware.usb.ext.IUsbExt;
-import android.hardware.usb.ext.PortSecurityState;
 import android.os.Build;
 import android.os.ServiceManager;
 import android.os.IBinder;
@@ -463,52 +461,7 @@ public final class UsbPortAidl implements UsbPortHal {
     public void setPortSecurityState(String portName,
                                      @android.hardware.usb.ext.PortSecurityState int state,
                                      android.os.ResultReceiver callback) {
-        IBinder ext;
-        try {
-            ext = mBinder.getExtension();
-        } catch (RemoteException e) {
-            Slog.e(TAG, "", e);
-            throw new UnsupportedOperationException(e);
-        }
-
-        if (ext == null) {
-            Slog.d(TAG, "setPortSecurityState: no IUsbExt");
-            throw new UnsupportedOperationException();
-        }
-
-        var halCallback = new android.hardware.usb.ext.IPortSecurityStateCallback.Stub() {
-            @Override
-            public void onSetPortSecurityStateCompleted(int status, int arg1, String arg2) {
-                Slog.d(TAG, "onSetPortSecurityStateCompleted, status: " + status);
-                android.os.Bundle b = null;
-                if (arg1 != 0 || arg2 != null) {
-                    b = new android.os.Bundle();
-                    b.putInt("arg1", arg1);
-                    b.putString("arg2", arg2);
-                }
-                callback.send(status, b);
-            }
-
-            @Override
-            public String getInterfaceHash() {
-                return android.hardware.usb.ext.IPortSecurityStateCallback.HASH;
-            }
-
-            @Override
-            public int getInterfaceVersion() {
-                return android.hardware.usb.ext.IPortSecurityStateCallback.VERSION;
-            }
-        };
-
-        Slog.d(TAG, "setPortSecurityState, port: " + portName + ", state " + state);
-
-        IUsbExt usbExt = IUsbExt.Stub.asInterface(ext);
-        try {
-            usbExt.setPortSecurityState(portName, state, halCallback);
-        } catch (RemoteException e) {
-            Slog.e(TAG, "", e);
-            throw new android.os.ParcelableException(e);
-        }
+        UsbPortAidlExt.setPortSecurityState(mBinder, portName, state, callback);
     }
 
     private static class HALCallback extends IUsbCallback.Stub {

--- a/services/usb/java/com/android/server/usb/hal/port/UsbPortAidlExt.java
+++ b/services/usb/java/com/android/server/usb/hal/port/UsbPortAidlExt.java
@@ -1,0 +1,67 @@
+package com.android.server.usb.hal.port;
+
+import android.annotation.Nullable;
+import android.hardware.usb.UsbManager;
+import android.hardware.usb.ext.IUsbExt;
+import android.hardware.usb.ext.PortSecurityState;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.os.ParcelableException;
+import android.os.RemoteException;
+import android.os.ResultReceiver;
+import android.util.Slog;
+
+class UsbPortAidlExt {
+    static final String TAG = UsbPortAidlExt.class.getSimpleName();
+
+    static void setPortSecurityState(IBinder usbHal, String portName,
+                                 @android.hardware.usb.ext.PortSecurityState int state,
+                                 ResultReceiver callback) {
+        IBinder ext;
+        try {
+            ext = usbHal.getExtension();
+        } catch (RemoteException e) {
+            Slog.e(TAG, "", e);
+            throw new UnsupportedOperationException(e);
+        }
+
+        if (ext == null) {
+            Slog.d(TAG, "setPortSecurityState: no IUsbExt");
+            throw new UnsupportedOperationException();
+        }
+
+        var halCallback = new android.hardware.usb.ext.IPortSecurityStateCallback.Stub() {
+            @Override
+            public void onSetPortSecurityStateCompleted(int status, int arg1, String arg2) {
+                Slog.d(TAG, "onSetPortSecurityStateCompleted, status: " + status);
+                android.os.Bundle b = null;
+                if (arg1 != 0 || arg2 != null) {
+                    b = new android.os.Bundle();
+                    b.putInt("arg1", arg1);
+                    b.putString("arg2", arg2);
+                }
+                callback.send(status, b);
+            }
+
+            @Override
+            public String getInterfaceHash() {
+                return android.hardware.usb.ext.IPortSecurityStateCallback.HASH;
+            }
+
+            @Override
+            public int getInterfaceVersion() {
+                return android.hardware.usb.ext.IPortSecurityStateCallback.VERSION;
+            }
+        };
+
+        Slog.d(TAG, "setPortSecurityState, port: " + portName + ", state " + state);
+
+        IUsbExt usbExt = IUsbExt.Stub.asInterface(ext);
+        try {
+            usbExt.setPortSecurityState(portName, state, halCallback);
+        } catch (RemoteException e) {
+            Slog.e(TAG, "", e);
+            throw new android.os.ParcelableException(e);
+        }
+    }
+}

--- a/services/usb/java/com/android/server/usb/hal/port/UsbPortAidlExt.java
+++ b/services/usb/java/com/android/server/usb/hal/port/UsbPortAidlExt.java
@@ -14,10 +14,15 @@ import android.util.Slog;
 class UsbPortAidlExt {
     static final String TAG = UsbPortAidlExt.class.getSimpleName();
 
-    static void setPortSecurityState(IBinder usbHal, String portName,
-                                 @android.hardware.usb.ext.PortSecurityState int state,
-                                 ResultReceiver callback) {
-        IBinder ext;
+    static void setPortSecurityState(@Nullable IBinder usbHal, String portName,
+                                     @PortSecurityState int state,
+                                     ResultReceiver callback) {
+        if (usbHal == null) {
+            sendSpssExceptionResult(new RuntimeException("USB HAL is null"), callback);
+            return;
+        }
+
+        final IBinder ext;
         try {
             ext = usbHal.getExtension();
         } catch (RemoteException e) {


### PR DESCRIPTION
Part of a changelist:
https://github.com/GrapheneOS/device_google_gs101/pull/53
https://github.com/GrapheneOS/device_google_gs201/pull/28
https://github.com/GrapheneOS/device_google_zuma/pull/19
https://github.com/GrapheneOS/platform_system_sepolicy/pull/62

14-caimito:
https://github.com/GrapheneOS/platform_frameworks_base/pull/14
https://github.com/GrapheneOS/device_google_zumapro/pull/9

15:
https://github.com/GrapheneOS/platform_frameworks_base/pull/15
https://github.com/GrapheneOS/device_google_gs101/pull/54
https://github.com/GrapheneOS/device_google_gs201/pull/29
https://github.com/GrapheneOS/device_google_zuma/pull/20
https://github.com/GrapheneOS/device_google_zumapro/pull/8
https://github.com/GrapheneOS/platform_system_sepolicy/pull/63

