### PR TITLE
fix KGUM.onPostureChanged() NPE SystemUI crash on foldable devices

### DIFF
--- a/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardUpdateMonitor.java
@@ -1873,7 +1873,10 @@ public class KeyguardUpdateMonitor implements TrustManager.TrustListener, Dumpab
                     if (posture == DEVICE_POSTURE_OPENED) {
                         mLogger.d("Posture changed to open - attempting to request active"
                                 + " unlock and run face auth");
-                        getFaceAuthInteractor().onDeviceUnfolded();
+                        var faceAuthInteractor = getFaceAuthInteractor();
+                        if (faceAuthInteractor != null) {
+                            faceAuthInteractor.onDeviceUnfolded();
+                        }
                         requestActiveUnlockFromWakeReason(PowerManager.WAKE_REASON_UNFOLD_DEVICE,
                                 false);
                     }


### PR DESCRIPTION
GrapheneOS doesn't ship face unlock.