### PR TITLE
don't ignore installer-of-record check for installer self-updates

### DIFF
--- a/services/core/java/com/android/server/pm/PackageInstallerSession.java
+++ b/services/core/java/com/android/server/pm/PackageInstallerSession.java
@@ -1132,8 +1132,8 @@ public class PackageInstallerSession extends IPackageInstallerSession.Stub {
 
         if (params.requireUserAction == SessionParams.USER_ACTION_NOT_REQUIRED
                 && isUpdateWithoutUserActionPermissionGranted
-                && ((isUpdateOwnershipEnforcementEnabled ? isUpdateOwner
-                : isInstallerOfRecord) || isSelfUpdate)) {
+                && (isUpdateOwnershipEnforcementEnabled ? isUpdateOwner
+                : isInstallerOfRecord)) {
             return USER_ACTION_PENDING_APK_PARSING;
         }
 


### PR DESCRIPTION
Before this change, an unprivileged installer was allowed to self-update without confirmation when it wasn't installer-of-record for itself.