### PR TITLE
add workaround for SSM.newTargetUser() system_server crash; add workaround for updateWifiBatteryStats() system_server crash

### DIFF
--- a/services/core/java/com/android/server/SystemServiceManager.java
+++ b/services/core/java/com/android/server/SystemServiceManager.java
@@ -379,6 +379,13 @@ public final class SystemServiceManager implements Dumpable {
     }
 
     private @NonNull TargetUser newTargetUser(@UserIdInt int userId) {
+        if (mUserManagerInternal == null) {
+            // see https://github.com/GrapheneOS/os-issue-tracker/issues/4510
+            var um = LocalServices.getService(UserManagerInternal.class);
+            if (um != null) {
+                mUserManagerInternal = um;
+            }
+        }
         final UserInfo userInfo = mUserManagerInternal.getUserInfo(userId);
         Preconditions.checkState(userInfo != null, "No UserInfo for " + userId);
         return new TargetUser(userInfo);

--- a/services/core/java/com/android/server/power/stats/BatteryStatsImpl.java
+++ b/services/core/java/com/android/server/power/stats/BatteryStatsImpl.java
@@ -12660,11 +12660,13 @@ public class BatteryStatsImpl extends BatteryStats {
 
                 // Distribute the remaining Tx power appropriately between all apps that transmitted
                 // packets.
-                for (int i = 0; i < txPackets.size(); i++) {
-                    final int uid = txPackets.keyAt(i);
-                    final long myTxTimeMs = (txPackets.valueAt(i) * leftOverTxTimeMs)
-                            / totalTxPackets;
-                    txTimesMs.incrementValue(uid, myTxTimeMs);
+                if (totalTxPackets > 0) { // see https://github.com/GrapheneOS/os-issue-tracker/issues/4627
+                    for (int i = 0; i < txPackets.size(); i++) {
+                        final int uid = txPackets.keyAt(i);
+                        final long myTxTimeMs = (txPackets.valueAt(i) * leftOverTxTimeMs)
+                                / totalTxPackets;
+                        txTimesMs.incrementValue(uid, myTxTimeMs);
+                    }
                 }
 
                 // Distribute the remaining Rx power appropriately between all apps that received


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/4510
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/4627