### PR TITLE
[13] gmscompat: fix flag overrides being partly ignored on recent versions

### DIFF
--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -339,6 +339,7 @@ public final class GmsHooks {
     public static Cursor maybeModifyQueryResult(Uri uri,
             @Nullable String[] projection, @Nullable Bundle queryArgs, @Nullable Cursor origCursor) {
         String uriString = uri.toString();
+        Log.d(TAG, "maybeModifyQueryResult for " + uriString);
 
         Consumer<ArrayMap<String, String>> mutator = null;
 


### PR DESCRIPTION
Current version of phenotype client library switched to using ContentProviderClient#query instead of ContentResolver#query.