### PR TITLE
gmscompat: prompt user to disable GmsCore background data restrictions; allow Android Auto FG services to have while-in-use perms

### DIFF
--- a/core/java/android/app/LocaleManager.java
+++ b/core/java/android/app/LocaleManager.java
@@ -24,10 +24,13 @@ import android.annotation.SystemApi;
 import android.annotation.SystemService;
 import android.annotation.TestApi;
 import android.annotation.UserHandleAware;
+import android.app.compat.gms.GmsCompat;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.os.LocaleList;
 import android.os.RemoteException;
+
+import com.android.internal.gmscompat.PlayStoreHooks;
 
 /**
  * This class gives access to system locale services. These services allow applications to
@@ -145,6 +148,10 @@ public class LocaleManager {
     @UserHandleAware
     @NonNull
     public LocaleList getApplicationLocales(@NonNull String appPackageName) {
+        if (GmsCompat.isPlayStore()) {
+            return PlayStoreHooks.getApplicationLocales();
+        }
+
         try {
             return mService.getApplicationLocales(appPackageName, mContext.getUserId());
         } catch (RemoteException e) {

--- a/core/java/android/content/res/Configuration.java
+++ b/core/java/android/content/res/Configuration.java
@@ -49,6 +49,7 @@ import android.annotation.Nullable;
 import android.annotation.TestApi;
 import android.app.GrammaticalInflectionManager;
 import android.app.WindowConfiguration;
+import android.app.compat.gms.GmsCompat;
 import android.compat.annotation.UnsupportedAppUsage;
 import android.content.LocaleProto;
 import android.content.pm.ActivityInfo;
@@ -66,6 +67,7 @@ import android.util.proto.ProtoOutputStream;
 import android.util.proto.WireTypeMismatchException;
 import android.view.View;
 
+import com.android.internal.gmscompat.PlayStoreHooks;
 import com.android.internal.util.XmlUtils;
 
 import org.xmlpull.v1.XmlPullParser;
@@ -2340,6 +2342,14 @@ public final class Configuration implements Parcelable, Comparable<Configuration
      * @return The locale list.
      */
     public @NonNull LocaleList getLocales() {
+        if (GmsCompat.isPlayStore()) {
+            return PlayStoreHooks.getApplicationLocales();
+        }
+        return getLocalesInner();
+    }
+
+    /** @hide */
+    public @NonNull LocaleList getLocalesInner() {
         fixUpLocaleList();
         return mLocaleList;
     }

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -18336,7 +18336,9 @@ public final class Settings {
                     // stop Play Store from attempting to auto-install some system component
                     // packages, such as "Android System SafetyCore" (com.google.android.safetycore)
                     // and "Android System Key Verifier" (com.google.android.contactkeys)
-                    return 0;
+                    if (!"1".equals(getString(cr, "gmscompat_bypass_sys_component_update_stub"))) {
+                        return 0;
+                    }
                 }
             }
 

--- a/core/java/com/android/internal/gmscompat/IGms2Gca.aidl
+++ b/core/java/com/android/internal/gmscompat/IGms2Gca.aidl
@@ -33,6 +33,8 @@ interface IGms2Gca {
 
     oneway void maybeShowContactsSyncNotification();
 
+    oneway void maybeShowGmsCoreRestrictedBackgroundDataNotif();
+
     void onUncaughtException(in ApplicationErrorReport aer);
     GmsCompatConfig requestConfigUpdate(String reason);
 

--- a/core/java/com/android/internal/gmscompat/PlayStoreHooks.java
+++ b/core/java/com/android/internal/gmscompat/PlayStoreHooks.java
@@ -35,15 +35,19 @@ import android.ext.PackageId;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
+import android.os.LocaleList;
 import android.os.RemoteException;
 import android.os.storage.StorageManager;
 import android.provider.Settings;
+import android.util.ArraySet;
 import android.util.Log;
 
 import com.android.internal.gmscompat.util.GmcActivityUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
@@ -346,6 +350,35 @@ public final class PlayStoreHooks {
                 return Settings.Global.getInt(cr, "gmscompat_play_store_can_install_" + pkgName, 0) == 1;
         }
         return true;
+    }
+
+    public static LocaleList getApplicationLocales() {
+        Context ctx = GmsCompat.appContext();
+        LocaleList actualLocales = ctx.getResources().getConfiguration().getLocalesInner();
+
+        if (Settings.Global.getInt(ctx.getContentResolver(), "gmscompat_play_store_fetch_all_locales", 0) != 1) {
+            return actualLocales;
+        }
+
+        int numActualLocales = actualLocales.size();
+        ArraySet<Locale> actualLocalesSet = new ArraySet<>(numActualLocales);
+
+        Locale[] allLocales = Locale.getAvailableLocales();
+        var res = new ArrayList<Locale>(allLocales.length);
+
+        for (int i = 0; i < numActualLocales; ++i) {
+            Locale l = actualLocales.get(i);
+            res.add(l);
+            actualLocalesSet.add(l);
+        }
+
+        for (int i = 0; i < allLocales.length; ++i) {
+            Locale l = allLocales[i];
+            if (!actualLocalesSet.contains(l)) {
+                res.add(l);
+            }
+        }
+        return new LocaleList(res.toArray(new Locale[0]));
     }
 
     private PlayStoreHooks() {}

--- a/services/core/java/com/android/server/am/ActiveServices.java
+++ b/services/core/java/com/android/server/am/ActiveServices.java
@@ -8496,6 +8496,11 @@ public final class ActiveServices {
                 ret = REASON_DEVICE_OWNER;
             }
         }
