### PR TITLE
fixup! cscopes: ignore Person.Builder.setUri() when Contact Scopes is enabled

### DIFF
--- a/core/java/android/app/Notification.java
+++ b/core/java/android/app/Notification.java
@@ -111,6 +111,7 @@ import android.widget.RemoteViews;
 
 import com.android.internal.R;
 import com.android.internal.annotations.VisibleForTesting;
+import com.android.internal.app.ContactScopes;
 import com.android.internal.graphics.ColorUtils;
 import com.android.internal.util.ArrayUtils;
 import com.android.internal.util.ContrastColorUtil;
@@ -5373,6 +5374,11 @@ public class Notification implements Parcelable
          * @deprecated use {@link #addPerson(Person)}
          */
         public Builder addPerson(String uri) {
+            if (ContactScopes.isEnabled()) {
+                // See comment in Person.Builder#setUri()
+                return this;
+            }
+
             addPerson(new Person.Builder().setUri(uri).build());
             return this;
         }
@@ -5399,6 +5405,13 @@ public class Notification implements Parcelable
          */
         @NonNull
         public Builder addPerson(Person person) {
+            if (ContactScopes.isEnabled()) {
+                if (person.getName() == null && person.getKey() == null) {
+                    // See comment in Person.Builder#setUri()
+                    return this;
+                }
+
+            }
             mPersonList.add(person);
             return this;
         }


### PR DESCRIPTION
Skip Person objects that become empty when Person uri is omitted.