### PR TITLE
allow to install APEXes on debug OS builds

### DIFF
--- a/services/core/java/com/android/server/pm/PackageInstallerService.java
+++ b/services/core/java/com/android/server/pm/PackageInstallerService.java
@@ -831,6 +831,9 @@ public class PackageInstallerService extends IPackageInstaller.Stub implements
                     == PackageManager.PERMISSION_DENIED) {
                 throw new SecurityException("Not allowed to perform APEX updates");
             }
+            if (Build.IS_USER) {
+                throw new SecurityException("Not allowed to perform APEX updates on user builds");
+            }
         } else if (params.isStaged) {
             mContext.enforceCallingOrSelfPermission(Manifest.permission.INSTALL_PACKAGES, TAG);
         }

--- a/services/core/java/com/android/server/pm/PackageInstallerService.java
+++ b/services/core/java/com/android/server/pm/PackageInstallerService.java
@@ -825,7 +825,12 @@ public class PackageInstallerService extends IPackageInstaller.Stub implements
 
         boolean isApex = (params.installFlags & PackageManager.INSTALL_APEX) != 0;
         if (isApex) {
-            throw new SecurityException("Not allowed to perform APEX updates");
+            if (mContext.checkCallingOrSelfPermission(Manifest.permission.INSTALL_PACKAGE_UPDATES)
+                    == PackageManager.PERMISSION_DENIED
+                    && mContext.checkCallingOrSelfPermission(Manifest.permission.INSTALL_PACKAGES)
+                    == PackageManager.PERMISSION_DENIED) {
+                throw new SecurityException("Not allowed to perform APEX updates");
+            }
         } else if (params.isStaged) {
             mContext.enforceCallingOrSelfPermission(Manifest.permission.INSTALL_PACKAGES, TAG);
         }

--- a/services/core/java/com/android/server/pm/PackageInstallerSession.java
+++ b/services/core/java/com/android/server/pm/PackageInstallerSession.java
@@ -3456,6 +3456,11 @@ public class PackageInstallerSession extends IPackageInstallerSession.Stub {
     @GuardedBy("mLock")
     private void validateApexInstallLocked()
             throws PackageManagerException {
+        if (Build.IS_USER) {
+            throw new PackageManagerException(PackageManager.INSTALL_FAILED_SESSION_INVALID,
+                    "APEX installation is not allowed on user builds");
+        }
+
         final List<File> addedFiles = getAddedApksLocked();
         if (addedFiles.isEmpty()) {
             throw new PackageManagerException(INSTALL_FAILED_INVALID_APK,

--- a/services/core/java/com/android/server/pm/PackageInstallerSession.java
+++ b/services/core/java/com/android/server/pm/PackageInstallerSession.java
@@ -3456,11 +3456,6 @@ public class PackageInstallerSession extends IPackageInstallerSession.Stub {
     @GuardedBy("mLock")
     private void validateApexInstallLocked()
             throws PackageManagerException {
-        if (true) {
-            throw new PackageManagerException(PackageManager.INSTALL_FAILED_SESSION_INVALID,
-                    "APEX installation is not allowed");
-        }
-
         final List<File> addedFiles = getAddedApksLocked();
         if (addedFiles.isEmpty()) {
             throw new PackageManagerException(INSTALL_FAILED_INVALID_APK,


### PR DESCRIPTION
It's useful for faster deployment of APEX-only changes via `adb install --force-non-staged $APEX`.