### PR TITLE
further restrict access to added global and per-user settings

### DIFF
--- a/core/api/system-current.txt
+++ b/core/api/system-current.txt
@@ -4912,13 +4912,21 @@ package android.ext {
     field public static final int HAS_WRITE_EXTERNAL_STORAGE_DECLARATION = 32; // 0x20
   }
 
+  public interface KnownSystemPackage {
+    field public static final int SETTINGS = 0; // 0x0
+    field public static final int SHELL = 1; // 0x1
+    field public static final int SYSTEM_UI = 2; // 0x2
+  }
+
   public final class KnownSystemPackages {
     method @NonNull public static android.ext.KnownSystemPackages get(@NonNull android.content.Context);
+    method @NonNull public String getById(int);
     field @NonNull public final String contactsProvider;
     field @NonNull public final String launcher;
     field @NonNull public final String mediaProvider;
     field @NonNull public final String permissionController;
     field @NonNull public final String settings;
+    field @NonNull public final String shell;
     field @NonNull public final String systemUi;
   }
 

--- a/core/java/android/ext/KnownSystemPackage.java
+++ b/core/java/android/ext/KnownSystemPackage.java
@@ -1,0 +1,24 @@
+package android.ext;
+
+import android.annotation.IntDef;
+import android.annotation.SystemApi;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/** @hide */
+@SystemApi
+public interface KnownSystemPackage {
+    int SETTINGS = 0;
+    int SHELL = 1;
+    int SYSTEM_UI = 2;
+
+    /** @hide */
+    @IntDef(value = {
+            SETTINGS,
+            SHELL,
+            SYSTEM_UI,
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    @interface Enum {}
+}

--- a/core/java/android/ext/KnownSystemPackages.java
+++ b/core/java/android/ext/KnownSystemPackages.java
@@ -26,6 +26,7 @@ public final class KnownSystemPackages {
     @NonNull public final String mediaProvider;
     @NonNull public final String permissionController;
     @NonNull public final String settings;
+    @NonNull public final String shell;
     @NonNull public final String systemUi;
 
     private KnownSystemPackages(Context ctx) {
@@ -35,6 +36,17 @@ public final class KnownSystemPackages {
         mediaProvider = "com.android.providers.media.module";
         permissionController = "com.android.permissioncontroller";
         settings = "com.android.settings";
+        shell = "com.android.shell";
         systemUi = res.getString(R.string.config_systemUi);
+    }
+
+    @NonNull
+    public String getById(@KnownSystemPackage.Enum int id) {
+        return switch (id) {
+            case KnownSystemPackage.SETTINGS -> settings;
+            case KnownSystemPackage.SHELL -> shell;
+            case KnownSystemPackage.SYSTEM_UI -> systemUi;
+            default -> throw new IllegalArgumentException();
+        };
     }
 }

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13193,6 +13193,7 @@ public final class Settings {
         public static final String SHOW_SYSTEM_PROCESS_CRASH_NOTIFICATIONS = "show_system_process_crash_notifs";
 
         /** @hide */
+        @Protected(restrictReads = false, readWrite = KnownSystemPackage.SETTINGS)
         public static final String WIDEVINE_PROVISIONING_SERVER = "widevine_provisioner_server";
 
         /** @hide */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13157,6 +13157,7 @@ public final class Settings {
         public static final String GNSS_SUPL = "force_disable_supl"; // historical name
 
         /** @hide */
+        @Protected(restrictReads = false, readWrite = KnownSystemPackage.SETTINGS)
         public static final String GNSS_PSDS_STANDARD = "psds_server"; // historical name
 
         /** @hide */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13201,6 +13201,7 @@ public final class Settings {
         public static final String BATTERY_CHARGE_LIMIT = "battery_charge_limit";
 
         /** @hide */
+        @Protected(restrictReads = false, readWrite = KnownSystemPackage.SETTINGS)
         public static final String NETWORK_LOCATION = "network_location";
 
         // ExtSettings END

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13173,12 +13173,15 @@ public final class Settings {
         public static final String REMOTE_KEY_PROVISIONING_SERVER = "attest_remote_provisioner_server";
 
         /** @hide */
+        @Protected(readWrite = KnownSystemPackage.SETTINGS)
         public static final String RESTRICT_MEMORY_DYN_CODE_LOADING_BY_DEFAULT = "restrict_memory_dyn_code_exec";
 
         /** @hide */
+        @Protected(readWrite = KnownSystemPackage.SETTINGS)
         public static final String RESTRICT_STORAGE_DYN_CODE_LOADING_BY_DEFAULT = "restrict_storage_dyn_code_exec";
 
         /** @hide */
+        @Protected(readWrite = KnownSystemPackage.SETTINGS)
         public static final String RESTRICT_WEBVIEW_DYN_CODE_LOADING_BY_DEFAULT = "restrict_webview_dyn_code_exec";
 
         /** @hide */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -61,6 +61,7 @@ import android.content.res.Resources;
 import android.database.ContentObserver;
 import android.database.Cursor;
 import android.database.SQLException;
+import android.ext.KnownSystemPackage;
 import android.location.ILocationManager;
 import android.location.LocationManager;
 import android.media.AudioManager;
@@ -3525,7 +3526,9 @@ public final class Settings {
             mAllFields = new ArraySet<>();
             mReadableFieldsWithMaxTargetSdk = new ArrayMap<>();
             getPublicSettingsForClass(callerClass, mAllFields, mReadableFields,
-                    mReadableFieldsWithMaxTargetSdk);
+                    mReadableFieldsWithMaxTargetSdk,
+                    // skip obtaining protectedSettings map, it's not needed for NameValueCache
+                    null);
         }
 
         // Returns last path component of the relevant Uri.
@@ -4083,9 +4086,26 @@ public final class Settings {
         int maxTargetSdk() default 0;
     }
 
+    @Target({ ElementType.FIELD })
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface Protected {
+        boolean restrictReads() default true;
+        // IDs of system packages that are allowed read-only access. Ignored if restrictReads is false.
+        @KnownSystemPackage.Enum int[] read() default {};
+        // IDs of system packages that are allowed read and write access
+        @KnownSystemPackage.Enum int[] readWrite();
+    }
+
+    /** @hide */
+    public record ProtectedSetting(String key,
+                                   boolean restrictReads,
+                                   @KnownSystemPackage.Enum int[] readableBy,
+                                   @KnownSystemPackage.Enum int[] readWritableBy) {}
+
     private static <T extends NameValueTable> void getPublicSettingsForClass(
             Class<T> callerClass, Set<String> allKeys, Set<String> readableKeys,
-            ArrayMap<String, Integer> keysWithMaxTargetSdk) {
+            ArrayMap<String, Integer> keysWithMaxTargetSdk,
+            @Nullable ArrayMap<String, ProtectedSetting> protectedSettings) {
         final Field[] allFields = callerClass.getDeclaredFields();
         try {
             for (int i = 0; i < allFields.length; i++) {
@@ -4097,15 +4117,24 @@ public final class Settings {
                 if (!value.getClass().equals(String.class)) {
                     continue;
                 }
-                allKeys.add((String) value);
+                final String key = (String) value;
+                allKeys.add(key);
                 final Readable annotation = field.getAnnotation(Readable.class);
 
                 if (annotation != null) {
-                    final String key = (String) value;
                     final int maxTargetSdk = annotation.maxTargetSdk();
                     readableKeys.add(key);
                     if (maxTargetSdk != 0) {
                         keysWithMaxTargetSdk.put(key, maxTargetSdk);
+                    }
+                }
+
+                if (protectedSettings != null) {
+                    final Protected anno = field.getAnnotation(Protected.class);
+                    if (anno != null) {
+                        var setting = new ProtectedSetting(key, anno.restrictReads(),
+                                anno.read(), anno.readWrite());
+                        protectedSettings.put(key, setting);
                     }
                 }
             }
@@ -4330,9 +4359,10 @@ public final class Settings {
 
         /** @hide */
         public static void getPublicSettings(Set<String> allKeys, Set<String> readableKeys,
-                ArrayMap<String, Integer> readableKeysWithMaxTargetSdk) {
+                ArrayMap<String, Integer> readableKeysWithMaxTargetSdk,
+                ArrayMap<String, ProtectedSetting> protectedSettings) {
             getPublicSettingsForClass(System.class, allKeys, readableKeys,
-                    readableKeysWithMaxTargetSdk);
+                    readableKeysWithMaxTargetSdk, protectedSettings);
         }
 
         /**
@@ -7179,9 +7209,10 @@ public final class Settings {
 
         /** @hide */
         public static void getPublicSettings(Set<String> allKeys, Set<String> readableKeys,
-                ArrayMap<String, Integer> readableKeysWithMaxTargetSdk) {
+                ArrayMap<String, Integer> readableKeysWithMaxTargetSdk,
+                ArrayMap<String, ProtectedSetting> protectedSettings) {
             getPublicSettingsForClass(Secure.class, allKeys, readableKeys,
-                    readableKeysWithMaxTargetSdk);
+                    readableKeysWithMaxTargetSdk, protectedSettings);
         }
 
         /**
@@ -18443,14 +18474,15 @@ public final class Settings {
 
         /** @hide */
         public static void getPublicSettings(Set<String> allKeys, Set<String> readableKeys,
-                ArrayMap<String, Integer> readableKeysWithMaxTargetSdk) {
+                ArrayMap<String, Integer> readableKeysWithMaxTargetSdk,
+                ArrayMap<String, ProtectedSetting> protectedSettings) {
             getPublicSettingsForClass(Global.class, allKeys, readableKeys,
-                    readableKeysWithMaxTargetSdk);
+                    readableKeysWithMaxTargetSdk, protectedSettings);
             // Add Global.Wearable keys on watches.
             if (ActivityThread.currentApplication().getApplicationContext().getPackageManager()
                     .hasSystemFeature(PackageManager.FEATURE_WATCH)) {
                 getPublicSettingsForClass(Global.Wearable.class, allKeys, readableKeys,
-                        readableKeysWithMaxTargetSdk);
+                        readableKeysWithMaxTargetSdk, protectedSettings);
             }
         }
 

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13169,6 +13169,7 @@ public final class Settings {
         public static final String BLUETOOTH_AUTO_OFF = "bluetooth_off_timeout";
 
         /** @hide */
+        @Protected(restrictReads = false, readWrite = KnownSystemPackage.SETTINGS)
         public static final String REMOTE_KEY_PROVISIONING_SERVER = "attest_remote_provisioner_server";
 
         /** @hide */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13197,6 +13197,7 @@ public final class Settings {
         public static final String WIDEVINE_PROVISIONING_SERVER = "widevine_provisioner_server";
 
         /** @hide */
+        @Protected(read = KnownSystemPackage.SYSTEM_UI, readWrite = KnownSystemPackage.SETTINGS)
         public static final String BATTERY_CHARGE_LIMIT = "battery_charge_limit";
 
         /** @hide */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -7034,13 +7034,16 @@ public final class Settings {
         public static final String SCREENSHOT_TIMESTAMP_EXIF = "screenshot_timestamp_exif";
 
         /** @hide */
+        @Protected(read = KnownSystemPackage.SYSTEM_UI, readWrite = KnownSystemPackage.SETTINGS)
         public static final String SCRAMBLE_PIN_LAYOUT_PRIMARY =
                 "lockscreen_scramble_pin_layout";
         /** @hide */
+        @Protected(read = KnownSystemPackage.SYSTEM_UI, readWrite = KnownSystemPackage.SETTINGS)
         public static final String SCRAMBLE_PIN_LAYOUT_SECONDARY =
                 "lockscreen_scramble_pin_layout_secondary";
 
         /** @hide */
+        @Protected(read = KnownSystemPackage.SYSTEM_UI, readWrite = KnownSystemPackage.SETTINGS)
         public static final String SCRAMBLE_SIM_PIN_LAYOUT = "scramble_sim_pin_layout";
 
         // ExtSettings END

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13165,6 +13165,7 @@ public final class Settings {
         public static final String WIFI_AUTO_OFF = "wifi_off_timeout";
 
         /** @hide */
+        @Protected(readWrite = KnownSystemPackage.SETTINGS)
         public static final String BLUETOOTH_AUTO_OFF = "bluetooth_off_timeout";
 
         /** @hide */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13144,6 +13144,7 @@ public final class Settings {
         // ExtSettings BEGIN
 
         /** @hide */
+        @Protected(restrictReads = false, readWrite = KnownSystemPackage.SETTINGS)
         public static final String ALLOW_DISABLING_HARDENING_VIA_APP_COMPAT_CONFIG =
                 "allow_automatic_pkg_hardening_config"; // historical name
 

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13189,6 +13189,7 @@ public final class Settings {
         public static final String FORCE_APP_MEMTAG_BY_DEFAULT = "force_app_memtag";
 
         /** @hide */
+        @Protected(readWrite = KnownSystemPackage.SETTINGS)
         public static final String SHOW_SYSTEM_PROCESS_CRASH_NOTIFICATIONS = "show_system_process_crash_notifs";
 
         /** @hide */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13149,6 +13149,7 @@ public final class Settings {
                 "allow_automatic_pkg_hardening_config"; // historical name
 
         /** @hide */
+        @Protected(readWrite = KnownSystemPackage.SETTINGS)
         public static final String AUTO_REBOOT_TIMEOUT = "settings_reboot_after_timeout";
 
         /** @hide */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -7030,6 +7030,7 @@ public final class Settings {
         public static final String AUTO_GRANT_OTHER_SENSORS_PERMISSION = "auto_grant_OTHER_SENSORS_perm";
 
         /** @hide */
+        @Protected(read = KnownSystemPackage.SYSTEM_UI, readWrite = KnownSystemPackage.SETTINGS)
         public static final String SCREENSHOT_TIMESTAMP_EXIF = "screenshot_timestamp_exif";
 
         /** @hide */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13161,6 +13161,7 @@ public final class Settings {
         public static final String GNSS_PSDS_STANDARD = "psds_server"; // historical name
 
         /** @hide */
+        @Protected(readWrite = KnownSystemPackage.SETTINGS)
         public static final String WIFI_AUTO_OFF = "wifi_off_timeout";
 
         /** @hide */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -7026,6 +7026,7 @@ public final class Settings {
         // ExtSettings BEGIN
 
         /** @hide */
+        @Protected(readWrite = KnownSystemPackage.SETTINGS)
         public static final String AUTO_GRANT_OTHER_SENSORS_PERMISSION = "auto_grant_OTHER_SENSORS_perm";
 
         /** @hide */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13185,6 +13185,7 @@ public final class Settings {
         public static final String RESTRICT_WEBVIEW_DYN_CODE_LOADING_BY_DEFAULT = "restrict_webview_dyn_code_exec";
 
         /** @hide */
+        @Protected(readWrite = KnownSystemPackage.SETTINGS)
         public static final String FORCE_APP_MEMTAG_BY_DEFAULT = "force_app_memtag";
 
         /** @hide */

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13153,6 +13153,7 @@ public final class Settings {
         public static final String AUTO_REBOOT_TIMEOUT = "settings_reboot_after_timeout";
 
         /** @hide */
+        @Protected(restrictReads = false, readWrite = KnownSystemPackage.SETTINGS)
         public static final String GNSS_SUPL = "force_disable_supl"; // historical name
 
         /** @hide */

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
@@ -75,6 +75,7 @@ import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteQueryBuilder;
+import android.ext.KnownSystemPackages;
 import android.hardware.camera2.utils.ArrayUtils;
 import android.media.AudioManager;
 import android.media.IRingtonePlayer;
@@ -345,27 +346,33 @@ public class SettingsProvider extends ContentProvider {
     private static final Set<String> sReadableSecureSettings = new ArraySet<>();
     private static final ArrayMap<String, Integer> sReadableSecureSettingsWithMaxTargetSdk =
             new ArrayMap<>();
+    private static final ArrayMap<String, Settings.ProtectedSetting> sProtectedSecureSettings =
+            new ArrayMap<>();
     static {
         Settings.Secure.getPublicSettings(sAllSecureSettings, sReadableSecureSettings,
-                sReadableSecureSettingsWithMaxTargetSdk);
+                sReadableSecureSettingsWithMaxTargetSdk, sProtectedSecureSettings);
     }
 
     private static final Set<String> sAllSystemSettings = new ArraySet<>();
     private static final Set<String> sReadableSystemSettings = new ArraySet<>();
     private static final ArrayMap<String, Integer> sReadableSystemSettingsWithMaxTargetSdk =
             new ArrayMap<>();
+    private static final ArrayMap<String, Settings.ProtectedSetting> sProtectedSystemSettings =
+            new ArrayMap<>();
     static {
         Settings.System.getPublicSettings(sAllSystemSettings, sReadableSystemSettings,
-                sReadableSystemSettingsWithMaxTargetSdk);
+                sReadableSystemSettingsWithMaxTargetSdk, sProtectedSystemSettings);
     }
 
     private static final Set<String> sAllGlobalSettings = new ArraySet<>();
     private static final Set<String> sReadableGlobalSettings = new ArraySet<>();
     private static final ArrayMap<String, Integer> sReadableGlobalSettingsWithMaxTargetSdk =
             new ArrayMap<>();
+    private static final ArrayMap<String, Settings.ProtectedSetting> sProtectedGlobalSettings =
+            new ArrayMap<>();
     static {
         Settings.Global.getPublicSettings(sAllGlobalSettings, sReadableGlobalSettings,
-                sReadableGlobalSettingsWithMaxTargetSdk);
+                sReadableGlobalSettingsWithMaxTargetSdk, sProtectedGlobalSettings);
     }
 
     private final Object mLock = new Object();
@@ -1544,6 +1551,8 @@ public class SettingsProvider extends ContentProvider {
         // Make sure the caller can change the settings - treated as secure.
         enforceHasAtLeastOnePermission(Manifest.permission.WRITE_SECURE_SETTINGS);
 
+        checkProtectedSettingAccess(/* isRead */ false, name, sProtectedGlobalSettings);
+
         // Resolve the userId on whose behalf the call is made.
         final int callingUserId = resolveCallingUserIdEnforcingPermissions(requestingUserId);
 
@@ -1829,6 +1838,8 @@ public class SettingsProvider extends ContentProvider {
         // Make sure the caller can change the settings.
         enforceHasAtLeastOnePermission(Manifest.permission.WRITE_SECURE_SETTINGS);
 
+        checkProtectedSettingAccess(/* isRead */ false, name, sProtectedSecureSettings);
+
         // Resolve the userId on whose behalf the call is made.
         final int callingUserId = resolveCallingUserIdEnforcingPermissions(requestingUserId);
 
@@ -1992,6 +2003,8 @@ public class SettingsProvider extends ContentProvider {
                 return false;
             }
         }
+
+        checkProtectedSettingAccess(/* isRead */ false, name, sProtectedSystemSettings);
 
         // Resolve the userId on whose behalf the call is made.
         final int callingUserId = resolveCallingUserIdEnforcingPermissions(runAsUserId);
@@ -2256,6 +2269,8 @@ public class SettingsProvider extends ContentProvider {
     }
 
     private void enforceSettingReadable(String settingName, int settingsType, int userId) {
+        checkProtectedSettingAccess(/* isRead */ true, settingName, getProtectedSettings(settingsType));
+
         if (UserHandle.getAppId(Binder.getCallingUid()) < Process.FIRST_APPLICATION_UID) {
             return;
         }
@@ -2296,6 +2311,61 @@ public class SettingsProvider extends ContentProvider {
             Slog.w(LOG_TAG, "Instant App " + ai.packageName
                     + " trying to access unexposed setting, this will be an error in the future.");
         }
+    }
+
+    private void checkProtectedSettingAccess(boolean isRead, String name, ArrayMap<String, Settings.ProtectedSetting> map) {
+        Settings.ProtectedSetting protSetting = map.get(name);
+        if (protSetting == null) {
+            return;
+        }
+        if (isRead && !protSetting.restrictReads()) {
+            return;
+        }
+        if (Binder.getCallingPid() == Process.myPid()) {
+            // SettingsProvider runs in system_server process
+            return;
+        }
+        String callingPackage = getCallingPackage();
+        if (callingPackage == null) {
+            if (Build.IS_DEBUGGABLE) {
+                if (Binder.getCallingUid() == 0) {
+                    Slog.d(LOG_TAG, "allowed root to access protected setting " + protSetting.key());
+                    return;
+                }
+            }
+            throw new SecurityException("callingPackage is null when accessing protected setting " + protSetting.key());
+        }
+        var ksp = KnownSystemPackages.get(requireContext());
+
+        for (int id : protSetting.readWritableBy()) {
+            if (callingPackage.equals(ksp.getById(id))) {
+                return;
+            }
+        }
+        if (isRead) {
+            for (int id : protSetting.readableBy()) {
+                if (callingPackage.equals(ksp.getById(id))) {
+                    return;
+                }
+            }
+        }
+
+        if (ksp.shell.equals(callingPackage)) {
+            // ADB is used for testing
+            Slog.d(LOG_TAG, "allowed shell to access protected setting " + protSetting.key());
+            return;
+        }
+
+        throw new SecurityException(callingPackage + " is not allowed to access protected setting " + protSetting.key());
+    }
+
+    private static ArrayMap<String, Settings.ProtectedSetting> getProtectedSettings(int settingsType) {
+        return switch (settingsType) {
+            case SETTINGS_TYPE_GLOBAL -> sProtectedGlobalSettings;
+            case SETTINGS_TYPE_SECURE -> sProtectedSecureSettings;
+            case SETTINGS_TYPE_SYSTEM -> sProtectedSystemSettings;
+            default -> throw new IllegalArgumentException();
+        };
     }
 
     /**


### PR DESCRIPTION
By default, Settings.{Global,Secure,System} that aren't annotated with `@Readable` are
readable only by preinstalled apps (with some exceptions, see enforceSettingReadable()).

Settings.{Global,Secure} settings are writable only by apps that hold the privileged
WRITE_SECURE_SETTINGS permission. Settings.System are also writable by apps that hold the WRITE_SETTINGS
app-op permission (it's surfaced as "Modify system settings" in the UI).

This PR adds `@Protected` setting annotation, which allows to further restrict settings access
by specifying which system apps are allowed to read and/or write them.

This PR also applies `@Protected` annotation to all added Settings.{Global,Secure} settings.