### PR TITLE
FusedLocation: don't attempt to flush inactive providers

### DIFF
--- a/packages/FusedLocation/src/com/android/location/fused/FusedLocationProvider.java
+++ b/packages/FusedLocation/src/com/android/location/fused/FusedLocationProvider.java
@@ -128,10 +128,12 @@ public class FusedLocationProvider extends LocationProviderBase {
     public void onFlush(OnFlushCompleteCallback callback) {
         synchronized (mLock) {
             AtomicInteger flushCount = new AtomicInteger(0);
-            if (mGpsPresent) {
+            boolean flushGps = mGpsListener.isActive();
+            if (flushGps) {
                 flushCount.incrementAndGet();
             }
-            if (mNlpPresent) {
+            boolean flushNetwork = mNetworkListener.isActive();
+            if (flushNetwork) {
                 flushCount.incrementAndGet();
             }
 
@@ -141,10 +143,10 @@ public class FusedLocationProvider extends LocationProviderBase {
                 }
             };
 
-            if (mGpsPresent) {
+            if (flushGps) {
                 mGpsListener.flush(wrapper);
             }
-            if (mNlpPresent) {
+            if (flushNetwork) {
                 mNetworkListener.flush(wrapper);
             }
         }
@@ -278,6 +280,10 @@ public class FusedLocationProvider extends LocationProviderBase {
             synchronized (mLock) {
                 mLocation = null;
             }
+        }
+
+        boolean isActive() {
+            return getInterval() != INTERVAL_DISABLED;
         }
 
         private void resetProviderRequest(long newInterval) {


### PR DESCRIPTION
Flush of inactive (unregistered or never registered) provider throws an exception which crashes the system_server.

This issue was hidden when there was no network location provider, see QUALITY_LOW_POWER logic in updateRequirementsLocked().

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/4915