### PR TITLE
gmscompat: improve support for overriding Gservices flags

### DIFF
--- a/core/java/com/android/internal/gmscompat/BinderGca2Gms.java
+++ b/core/java/com/android/internal/gmscompat/BinderGca2Gms.java
@@ -8,11 +8,14 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.ext.PackageId;
 import android.net.Uri;
+import android.util.ArrayMap;
 import android.util.ArraySet;
 import android.util.Log;
 
 import com.android.internal.gmscompat.flags.GmsFlag;
+import com.android.internal.gmscompat.flags.GservicesFlags;
 import com.android.internal.gmscompat.util.GmcActivityUtils;
 
 import java.util.concurrent.Callable;
@@ -47,23 +50,7 @@ class BinderGca2Gms extends IGca2Gms.Stub {
             updatePhenotype(phenotypeDb, GmsHooks.config());
         }
 
-        // Gservices flags are hosted by GservicesProvider ContentProvider in GmsCore.
-        // Its clients register change listeners via
-        // BroadcastReceivers (com.google.gservices.intent.action.GSERVICES_CHANGED) and
-        // ContentResolver#registerContentObserver().
-        // Code below performs a delete of a non-existing key (key is chosen randomly).
-        // GmsCore will notify all of its listeners after this operation, despite database remaining
-        // unchanged. There's no other simple way to achieve the same effect (AFAIK).
-        //
-        // Additional values from GmsCompatConfig will be added only inside client's processes,
-        // database inside GSF remains unchanged.
-
-        ContentResolver cr = GmsCompat.appContext().getContentResolver();
-        ContentValues cv = new ContentValues();
-        cv.put("iquee6jo8ooquoomaeraip7gah4shee8phiet0Ahng0yeipei3", (String) null);
-
-        Uri gservicesUri = Uri.parse("content://" + GmsFlag.GSERVICES_CONTENT_PROVIDER_AUTHORITY + "/override");
-        cr.update(gservicesUri, cv, null, null);
+        GservicesFlags.applyOverrides(GmsHooks.config());
     }
 
     private static void updatePhenotype(SQLiteOpenHelper phenotypeDb, GmsCompatConfig newConfig) {

--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -58,6 +58,7 @@ import android.webkit.WebView;
 
 import com.android.internal.gmscompat.client.GmsCompatClientService;
 import com.android.internal.gmscompat.flags.GmsFlag;
+import com.android.internal.gmscompat.flags.GservicesFlags;
 import com.android.internal.gmscompat.gcarriersettings.GCarrierSettingsApp;
 import com.android.internal.gmscompat.gcarriersettings.TestCarrierConfigService;
 import com.android.internal.gmscompat.sysservice.GmcPackageManager;
@@ -119,6 +120,10 @@ public final class GmsHooks {
         }
 
         Thread.setUncaughtExceptionPreHandler(new UncaughtExceptionPreHandler());
+
+        if (inPersistentGmsCoreProcess) {
+            GservicesFlags.applyOverrides(config());
+        }
 
         GmcPackageManager.init(ctx);
     }
@@ -340,32 +345,7 @@ public final class GmsHooks {
         Log.d(TAG, "maybeModifyQueryResult for " + uriString);
 
         Consumer<ArrayMap<String, String>> mutator = null;
-
-        if (GmsFlag.GSERVICES_URI.equals(uriString)) {
-            if (queryArgs == null) {
-                return null;
-            }
-            String[] selectionArgs = queryArgs.getStringArray(ContentResolver.QUERY_ARG_SQL_SELECTION_ARGS);
-            if (selectionArgs == null) {
-                return null;
-            }
-
-            ArrayMap<String, GmsFlag> flags = config().gservicesFlags;
-            if (flags == null) {
-                return null;
-            }
-
-            mutator = map -> {
-                for (GmsFlag f : flags.values()) {
-                    for (String sel : selectionArgs) {
-                        if (f.name.startsWith(sel)) {
-                            f.applyToGservicesMap(map);
-                            break;
-                        }
-                    }
-                }
-            };
-        } else if (uriString.startsWith(GmsFlag.PHENOTYPE_URI_PREFIX)) {
+        if (uriString.startsWith(GmsFlag.PHENOTYPE_URI_PREFIX)) {
             List<String> path = uri.getPathSegments();
             if (path.size() != 1) {
                 Log.e(TAG, "unknown phenotype uri " + uriString, new Throwable());

--- a/core/java/com/android/internal/gmscompat/flags/GservicesFlags.java
+++ b/core/java/com/android/internal/gmscompat/flags/GservicesFlags.java
@@ -1,0 +1,34 @@
+package com.android.internal.gmscompat.flags;
+
+import android.app.compat.gms.GmsCompat;
+import android.content.Intent;
+import android.ext.PackageId;
+import android.util.ArrayMap;
+import android.util.Log;
+
+import com.android.internal.gmscompat.GmsCompatConfig;
+
+public class GservicesFlags {
+    private static final String TAG = "GmcGservicesFlags";
+
+    public static void applyOverrides(GmsCompatConfig config) {
+        ArrayMap<String, GmsFlag> gservicesFlags = config.gservicesFlags;
+        if (gservicesFlags == null) {
+            return;
+        }
+
+        var overriddenFlags = new ArrayMap<String, String>(gservicesFlags.size());
+        for (int i = 0; i < gservicesFlags.size(); ++i) {
+            GmsFlag flag = gservicesFlags.valueAt(i);
+            flag.applyToGservicesMap(overriddenFlags);
+        }
+
+        if (!overriddenFlags.isEmpty()) {
+            var intent = new Intent("com.google.gservices.intent.action.GSERVICES_OVERRIDE");
+            intent.setPackage(PackageId.GMS_CORE_NAME);
+            overriddenFlags.forEach(intent::putExtra);
+            Log.d(TAG, "sending GSERVICES_OVERRIDE broadcast, extras: " + intent.getExtras().toStringDeep());
+            GmsCompat.appContext().sendBroadcast(intent);
+        }
+    }
+}


### PR DESCRIPTION
Previous approach was to modify the ContentResolver query result, which doesn't work when Gservices database is read directly, as is done in GmsCore in some cases now that Gservices database is hosted by GmsCore.

Instead, use GservicesProvider's built-in support for flag overrides which is implemented by the GSERVICES_OVERRIDE broadcast receiver.