### PR TITLE
bring back "fix NPE system_server crash in IMMS.resetDefaultImeLocked()" change

### DIFF
--- a/services/core/java/com/android/server/inputmethod/InputMethodManagerService.java
+++ b/services/core/java/com/android/server/inputmethod/InputMethodManagerService.java
@@ -1294,9 +1294,11 @@ public final class InputMethodManagerService implements IInputMethodManagerImpl.
         // Do not reset the default (current) IME when it is a 3rd-party IME
         String selectedMethodId = bindingController.getSelectedMethodId();
         final InputMethodSettings settings = InputMethodSettingsRepository.get(userId);
-        if (selectedMethodId != null
-                && !settings.getMethodMap().get(selectedMethodId).isSystem()) {
-            return;
+        if (selectedMethodId != null) {
+            InputMethodInfo selectedMethod = settings.getMethodMap().get(selectedMethodId);
+            if (selectedMethod != null && !selectedMethod.isSystem()) {
+                return;
+            }
         }
         final List<InputMethodInfo> suitableImes = InputMethodInfoUtils.getDefaultEnabledImes(
                 context, settings.getEnabledInputMethodList());


### PR DESCRIPTION
`fix NPE system_server crash in IMMS.resetDefaultImeLocked()` commit was discarded during 15 QPR1 port because it looked like the issue was resolved upstream, which is not the case.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/4508