### PR TITLE
gmscompat: fix dev build options, ignore uses-permission in GSF AndroidManifest; improve handling of OTHER_SENSORS

### DIFF
--- a/core/api/system-current.txt
+++ b/core/api/system-current.txt
@@ -2140,7 +2140,6 @@ package android.app.compat.gms {
     method public static boolean isAndroidAuto();
     method public static boolean isEnabled();
     method public static boolean isEnabledFor(@NonNull android.content.pm.ApplicationInfo);
-    method public static boolean isEnabledFor(int, boolean);
     method public static boolean isEnabledFor(@NonNull String, int);
   }
 

--- a/core/api/system-lint-baseline.txt
+++ b/core/api/system-lint-baseline.txt
@@ -2031,8 +2031,6 @@ UnflaggedApi: android.app.compat.gms.GmsCompat#isEnabledFor(String, int):
     New API must be flagged with @FlaggedApi: method android.app.compat.gms.GmsCompat.isEnabledFor(String,int)
 UnflaggedApi: android.app.compat.gms.GmsCompat#isEnabledFor(android.content.pm.ApplicationInfo):
     New API must be flagged with @FlaggedApi: method android.app.compat.gms.GmsCompat.isEnabledFor(android.content.pm.ApplicationInfo)
-UnflaggedApi: android.app.compat.gms.GmsCompat#isEnabledFor(int, boolean):
-    New API must be flagged with @FlaggedApi: method android.app.compat.gms.GmsCompat.isEnabledFor(int,boolean)
 UnflaggedApi: android.app.compat.gms.GmsUtils:
     New API must be flagged with @FlaggedApi: class android.app.compat.gms.GmsUtils
 UnflaggedApi: android.app.compat.gms.GmsUtils#createAppPlayStoreIntent(String):

--- a/core/java/android/app/ActivityThread.java
+++ b/core/java/android/app/ActivityThread.java
@@ -59,6 +59,7 @@ import android.app.backup.BackupAgent;
 import android.app.backup.BackupAnnotations.BackupDestination;
 import android.app.backup.BackupAnnotations.OperationType;
 import android.app.compat.CompatChanges;
+import android.app.compat.gms.GmsCompat;
 import android.app.sdksandbox.sandboxactivity.ActivityContextInfo;
 import android.app.sdksandbox.sandboxactivity.SdkSandboxActivityAuthority;
 import android.app.servertransaction.ActivityLifecycleItem;
@@ -231,6 +232,7 @@ import com.android.internal.annotations.GuardedBy;
 import com.android.internal.annotations.VisibleForTesting;
 import com.android.internal.app.IVoiceInteractor;
 import com.android.internal.content.ReferrerIntent;
+import com.android.internal.gmscompat.GmcDebug;
 import com.android.internal.os.BinderCallsStats;
 import com.android.internal.os.BinderInternal;
 import com.android.internal.os.RuntimeInit;
@@ -4780,6 +4782,9 @@ public final class ActivityThread extends ClientTransactionHandler
 
             sCurrentBroadcastIntent.set(data.intent);
             receiver.setPendingResult(data);
