### PR TITLE
never remove location providers at runtime

### DIFF
--- a/packages/FusedLocation/src/com/android/location/fused/FusedLocationService.java
+++ b/packages/FusedLocation/src/com/android/location/fused/FusedLocationService.java
@@ -26,30 +26,27 @@ import java.io.PrintWriter;
 
 public class FusedLocationService extends Service {
 
-    @Nullable private FusedLocationProvider mProvider;
+    private FusedLocationProvider mProvider;
+
+    @Override
+    public void onCreate() {
+        mProvider = new FusedLocationProvider(this);
+        mProvider.start();
+    }
 
     @Override
     public IBinder onBind(Intent intent) {
-        if (mProvider == null) {
-            mProvider = new FusedLocationProvider(this);
-            mProvider.start();
-        }
-
         return mProvider.getBinder();
     }
 
     @Override
     public void onDestroy() {
-        if (mProvider != null) {
-            mProvider.stop();
-            mProvider = null;
-        }
+        mProvider.stop();
+        mProvider = null;
     }
 
     @Override
     protected void dump(FileDescriptor fd, PrintWriter writer, String[] args) {
-        if (mProvider != null) {
-            mProvider.dump(writer);
-        }
+        mProvider.dump(writer);
     }
 }

--- a/packages/FusedLocation/src/com/android/location/gnss/GnssOverlayLocationService.java
+++ b/packages/FusedLocation/src/com/android/location/gnss/GnssOverlayLocationService.java
@@ -26,24 +26,23 @@ import java.io.PrintWriter;
 
 public class GnssOverlayLocationService extends Service {
 
-    @Nullable private GnssOverlayLocationProvider mProvider;
+    private GnssOverlayLocationProvider mProvider;
+
+    @Override
+    public void onCreate() {
+        mProvider = new GnssOverlayLocationProvider(this);
+        mProvider.start();
+    }
 
     @Override
     public IBinder onBind(Intent intent) {
-        if (mProvider == null) {
-            mProvider = new GnssOverlayLocationProvider(this);
-            mProvider.start();
-        }
-
         return mProvider.getBinder();
     }
 
     @Override
     public void onDestroy() {
-        if (mProvider != null) {
-            mProvider.stop();
-            mProvider = null;
-        }
+        mProvider.stop();
+        mProvider = null;
     }
 
     @Override

--- a/services/core/java/com/android/server/location/LocationManagerService.java
+++ b/services/core/java/com/android/server/location/LocationManagerService.java
@@ -392,16 +392,6 @@ public class LocationManagerService extends ILocationManager.Stub implements
         }
     }
 
-    private void removeLocationProviderManager(LocationProviderManager manager) {
-        synchronized (mProviderManagers) {
-            boolean removed = mProviderManagers.remove(manager);
-            Preconditions.checkArgument(removed);
-            manager.setMockProvider(null);
-            manager.setRealProvider(null);
-            manager.stopManager();
-        }
-    }
-
     void onSystemReady() {
         if (Build.IS_DEBUGGABLE) {
             // on debug builds, watch for location noteOps while location is off. there are some
@@ -1493,9 +1483,6 @@ public class LocationManagerService extends ILocationManager.Stub implements
             }
 
             manager.setMockProvider(null);
-            if (!manager.hasProvider()) {
-                removeLocationProviderManager(manager);
-            }
         }
     }
 

--- a/services/core/java/com/android/server/location/provider/LocationProviderManager.java
+++ b/services/core/java/com/android/server/location/provider/LocationProviderManager.java
@@ -1589,36 +1589,6 @@ public class LocationProviderManager extends
         }
     }
 
-    public void stopManager() {
-        synchronized (mMultiplexerLock) {
-            Preconditions.checkState(mState == STATE_STARTED);
-            mState = STATE_STOPPING;
-
-            final long identity = Binder.clearCallingIdentity();
-            try {
-                onEnabledChanged(UserHandle.USER_ALL);
-                removeRegistrationIf(key -> true);
-                mProvider.getController().stop();
-            } finally {
-                Binder.restoreCallingIdentity(identity);
-            }
-
-            mUserHelper.removeListener(mUserChangedListener);
-            mLocationSettings.unregisterLocationUserSettingsListener(mLocationUserSettingsListener);
-            mSettingsHelper.removeOnLocationEnabledChangedListener(mLocationEnabledChangedListener);
-
-            // if external entities are registering listeners it's their responsibility to
-            // unregister them before stopManager() is called
-            Preconditions.checkState(mEnabledListeners.isEmpty());
-            mProviderRequestListeners.clear();
-
-            mEnabled.clear();
-            mLastLocations.clear();
-            mStateChangedListener = null;
-            mState = STATE_STOPPED;
-        }
-    }
-
     public String getName() {
         return mName;
     }


### PR DESCRIPTION
Location providers aren't expected to be removed at runtime by the apps and by the OS itself.

Removing a location provider leads to app and system_server crashes when they attempt to use the
previously existing provider.

Upstream removes location providers in just one case: when a test (mock) location provider is added
and then removed for a non-existing location provider.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/4401