### PR TITLE
config: enable desktop mode support

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -7213,7 +7213,7 @@
     <string name="config_wearRemoteIntentAction" translatable="false" />
 
     <!-- Whether desktop mode is supported on the current device  -->
-    <bool name="config_isDesktopModeSupported">false</bool>
+    <bool name="config_isDesktopModeSupported">true</bool>
 
     <!-- Maximum number of active tasks on a given Desktop Windowing session. Set to 0 for unlimited. -->
     <integer name="config_maxDesktopWindowingActiveTasks">0</integer>


### PR DESCRIPTION
Desktop mode support remains disabled by default, it's controlled by a dev option.