### PR TITLE
don't remove app widgets from user's home screen when the user stops

### DIFF
--- a/services/appwidget/java/com/android/server/appwidget/AppWidgetService.java
+++ b/services/appwidget/java/com/android/server/appwidget/AppWidgetService.java
@@ -52,7 +52,7 @@ public class AppWidgetService extends SystemService {
 
     @Override
     public void onUserStopping(@NonNull TargetUser user) {
-        mImpl.onUserStopped(user.getUserIdentifier());
+        mImpl.onUserStopping(user.getUserIdentifier());
     }
 
     @Override

--- a/services/appwidget/java/com/android/server/appwidget/AppWidgetServiceImpl.java
+++ b/services/appwidget/java/com/android/server/appwidget/AppWidgetServiceImpl.java
@@ -3782,7 +3782,7 @@ class AppWidgetServiceImpl extends IAppWidgetService.Stub implements WidgetBacku
         return new AtomicFile(settingsFile);
     }
 
-    void onUserStopped(int userId) {
+    void onUserStopping(int userId) {
         if (DEBUG) {
             Slog.i(TAG, "onUserStopped() " + userId);
         }
@@ -3802,6 +3802,10 @@ class AppWidgetServiceImpl extends IAppWidgetService.Stub implements WidgetBacku
                 // as we do not want to make host callbacks and provider broadcasts
                 // as the host and the provider will be killed.
                 if (hostInUser && (!hasProvider || providerInUser)) {
+                    // The user's app widget host (i.e. the launcher) is usually still running at
+                    // this point. Don't notify it that the widget is removed to avoid affecting
+                    // homescreen configuration
+                    widget.host.callbacks = null;
                     removeWidgetLocked(widget);
                     widget.host.widgets.remove(widget);
                     widget.host = null;


### PR DESCRIPTION
onUserStopped() method name was misleading, it's called from onUserStopping(), while the user is still running.

Initial research was done by maade93791 <70593890+maade69@users.noreply.github.com>

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/453