### PR TITLE
fix ANR details link not working in profiles and in secondary users

### DIFF
--- a/services/core/java/com/android/server/am/AppNotRespondingDialog.java
+++ b/services/core/java/com/android/server/am/AppNotRespondingDialog.java
@@ -24,6 +24,7 @@ import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.os.UserHandle;
 import android.text.BidiFormatter;
 import android.util.Slog;
 import android.view.LayoutInflater;
@@ -179,7 +180,7 @@ final class AppNotRespondingDialog extends BaseErrorDialog implements View.OnCli
 
             if (appErrorIntent != null) {
                 try {
-                    getContext().startActivity(appErrorIntent);
+                    getContext().startActivityAsUser(appErrorIntent, UserHandle.of(mProc.userId));
                 } catch (ActivityNotFoundException e) {
                     Slog.w(TAG, "bug report receiver dissappeared", e);
                 }


### PR DESCRIPTION
Crash report dialog is not affected, it uses startActivityAsUser() already.

Crash report dialog was fixed in 2012: d4ac8d7b3de27a9f0e4c6af2496ca71d794e42d1, but ANR dialog wasn't. Both crash and ANR dialogs were added in 2009, before Android had multi-user support: f5b9c72022f574417862e064cc0fdd8ea2d846dc.