### PR TITLE
gmscompat: skip location settings check activity when rerouting is on

### DIFF
--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -511,7 +511,20 @@ public final class GmsHooks {
 
     // Activity#onCreate(Bundle)
     public static void activityOnCreate(Activity activity) {
-
+        if (!GmsCompat.isGmsCore()) {
+            return;
+        }
+        if (activity.getClass().getName().equals("com.google.android.location.settings.LocationSettingsCheckerActivity")) {
+            try {
+                if (!GmsCompatApp.iGms2Gca().isHybridLocationServiceEnabled()) {
+                    return;
+                }
+            } catch (RemoteException e) {
+                throw GmsCompatApp.callFailed(e);
+            }
+            Log.d(TAG, "hybrid location service is enabled, finishing LocationSettingsCheckerActivity");
+            activity.finish();
+        }
     }
 
     // ContentResolver#insert(Uri, ContentValues, Bundle)

--- a/core/java/com/android/internal/gmscompat/IGms2Gca.aidl
+++ b/core/java/com/android/internal/gmscompat/IGms2Gca.aidl
@@ -47,4 +47,6 @@ interface IGms2Gca {
     Notification getMediaProjectionNotification();
 
     void raisePackageToForeground(String targetPkg, long durationMs, @nullable String reason, int reasonCode);
+
+    boolean isHybridLocationServiceEnabled();
 }


### PR DESCRIPTION
LocationSettingsCheckerActivity is launched by location service clients to ask the user to adjust location settings. It's irrelevant when hybrid location service is enabled.

Depends on https://github.com/GrapheneOS/platform_packages_apps_GmsCompat/pull/238