### PR TITLE
fixup! exempt telephony service from the new package visibility restrictions

### DIFF
--- a/services/core/java/com/android/server/pm/ComputerEngine.java
+++ b/services/core/java/com/android/server/pm/ComputerEngine.java
@@ -2519,6 +2519,11 @@ public class ComputerEngine implements Computer {
                 return false;
             }
         }
+
+        if (UserHandle.getAppId(callingUid) == Process.PHONE_UID) {
+            return false;
+        }
+
         // if we're in an isolated process, get the real calling UID
         if (Process.isIsolated(callingUid)) {
             callingUid = getIsolatedOwner(callingUid);


### PR DESCRIPTION
The original change (https://github.com/GrapheneOS-Archive/platform_frameworks_base-old/pull/429) handled only sharedUid packages. Regular packages weren't handled.

This fixes the following issues:
https://github.com/GrapheneOS/os-issue-tracker/issues/2483#issuecomment-1871675323
https://discuss.grapheneos.org/d/9908-previously-working-app-after-latest-updates-just-crash
https://discuss.grapheneos.org/d/11505-enabling-precise-location-crashes-application

This bug also impacts fresh installs of Play services in secondary users when Play services has the Location permission, because fresh installs of Play services no longer use sharedUid since the first release of GrapheneOS based on Android 15.

This bug is said to be fixed upstream now, but it's not clear whether the fix will be complete and when it will ship:
https://issuetracker.google.com/issues/356176632