+            if (GmsCompat.isEnabled()) {
+                GmcDebug.maybeLogReceiveBroadcast(receiver, data.intent, true);
+            }
             receiver.onReceive(context.getReceiverRestrictedContext(),
                     data.intent);
         } catch (Exception e) {
@@ -5170,6 +5175,9 @@ public final class ActivityThread extends ClientTransactionHandler
                 }
                 int res;
                 if (!data.taskRemoved) {
+                    if (GmsCompat.isEnabled()) {
+                        GmcDebug.maybeLogServiceOnStartCommand(s, data.args, data.flags, data.startId);
+                    }
                     res = s.onStartCommand(data.args, data.flags, data.startId);
                 } else {
                     s.onTaskRemoved(data.args);

--- a/core/java/android/app/ContextImpl.java
+++ b/core/java/android/app/ContextImpl.java
@@ -22,6 +22,8 @@ import static android.os.StrictMode.vmIncorrectContextUseEnabled;
 import static android.permission.flags.Flags.shouldRegisterAttributionSource;
 import static android.view.WindowManager.LayoutParams.WindowType;
 import static com.android.internal.app.ContentProviderRedirector.translateContentProviderAuthority;
+import static com.android.internal.gmscompat.GmcDebug.maybeLogSendBroadcast;
+import static com.android.internal.gmscompat.GmcDebug.maybeLogStartService;
 
 import android.Manifest;
 import android.annotation.CallbackExecutor;
@@ -104,6 +106,7 @@ import android.window.WindowTokenClient;
 import android.window.WindowTokenClientController;
 
 import com.android.internal.annotations.GuardedBy;
+import com.android.internal.gmscompat.GmcDebug;
 import com.android.internal.gmscompat.sysservice.GmcPackageManager;
 import com.android.internal.gmscompat.GmsHooks;
 import com.android.internal.gmscompat.sysservice.GmcUserManager;
@@ -1251,6 +1254,9 @@ class ContextImpl extends Context {
 
     @Override
     public void sendBroadcast(Intent intent) {
+        if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, null, null, 0);
+        }
         warnIfCallingFromSystemProcess();
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         try {
@@ -1266,6 +1272,9 @@ class ContextImpl extends Context {
 
     @Override
     public void sendBroadcast(Intent intent, String receiverPermission) {
+        if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, receiverPermission, null, 0);
+        }
         warnIfCallingFromSystemProcess();
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         String[] receiverPermissions = receiverPermission == null ? null
@@ -1284,6 +1293,9 @@ class ContextImpl extends Context {
 
     @Override
     public void sendBroadcastMultiplePermissions(Intent intent, String[] receiverPermissions) {
+        if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, null, receiverPermissions, null, null, 0);
+        }
         warnIfCallingFromSystemProcess();
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         try {
@@ -1301,6 +1313,9 @@ class ContextImpl extends Context {
     @Override
     public void sendBroadcastMultiplePermissions(Intent intent, String[] receiverPermissions,
             Bundle options) {
+        if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, null, receiverPermissions, options, null, 0);
+        }
         warnIfCallingFromSystemProcess();
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         try {
@@ -1318,6 +1333,9 @@ class ContextImpl extends Context {
     @Override
     public void sendBroadcastAsUserMultiplePermissions(Intent intent, UserHandle user,
             String[] receiverPermissions) {
+        if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, null, receiverPermissions, null, null, 0);
+        }
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         try {
             intent.prepareToLeaveProcess(this);
@@ -1334,6 +1352,9 @@ class ContextImpl extends Context {
     @Override
     public void sendBroadcastMultiplePermissions(Intent intent, String[] receiverPermissions,
             String[] excludedPermissions, String[] excludedPackages, BroadcastOptions options) {
+        if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, null, receiverPermissions, null, options, 0);
+        }
         warnIfCallingFromSystemProcess();
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         try {
@@ -1351,6 +1372,7 @@ class ContextImpl extends Context {
     @Override
     public void sendBroadcast(Intent intent, String receiverPermission, Bundle options) {
         if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, receiverPermission, options, 0);
             options = GmsHooks.filterBroadcastOptions(intent, options);
         }
 
@@ -1382,6 +1404,9 @@ class ContextImpl extends Context {
 
     @Override
     public void sendBroadcast(Intent intent, String receiverPermission, int appOp) {
+        if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, receiverPermission, null, appOp);
+        }
         warnIfCallingFromSystemProcess();
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         String[] receiverPermissions = receiverPermission == null ? null
@@ -1405,6 +1430,9 @@ class ContextImpl extends Context {
 
     @Override
     public void sendOrderedBroadcast(Intent intent, String receiverPermission, Bundle options) {
+        if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, receiverPermission, options, 0);
+        }
         warnIfCallingFromSystemProcess();
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         String[] receiverPermissions = receiverPermission == null ? null
@@ -1453,6 +1481,8 @@ class ContextImpl extends Context {
             Handler scheduler, int initialCode, String initialData,
             Bundle initialExtras, Bundle options) {
         if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, receiverPermission, null, options, null, appOp,
+                    initialCode, initialData, initialExtras);
             options = GmsHooks.filterBroadcastOptions(intent, options);
         }
 
@@ -1492,6 +1522,7 @@ class ContextImpl extends Context {
     @Override
     public void sendBroadcastAsUser(Intent intent, UserHandle user) {
         if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, null, null, 0);
             user = GmcUserManager.translateUserHandle(user);
         }
 
@@ -1517,6 +1548,7 @@ class ContextImpl extends Context {
     public void sendBroadcastAsUser(Intent intent, UserHandle user, String receiverPermission,
             Bundle options) {
         if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, receiverPermission, options,  0);
             options = GmsHooks.filterBroadcastOptions(intent, options);
             user = GmcUserManager.translateUserHandle(user);
         }
@@ -1540,6 +1572,7 @@ class ContextImpl extends Context {
     public void sendBroadcastAsUser(Intent intent, UserHandle user,
             String receiverPermission, int appOp) {
         if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, receiverPermission, null, null, null, appOp);
             user = GmcUserManager.translateUserHandle(user);
         }
 
@@ -1579,6 +1612,7 @@ class ContextImpl extends Context {
             String receiverPermission, int appOp, Bundle options, BroadcastReceiver resultReceiver,
             Handler scheduler, int initialCode, String initialData, Bundle initialExtras) {
         if (GmsCompat.isEnabled()) {
+            maybeLogSendBroadcast(intent, receiverPermission, null, options, null, appOp, initialCode, initialData, initialExtras);
             options = GmsHooks.filterBroadcastOptions(intent, options);
             user = GmcUserManager.translateUserHandle(user);
         }
@@ -1984,6 +2018,9 @@ class ContextImpl extends Context {
 
     private ComponentName startServiceCommon(Intent service, boolean requireForeground,
             UserHandle user) {
+        if (GmsCompat.isEnabled()) {
+            maybeLogStartService(service, requireForeground);
+        }
         // Keep this in sync with ActivityManagerLocal.startSdkSandboxService
         try {
             validateServiceIntent(service);
@@ -2026,6 +2063,9 @@ class ContextImpl extends Context {
     }
 
     private boolean stopServiceCommon(Intent service, UserHandle user) {
+        if (GmsCompat.isEnabled()) {
+            GmcDebug.maybeLogStopService(service);
+        }
         // // Keep this in sync with ActivityManagerLocal.stopSdkSandboxService
         try {
             validateServiceIntent(service);
@@ -2181,6 +2221,7 @@ class ContextImpl extends Context {
             if (!GmsCompat.hasPermission(Manifest.permission.START_ACTIVITIES_FROM_BACKGROUND)) {
                 flags &= ~BIND_ALLOW_BACKGROUND_ACTIVITY_STARTS;
             }
+            GmcDebug.maybeLogBindService(service, conn, flags, instanceName);
         }
 
         String pkg = service.getPackage();
@@ -2242,6 +2283,9 @@ class ContextImpl extends Context {
     public void unbindService(ServiceConnection conn) {
         if (conn == null) {
             throw new IllegalArgumentException("connection is null");
+        }
+        if (GmsCompat.isEnabled()) {
+            GmcDebug.maybeLogUnbindService(conn);
         }
         if (mPackageInfo != null) {
             IServiceConnection sd = mPackageInfo.forgetServiceDispatcher(

--- a/core/java/android/app/compat/gms/GmsCompat.java
+++ b/core/java/android/app/compat/gms/GmsCompat.java
@@ -122,16 +122,17 @@ public final class GmsCompat {
     }
 
     public static boolean isEnabledFor(@NonNull ApplicationInfo app) {
+        return isEnabledFor(app.ext().getPackageId(), app.packageName, app.isPrivilegedApp());
+    }
+
+    /** @hide */
+    public static boolean isEnabledFor(int packageId, String packageName, boolean isPrivileged) {
         if (isDevBuild()) {
-            if (isTestPackage(app.packageName)) {
+            if (isTestPackage(packageName)) {
                 return true;
             }
         }
 
-        return isEnabledFor(app.ext().getPackageId(), app.isPrivilegedApp());
-    }
-
-    public static boolean isEnabledFor(int packageId, boolean isPrivileged) {
         if (isPrivileged) {
             // don't enable GmsCompat for privileged GMS
             return false;

--- a/core/java/android/app/compat/gms/GmsCompat.java
+++ b/core/java/android/app/compat/gms/GmsCompat.java
@@ -57,6 +57,11 @@ public final class GmsCompat {
     }
 
     /** @hide */
+    public static boolean isDevBuild() {
+        return !Build.IS_USER;
+    }
+
+    /** @hide */
     public static boolean isGmsCore() {
         return curPackageId == PackageId.GMS_CORE;
     }
@@ -117,7 +122,7 @@ public final class GmsCompat {
     }
 
     public static boolean isEnabledFor(@NonNull ApplicationInfo app) {
-        if (Build.IS_DEBUGGABLE) {
+        if (isDevBuild()) {
             if (isTestPackage(app.packageName)) {
                 return true;
             }
@@ -147,7 +152,7 @@ public final class GmsCompat {
 
     /** @hide */
     public static boolean canBeEnabledFor(String pkgName) {
-        if (Build.IS_DEBUGGABLE) {
+        if (isDevBuild()) {
             if (isTestPackage(pkgName)) {
                 return true;
             }
@@ -192,7 +197,7 @@ public final class GmsCompat {
 
     /** @hide */
     public static boolean isEnabledFor(@NonNull String packageName, int userId, boolean matchDisabledApp) {
-        if (Build.isDebuggable()) {
+        if (isDevBuild()) {
             if (isTestPackage(packageName, userId, matchDisabledApp)) {
                 return true;
             }
@@ -284,10 +289,9 @@ public final class GmsCompat {
         return ArrayUtils.contains(testPkgs.split(","), packageName);
     }
 
-    // call only when Build.isDebuggable() is true
     /** @hide */
     public static boolean isTestPackage(String packageName, int userId, boolean matchDisabledApp) {
-        if (!Build.isDebuggable()) {
+        if (!isDevBuild()) {
             return false;
         }
         if (!isTestPackage(packageName)) {

--- a/core/java/android/app/compat/gms/GmsModuleHooks.java
+++ b/core/java/android/app/compat/gms/GmsModuleHooks.java
@@ -97,7 +97,7 @@ public class GmsModuleHooks {
             return false;
         }
 
-        if (Build.isDebuggable()) {
+        if (GmsCompat.isDevBuild()) {
             Log.i(TAG, "intercepted " + origException, stackTrace);
         }
 

--- a/core/java/com/android/internal/gmscompat/GmcDebug.java
+++ b/core/java/com/android/internal/gmscompat/GmcDebug.java
@@ -1,0 +1,167 @@
+package com.android.internal.gmscompat;
+
+import android.app.BroadcastOptions;
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.Bundle;
+import android.util.Log;
+
+import java.util.Arrays;
+
+public class GmcDebug {
+
+    public static void maybeLogStartService(Intent service, boolean requireForeground) {
+        String LOG_TAG = "GmcStartService";
+        if (!Log.isLoggable(LOG_TAG, Log.VERBOSE)) {
+            return;
+        }
+        var b = new StringBuilder();
+        appendIntent(service, b);
+        if (requireForeground) {
+            b.append(", requireForeground");
+        }
+        Log.v(LOG_TAG, b.toString(), new Throwable());
+    }
+
+    public static void maybeLogStopService(Intent service) {
+        String LOG_TAG = "GmcStopService";
+        if (!Log.isLoggable(LOG_TAG, Log.VERBOSE)) {
+            return;
+        }
+        var b = new StringBuilder();
+        appendIntent(service, b);
+        Log.v(LOG_TAG, b.toString(), new Throwable());
+    }
+
+    public static void maybeLogServiceOnStartCommand(Service service, Intent intent, int flags, int startId) {
+        String LOG_TAG = "GmcServiceCmd";
+        if (!Log.isLoggable(LOG_TAG, Log.VERBOSE)) {
+            return;
+        }
+        var b = new StringBuilder();
+        b.append(service.getClass().getName());
+        b.append(", ");
+        if (intent != null) {
+            appendIntent(intent, b);
+        } else {
+            b.append("intent is null");
+        }
+        b.append(", flags: ");
+        b.append(Integer.toHexString(flags));
+        b.append(", startId: ");
+        b.append(startId);
+        Log.v(LOG_TAG, b.toString());
+    }
+
+    public static void maybeLogBindService(Intent service, ServiceConnection conn, long flags, String instanceName) {
+        String LOG_TAG = "GmcBindService";
+        if (!Log.isLoggable(LOG_TAG, Log.VERBOSE)) {
+            return;
+        }
+        var b = new StringBuilder();
+        appendIntent(service, b);
+        b.append(", conn: ");
+        b.append(System.identityHashCode(conn));
+        b.append(", flags: ");
+        b.append(Long.toHexString(flags));
+        if (instanceName != null) {
+            b.append(", instanceName: ");
+            b.append(instanceName);
+        }
+        Log.v(LOG_TAG, b.toString(), new Throwable());
+    }
+
+    public static void maybeLogUnbindService(ServiceConnection conn) {
+        String LOG_TAG = "GmcUnbindService";
+        if (!Log.isLoggable(LOG_TAG, Log.VERBOSE)) {
+            return;
+        }
+        Log.v(LOG_TAG, "conn: " + System.identityHashCode(conn), new Throwable());
+    }
+
+    public static void maybeLogServiceConnCallback(String name, ComponentName cn) {
+        String LOG_TAG = "GmcServiceConnCb";
+        if (!Log.isLoggable(LOG_TAG, Log.VERBOSE)) {
+            return;
+        }
+        Log.v(LOG_TAG, name + ", " + cn.toShortString());
+    }
+
+    public static void maybeLogSendBroadcast(Intent intent, String receiverPerm, Bundle options,
+            int appOp) {
+        maybeLogSendBroadcast(intent, receiverPerm, null, options, null, appOp, 0, null, null);
+    }
+
+    public static void maybeLogSendBroadcast(Intent intent, String receiverPerm, String[] receiverPerms, Bundle options, BroadcastOptions brOptions,
+            int appOp) {
+        maybeLogSendBroadcast(intent, receiverPerm, receiverPerms, options, brOptions, appOp, 0, null, null);
+    }
+
+    public static void maybeLogSendBroadcast(Intent intent, String receiverPerm, String[] receiverPerms, Bundle options, BroadcastOptions brOptions,
+            int appOp, int initialCode, String initialData, Bundle initialExtras) {
+        String LOG_TAG = "GmcSendBroadcast";
+        if (!Log.isLoggable(LOG_TAG, Log.VERBOSE)) {
+            return;
+        }
+        var b = new StringBuilder("sendBroadcast: ");
+        appendIntent(intent, b);
+        if (options != null) {
+            b.append(", options: ");
+            b.append(options.toStringDeep());
+        }
+        if (brOptions != null) {
+            b.append(", brOptions: ");
+            b.append(brOptions);
+        }
+        if (receiverPerm != null) {
+            b.append(", receiverPerm: ");
+            b.append(receiverPerm);
+        }
+        if (receiverPerms != null) {
+            b.append(", receiverPerms: ");
+            b.append(Arrays.toString(receiverPerms));
+        }
+        if (appOp != 0) {
+            b.append(", appOp: ");
+            b.append(appOp);
+        }
+        if (initialCode != 0) {
+            b.append(", initialCode: ");
+            b.append(initialCode);
+        }
+        if (initialData != null) {
+            b.append(", initialData: ");
+            b.append(initialData);
+        }
+        if (initialExtras != null) {
+            b.append(", initialExtras: ");
+            b.append(initialExtras.toStringDeep());
+        }
+        Log.v(LOG_TAG, b.toString(), new Throwable());
+    }
+
+    public static void maybeLogReceiveBroadcast(BroadcastReceiver receiver, Intent intent, boolean isManifest) {
+        String LOG_TAG = "GmcRecvBroadcast";
+        if (!Log.isLoggable(LOG_TAG, Log.VERBOSE)) {
+            return;
+        }
+        var b = new StringBuilder();
+        b.append(isManifest? "manifest; " : "dynamic; ");
+        appendIntent(intent, b);
+        b.append(", receiver: ");
+        b.append(receiver.getClass().getName());
+        Log.v(LOG_TAG, b.toString());
+    }
+
+    private static void appendIntent(Intent intent, StringBuilder b) {
+        intent.toString(b);
+        Bundle extras = intent.getExtras();
+        if (extras != null) {
+            b.append(", extras: ");
+            b.append(extras.toStringDeep());
+        }
+    }
+}

--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -604,8 +604,9 @@ public final class GmsHooks {
 
         boolean res = stub.stubOutMethod(p);
 
-        if (Build.isDebuggable()) {
-            Log.i(TAG, res ? "intercepted" : "stubOut failed", e);
+        String logTag = "GmcDynStub";
+        if (GmsCompat.isDevBuild() || Log.isLoggable(logTag, Log.DEBUG)) {
+            Log.d(logTag, res ? "intercepted" : "stubOut failed", e);
         }
 
         return res;

--- a/core/java/com/android/internal/pm/pkg/parsing/ParsingPackage.java
+++ b/core/java/com/android/internal/pm/pkg/parsing/ParsingPackage.java
@@ -561,4 +561,6 @@ public interface ParsingPackage {
     }
 
     void setPackageExt(@Nullable PackageExtIface ext);
+
+    boolean isDeclaredHavingCode();
 }

--- a/core/java/com/android/internal/pm/pkg/parsing/ParsingPackageUtils.java
+++ b/core/java/com/android/internal/pm/pkg/parsing/ParsingPackageUtils.java
@@ -1098,7 +1098,7 @@ public class ParsingPackageUtils {
             }
         }
 
-        if (usesPerms.add(android.Manifest.permission.OTHER_SENSORS)) {
+        if (pkg.isDeclaredHavingCode() && usesPerms.add(android.Manifest.permission.OTHER_SENSORS)) {
             pkg.addUsesPermission(new ParsedUsesPermissionImpl(android.Manifest.permission.OTHER_SENSORS, 0));
         }
 

--- a/core/java/com/android/internal/pm/pkg/parsing/ParsingPackageUtils.java
+++ b/core/java/com/android/internal/pm/pkg/parsing/ParsingPackageUtils.java
@@ -1099,7 +1099,7 @@ public class ParsingPackageUtils {
         }
 
         if (pkg.isDeclaredHavingCode() && usesPerms.add(android.Manifest.permission.OTHER_SENSORS)) {
-            pkg.addUsesPermission(new ParsedUsesPermissionImpl(android.Manifest.permission.OTHER_SENSORS, 0));
+            pkg.addImplicitPermission(android.Manifest.permission.OTHER_SENSORS);
         }
 
         convertCompatPermissions(pkg);

--- a/services/core/java/com/android/server/pm/AppsFilterImpl.java
+++ b/services/core/java/com/android/server/pm/AppsFilterImpl.java
@@ -583,7 +583,7 @@ public final class AppsFilterImpl extends AppsFilterLocked implements Watchable,
             }
         }
 
-        final boolean isGmsApp = GmsCompat.isEnabledFor(PackageExt.get(newPkg).getPackageId(), newPkgSetting.isPrivileged());
+        final boolean isGmsApp = GmsCompat.isEnabledFor(PackageExt.get(newPkg).getPackageId(), newPkg.getPackageName(), newPkgSetting.isPrivileged());
 
         final boolean newIsForceQueryable;
         synchronized (mForceQueryableLock) {

--- a/services/core/java/com/android/server/pm/ext/GsfParsingHooks.java
+++ b/services/core/java/com/android/server/pm/ext/GsfParsingHooks.java
@@ -1,9 +1,8 @@
 package com.android.server.pm.ext;
 
-import android.os.Build;
-
 import com.android.internal.pm.pkg.component.ParsedPermission;
 import com.android.internal.pm.pkg.component.ParsedProvider;
+import com.android.internal.pm.pkg.component.ParsedUsesPermission;
 import com.android.internal.pm.pkg.parsing.PackageParsingHooks;
 
 class GsfParsingHooks extends PackageParsingHooks {
@@ -46,6 +45,14 @@ class GsfParsingHooks extends PackageParsingHooks {
     }
 
     @Override
+    public boolean shouldSkipUsesPermission(ParsedUsesPermission p) {
+        // See shouldSkipProvider(). GSF is in the same sharedUid as GmsCore, ignore all
+        // uses-permission declarations to remove misleading permission entries in App info UI for
+        // GSF.
+        return true;
+    }
+
+    @Override
     public boolean shouldSkipProvider(ParsedProvider p) {
         // On SDK 35, all GSF ContentProviders are moved to GmsCore and GSF becomes an
         // "android:hasCode=false" package, i.e. it never runs.
@@ -54,7 +61,7 @@ class GsfParsingHooks extends PackageParsingHooks {
         // updating to SDK 35 (Android 15), which leads to GmsCore breaking due to ContentProvider
         // conflicts between GSF and GmsCore.
         //
-        // As a workaround, ignore all GSF ContentProvider on SDK 35+.
-        return Build.VERSION.SDK_INT >= 35;
+        // As a workaround, ignore all GSF ContentProvider.
+        return true;
     }
 }


### PR DESCRIPTION
`don't add OTHER_SENSORS uses-permission to hasCode=false packages` change is related to `gmscompat: ignore uses-permission in GSF AndroidManifest` change, it prevents users from inadvertently removing Sensors permission from Play services by removing it from GSF, since GSF and Play services are in the same sharedUid for existing installs.