+        if (ret == REASON_DENIED) {
+            if (ActiveServicesHooks.shouldAllowFgsWhileInUsePermission(this, callingUid)) {
+                ret = REASON_ALLOWLISTED_PACKAGE;
+            }
+        }
         return ret;
     }
 

--- a/services/core/java/com/android/server/am/ActiveServicesHooks.java
+++ b/services/core/java/com/android/server/am/ActiveServicesHooks.java
@@ -1,0 +1,25 @@
+package com.android.server.am;
+
+import android.content.pm.PackageManagerInternal;
+import android.os.UserHandle;
+import android.util.Slog;
+
+import com.android.server.pm.ext.PackageExt;
+import com.android.server.pm.pkg.AndroidPackage;
+
+class ActiveServicesHooks {
+    static final String TAG = ActiveServicesHooks.class.getSimpleName();
+
+    static boolean shouldAllowFgsWhileInUsePermission(ActiveServices activeServices, int uid) {
+        PackageManagerInternal pm = activeServices.mAm.getPackageManagerInternal();
+        AndroidPackage pkg = pm.getPackage(uid);
+        if (pkg == null) {
+            return false;
+        }
+        boolean res = PackageExt.get(pkg).hooks().shouldAllowFgsWhileInUsePermission(pm, UserHandle.getUserId(uid));
+        if (res) {
+            Slog.d(TAG, "shouldAllowFgsWhileInUsePermission for " + pkg.getPackageName() + " returned true");
+        }
+        return res;
+    }
+}

--- a/services/core/java/com/android/server/ext/TombstoneHandler.java
+++ b/services/core/java/com/android/server/ext/TombstoneHandler.java
@@ -424,14 +424,14 @@ public class TombstoneHandler {
         if ("/apex/com.google.android.hardware.biometrics.fingerprint/bin/hw/android.hardware.biometrics.fingerprint-service.goodix".equals(cmdline[0])) {
             // rare harmless crash, fingerprint service restarts and continues to work
             return checkBacktraceFunctionNames(backtrace, 0
-                    , "android::VectorImpl::editArrayImpl"
-                    , "goodix::EventCenter::hasUpEvt"
-                    , "goodix::DelmarSensor::checkFingerUp"
-                    , "goodix::DelmarSensor::readImage"
-                    , "goodix::CustomizedSensor::readImage"
-                    , "goodix::DelmarFingerprintCore::onAfterAuthCapture"
-                    , "goodix::CustomizedFingerprintCore::onAfterAuthCapture"
-                    , "goodix::FingerprintCore::onAuthDownEvt"
+                    , "android::VectorImpl::editArrayImpl()"
+                    , "goodix::EventCenter::hasUpEvt()"
+                    , "goodix::DelmarSensor::checkFingerUp(unsigned int)"
+                    , "goodix::DelmarSensor::readImage(unsigned int, unsigned long)"
+                    , "goodix::CustomizedSensor::readImage(unsigned int, unsigned long)"
+                    , "goodix::DelmarFingerprintCore::onAfterAuthCapture(goodix::FingerprintCore::AuthenticateContext*)"
+                    , "goodix::CustomizedFingerprintCore::onAfterAuthCapture(goodix::FingerprintCore::AuthenticateContext*)"
+                    , "goodix::FingerprintCore::onAuthDownEvt()"
             );
         }
 

--- a/services/core/java/com/android/server/pm/ext/AndroidAutoHooks.java
+++ b/services/core/java/com/android/server/pm/ext/AndroidAutoHooks.java
@@ -130,4 +130,11 @@ public class AndroidAutoHooks extends PackageHooks {
 
         return (pkgFlags & flags) != 0 ? PERMISSION_OVERRIDE_GRANT : PERMISSION_OVERRIDE_REVOKE;
     }
+
+    @Override
+    public boolean shouldAllowFgsWhileInUsePermission(PackageManagerInternal pm, int userId) {
+        GosPackageStatePm gosPs = pm.getGosPackageState(PackageId.ANDROID_AUTO_NAME, userId);
+        long anyOfFlags = PKG_FLAG_GRANT_PERMS_FOR_WIRED_ANDROID_AUTO | PKG_FLAG_GRANT_PERMS_FOR_WIRELESS_ANDROID_AUTO;
+        return gosPs != null && (gosPs.packageFlags & anyOfFlags) != 0;
+    }
 }

--- a/services/core/java/com/android/server/pm/ext/PackageHooks.java
+++ b/services/core/java/com/android/server/pm/ext/PackageHooks.java
@@ -2,6 +2,7 @@ package com.android.server.pm.ext;
 
 import android.annotation.Nullable;
 import android.content.pm.PackageManager;
+import android.content.pm.PackageManagerInternal;
 import android.util.ArraySet;
 
 import com.android.server.pm.pkg.AndroidPackage;
@@ -89,5 +90,9 @@ public class PackageHooks {
     protected static long getGosPsPackageFlags(PackageUserStateInternal pkgUserState) {
         GosPackageStatePm ps = pkgUserState.getGosPackageState();
         return ps != null ? ps.packageFlags : 0L;
+    }
+
+    public boolean shouldAllowFgsWhileInUsePermission(PackageManagerInternal pm, int userId) {
+        return false;
     }
 }


### PR DESCRIPTION
Depends on https://github.com/GrapheneOS/platform_packages_apps_GmsCompat/pull/220