### PR TITLE
make Google's text-to-speech app force-queryable

### DIFF
--- a/services/core/java/com/android/server/pm/AppsFilterImpl.java
+++ b/services/core/java/com/android/server/pm/AppsFilterImpl.java
@@ -45,6 +45,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManagerInternal;
 import android.content.pm.SigningDetails;
 import android.content.pm.UserInfo;
+import android.ext.PackageId;
 import android.os.Handler;
 import android.os.SystemClock;
 import android.os.SystemProperties;
@@ -583,7 +584,8 @@ public final class AppsFilterImpl extends AppsFilterLocked implements Watchable,
             }
         }
 
-        final boolean isGmsApp = GmsCompat.isEnabledFor(PackageExt.get(newPkg).getPackageId(), newPkg.getPackageName(), newPkgSetting.isPrivileged());
+        final int packageId = PackageExt.get(newPkg).getPackageId();
+        final boolean isGmsApp = GmsCompat.isEnabledFor(packageId, newPkg.getPackageName(), newPkgSetting.isPrivileged());
 
         final boolean newIsForceQueryable;
         synchronized (mForceQueryableLock) {
@@ -591,6 +593,7 @@ public final class AppsFilterImpl extends AppsFilterLocked implements Watchable,
                             /* shared user that is already force queryable */
                             || newPkgSetting.isForceQueryableOverride() /* adb override */
                             || isGmsApp
+                            || packageId == PackageId.G_TEXT_TO_SPEECH
                             || (newPkgSetting.isSystem() && (mSystemAppsQueryable
                             || newPkg.isForceQueryable()
                             || ArrayUtils.contains(mForceQueryableByDevicePackageNames,


### PR DESCRIPTION
Google TTS app is forceQueryable on stock OS. Third-party apps expect to be able to query it without holding the QUERY_ALL_PACKAGES permission.

Resolves https://github.com/GrapheneOS/os-issue-tracker/issues/3546