### PR TITLE
fix an upstream race condition in handling of system error files

### DIFF
--- a/services/core/java/com/android/server/BootReceiver.java
+++ b/services/core/java/com/android/server/BootReceiver.java
@@ -488,11 +488,15 @@ public class BootReceiver extends BroadcastReceiver {
         if (fileTime <= 0) return false;  // File does not exist
 
         final String filename = file.getPath();
-        if (timestamps.containsKey(filename) && timestamps.get(filename) == fileTime) {
-            return false;  // Already logged this particular file
-        }
+        synchronized (timestamps) {
+            Long prevFileTime = timestamps.get(filename);
+            if (prevFileTime != null && prevFileTime.longValue() == fileTime) {
+                Slog.d(TAG, "already logged " + filename);
+                return false;  // Already logged this particular file
+            }
 
-        timestamps.put(filename, fileTime);
+            timestamps.put(filename, fileTime);
+        }
         return true;
     }
 
@@ -875,7 +879,22 @@ public class BootReceiver extends BroadcastReceiver {
         Slog.i(TAG, "fs_stat, partition:" + partition + " stat:0x" + Integer.toHexString(stat));
     }
 
+    private static HashMap<String, Long> logFileTimestamps;
+
     private static HashMap<String, Long> readTimestamps() {
+        synchronized (sFile) {
+            HashMap<String, Long> res = logFileTimestamps;
+            if (res == null) {
+                // Timestamps file is rewritten after it's modified and there's more than one writer
+                // thread. Read timestamps file at most once to avoid a race condition.
+                res = readTimestampsInner();
+                logFileTimestamps = res;
+            }
+            return res;
+        }
+    }
+
+    private static HashMap<String, Long> readTimestampsInner() {
         synchronized (sFile) {
             HashMap<String, Long> timestamps = new HashMap<String, Long>();
             boolean success = false;


### PR DESCRIPTION
System error file contents are added to the DropBox when file's timestamp changes. Last known file timestamps are kept in a separate file. This race condition caused some updates to last known timestamps getting lost, which led to their corresponding system error files being treated as new system errors after device reboot.