### PR TITLE
gmscompat: fix MANAGE_USB_ANDROID_AUTO not being checked for some calls 

### DIFF
--- a/core/java/android/hardware/usb/IUsbManager.aidl
+++ b/core/java/android/hardware/usb/IUsbManager.aidl
@@ -127,14 +127,14 @@ interface IUsbManager
     boolean isFunctionEnabled(String function);
 
     /* Sets the current USB function. */
-    @EnforcePermission("MANAGE_USB")
+    @EnforcePermission(anyOf={"MANAGE_USB", "MANAGE_USB_ANDROID_AUTO"})
     void setCurrentFunctions(long functions, int operationId);
 
     /* Compatibility version of setCurrentFunctions(long). */
     void setCurrentFunction(String function, boolean usbDataUnlocked, int operationId);
 
     /* Gets the current USB functions. */
-    @EnforcePermission("MANAGE_USB")
+    @EnforcePermission(anyOf={"MANAGE_USB", "MANAGE_USB_ANDROID_AUTO"})
     long getCurrentFunctions();
 
     /* Gets the current USB Speed. */
@@ -156,7 +156,7 @@ interface IUsbManager
     long getScreenUnlockedFunctions();
 
     /* Resets the USB gadget. */
-    @EnforcePermission("MANAGE_USB")
+    @EnforcePermission(anyOf={"MANAGE_USB", "MANAGE_USB_ANDROID_AUTO"})
     void resetUsbGadget();
 
     /* Resets the USB port. */
@@ -180,7 +180,7 @@ interface IUsbManager
     ParcelFileDescriptor getControlFd(long function);
 
     /* Gets the list of USB ports. */
-    @EnforcePermission("MANAGE_USB")
+    @EnforcePermission(anyOf={"MANAGE_USB", "MANAGE_USB_ANDROID_AUTO"})
     List<ParcelableUsbPort> getPorts();
 
     /* Gets the status of the specified USB port. */

--- a/services/usb/java/com/android/server/usb/UsbService.java
+++ b/services/usb/java/com/android/server/usb/UsbService.java
@@ -308,7 +308,7 @@ public class UsbService extends IUsbManager.Stub {
         }
     }
 
-    private void enforceCallingOrSelfManageUsborAndroidAuto(String message) {
+    private void enforceCallingOrSelfManageUsbOrAndroidAuto(String message) {
         try {
             mContext.enforceCallingOrSelfPermission(android.Manifest.permission.MANAGE_USB, message);
         } catch (SecurityException se) {
@@ -787,7 +787,7 @@ public class UsbService extends IUsbManager.Stub {
         Objects.requireNonNull(callback, "resetUsbPort: callback must not be null. opId:"
                 + operationId);
         /** @see android.hardware.usb.UsbManager#resetUsbPort */
-        enforceCallingOrSelfManageUsborAndroidAuto(null);
+        enforceCallingOrSelfManageUsbOrAndroidAuto(null);
 
         final long ident = Binder.clearCallingIdentity();
 
@@ -839,7 +839,7 @@ public class UsbService extends IUsbManager.Stub {
     public UsbPortStatus getPortStatus(String portId) {
         Objects.requireNonNull(portId, "portId must not be null");
         /** @see android.hardware.usb.UsbManager#getPortStatus  */
-        enforceCallingOrSelfManageUsborAndroidAuto(null);
+        enforceCallingOrSelfManageUsbOrAndroidAuto(null);
 
         final long ident = Binder.clearCallingIdentity();
         try {
@@ -868,7 +868,7 @@ public class UsbService extends IUsbManager.Stub {
         Objects.requireNonNull(portId, "portId must not be null");
         UsbPort.checkRoles(powerRole, dataRole);
         /** @see android.hardware.usb.UsbManager#setPortRoles */
-        enforceCallingOrSelfManageUsborAndroidAuto(null);
+        enforceCallingOrSelfManageUsbOrAndroidAuto(null);
 
         final long ident = Binder.clearCallingIdentity();
         try {


### PR DESCRIPTION
It's not enough to specify MANAGE_USB_ANDROID_AUTO in @EnforcePermission annotation in interface
implementation, it has to be specified in AIDL interface definition.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/4249