### PR TITLE
PackageVerityExt: fix handling of static shared libraries, v2

### DIFF
--- a/services/core/java/com/android/server/pm/PackageVerityExt.java
+++ b/services/core/java/com/android/server/pm/PackageVerityExt.java
@@ -63,18 +63,9 @@ public class PackageVerityExt {
     @Nullable public static AndroidPackage getSystemPackage(AndroidPackage pkg) {
         if (pkg.isStaticSharedLibrary()) {
             String name = pkg.getStaticSharedLibraryName();
-            final AndroidPackage system;
             synchronized (staticSharedLibraries) {
-                system = staticSharedLibraries.get(name);
+                return staticSharedLibraries.get(name);
             }
-            if (system != null && system.getStaticSharedLibraryVersion() == pkg.getStaticSharedLibraryVersion()) {
-                // Each version of static shared library is treated by the OS as a completely
-                // separate package with its own package state. Note that rejecting static shared
-                // libraries with mismatching version code would only delete their APKs, package
-                // state would be left behind.
-                return system;
-            }
-            return null;
         } else {
             String name = pkg.getManifestPackageName();
             synchronized (packages) {

--- a/services/core/java/com/android/server/pm/PackageVerityExt.java
+++ b/services/core/java/com/android/server/pm/PackageVerityExt.java
@@ -104,11 +104,26 @@ public class PackageVerityExt {
             }
         }
 
-        if (checkVersionCode && systemPkg.getLongVersionCode() >= systemPkgUpdate.getLongVersionCode()) {
-            throw new PackageManagerException(INSTALL_FAILED_UPDATE_INCOMPATIBLE,
-                    "versionCode of system image package (" + systemPkg.getLongVersionCode()
-                            + ") is >= versionCode of system package update ("
-                            + systemPkgUpdate.getLongVersionCode() + ")");
+        if (checkVersionCode) {
+            boolean shouldReject;
+            String op;
+            if (systemPkg.isStaticSharedLibrary()) {
+                // Each version of static shared library is treated by the OS as a completely
+                // separate package with its own package state. Note that rejecting static shared
+                // libraries with mismatching version code would only delete their APKs, package
+                // state would be left behind.
+                shouldReject = systemPkg.getLongVersionCode() == systemPkgUpdate.getLongVersionCode();
+                op = "==";
+            } else {
+                shouldReject = systemPkg.getLongVersionCode() >= systemPkgUpdate.getLongVersionCode();
+                op = ">=";
+            }
+            if (shouldReject) {
+                throw new PackageManagerException(INSTALL_FAILED_UPDATE_INCOMPATIBLE,
+                        "versionCode of system image package (" + systemPkg.getLongVersionCode()
+                                + ") is " + op + " versionCode of system package update ("
+                                + systemPkgUpdate.getLongVersionCode() + ")");
+            }
         }
 
         boolean checkFsVerity = true;


### PR DESCRIPTION
The original fix weakened several checks for static shared library versions that are newer than the
system image version.