### PR TITLE
Bypass system app check for Google sign-in

### DIFF
--- a/core/java/android/service/credentials/CredentialProviderInfoFactory.java
+++ b/core/java/android/service/credentials/CredentialProviderInfoFactory.java
@@ -37,6 +37,7 @@ import android.content.res.TypedArray;
 import android.content.res.XmlResourceParser;
 import android.credentials.CredentialManager;
 import android.credentials.CredentialProviderInfo;
+import android.ext.PackageId;
 import android.os.Bundle;
 import android.os.RemoteException;
 import android.os.UserHandle;
@@ -182,7 +183,7 @@ public final class CredentialProviderInfoFactory {
         requireNonNull(context, "context must not be null");
 
         // Pretend like GMS is installed as a system app on GrapheneOS
-        if (serviceInfo.packageName == "com.google.android.gms") {
+        if (serviceInfo.packageName == PackageId.GMS_CORE_NAME) {
             return true;
         }
         
@@ -403,7 +404,7 @@ public final class CredentialProviderInfoFactory {
 
             // Google sign-in expects GMS to be installed as a system app, which it isn't on
             // GrapheneOS, so we just pretend it is.
-            if (serviceInfo != null && serviceInfo.packageName == "com.google.android.gms") {
+            if (serviceInfo != null && serviceInfo.packageName == PackageId.GMS_CORE_NAME) {
                 services.add(serviceInfo);
                 continue;
             }

--- a/core/java/android/service/credentials/CredentialProviderInfoFactory.java
+++ b/core/java/android/service/credentials/CredentialProviderInfoFactory.java
@@ -181,6 +181,11 @@ public final class CredentialProviderInfoFactory {
             boolean disableSystemAppVerificationForTests) {
         requireNonNull(context, "context must not be null");
 
+        // Pretend like GMS is installed as a system app on GrapheneOS
+        if (serviceInfo.packageName == "com.google.android.gms") {
+            return true;
+        }
+        
         if (disableSystemAppVerificationForTests) {
             Bundle metadata = serviceInfo.metaData;
             if (metadata == null) {
@@ -393,6 +398,13 @@ public final class CredentialProviderInfoFactory {
                 if (serviceInfo != null) {
                     services.add(serviceInfo);
                 }
+                continue;
+            }
+
+            // Google sign-in expects GMS to be installed as a system app, which it isn't on
+            // GrapheneOS, so we just pretend it is.
+            if (serviceInfo != null && serviceInfo.packageName == "com.google.android.gms") {
+                services.add(serviceInfo);
                 continue;
             }
 


### PR DESCRIPTION
Fixes https://github.com/GrapheneOS/os-issue-tracker/issues/3875

This fixes the error and makes the log-in screen open.

Unfortunately, I wasn't able to test the entire sign-in flow (ie. if the selected account is actually returned to the calling app) because GMS shows an error screen on emulator builds, preventing me from logging in

![image](https://github.com/user-attachments/assets/90a71f60-7255-4841-86d9-0ae7fada15ad)

![image](https://github.com/user-attachments/assets/dee874bc-0d9d-4db3-9beb-6d34d53f048d)
