### PR TITLE
Prevent GmsCore NPE in RecoverySystem

### DIFF
--- a/core/java/android/os/RecoverySystem.java
+++ b/core/java/android/os/RecoverySystem.java
@@ -27,6 +27,7 @@ import android.annotation.SystemApi;
 import android.annotation.SystemService;
 import android.app.KeyguardManager;
 import android.app.PendingIntent;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.BroadcastReceiver;
 import android.content.ContentResolver;
@@ -711,7 +712,8 @@ public class RecoverySystem {
         }
 
         RecoverySystem rs = (RecoverySystem) context.getSystemService(Context.RECOVERY_SERVICE);
-        if (!rs.requestLskf(context.getPackageName(), intentSender)) {
+        if ((GmsCompat.isEnabled() && rs == null) ||
+                !rs.requestLskf(context.getPackageName(), intentSender)) {
             throw new IOException("preparation for update failed");
         }
     }


### PR DESCRIPTION
Fix bug with crash report:

```
type: crash
osVersion: google/bluejay/bluejay:15/AP3A.241005.015/2024102400:user/release-keys
package: com.google.android.gms:244134035
process: com.google.android.gms
processUptime: 26556 + 1173 ms
installer: com.android.vending
GmsCompatConfig version: 145

java.lang.NullPointerException: Attempt to invoke direct method 'boolean android.os.RecoverySystem.requestLskf(java.lang.String, android.content.IntentSender)' on a null object reference
	at android.os.RecoverySystem.prepareForUnattendedUpdate(RecoverySystem.java:714)
	at com.google.android.gms.update.control.DeviceControl.g(:com.google.android.gms@244134035@24.41.34 (260400-685836814):34)
	at com.google.android.gms.update.control.InstallationControl.w(:com.google.android.gms@244134035@24.41.34 (260400-685836814):48)
	at dtjb.a(:com.google.android.gms@244134035@24.41.34 (260400-685836814):229)
	at com.google.android.gms.update.control.InstallationControl.u(:com.google.android.gms@244134035@24.41.34 (260400-685836814):120)
	at dtlb.a(:com.google.android.gms@244134035@24.41.34 (260400-685836814):78)
	at com.google.android.gms.update.execution.InstallationIntentOperation.onHandleIntent(:com.google.android.gms@244134035@24.41.34 (260400-685836814):150)
	at com.google.android.chimera.IntentOperation.onHandleIntent(:com.google.android.gms@244134035@24.41.34 (260400-685836814):2)
	at ajgr.onHandleIntent(:com.google.android.gms@244134035@24.41.34 (260400-685836814):8)
	at ogt.run(:com.google.android.gms@244134035@24.41.34 (260400-685836814):70)
	at ogs.run(:com.google.android.gms@244134035@24.41.34 (260400-685836814):152)
	at ethj.run(:com.google.android.gms@244134035@24.41.34 (260400-685836814):21)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
	at java.lang.Thread.run(Thread.java:1012)
```