### PR TITLE
SystemUI: fix keyguard media section placement when split shade is used

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/KeyguardSliceViewSection.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/KeyguardSliceViewSection.kt
@@ -18,6 +18,7 @@
 package com.android.systemui.keyguard.ui.view.layout.sections
 
 import android.content.Context
+import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.Barrier
@@ -59,7 +60,8 @@ constructor(
                 ConstraintSet.PARENT_ID,
                 ConstraintSet.START,
                 context.resources.getDimensionPixelSize(customR.dimen.clock_padding_start) +
-                    context.resources.getDimensionPixelSize(customR.dimen.status_view_margin_horizontal),
+                    context.resources.getDimensionPixelSize(customR.dimen.status_view_margin_horizontal) +
+                    TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 4f, context.resources.displayMetrics).toInt(),
             )
             connect(
                 R.id.keyguard_slice_view,

--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/SplitShadeMediaSection.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/SplitShadeMediaSection.kt
@@ -82,7 +82,7 @@ constructor(
         constraintSet.apply {
             constrainWidth(mediaContainerId, MATCH_CONSTRAINT)
             constrainHeight(mediaContainerId, WRAP_CONTENT)
-            connect(mediaContainerId, TOP, R.id.smart_space_barrier_bottom, BOTTOM)
+            connect(mediaContainerId, TOP, com.android.systemui.customization.R.id.lockscreen_clock_view, BOTTOM)
             connect(mediaContainerId, START, PARENT_ID, START)
             connect(mediaContainerId, END, R.id.split_shade_guideline, END)
         }


### PR DESCRIPTION
Split notification shade is used on tablets in landscape mode and on foldables in unfolded state.
