### PR TITLE
Use ROOT_UID field to check for 0 uid instead of hardwired constant for consistency

### DIFF
--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
@@ -2328,7 +2328,7 @@ public class SettingsProvider extends ContentProvider {
         String callingPackage = getCallingPackage();
         if (callingPackage == null) {
             if (Build.IS_DEBUGGABLE) {
-                if (Binder.getCallingUid() == 0) {
+                if (Binder.getCallingUid() == ROOT_UID) {
                     Slog.d(LOG_TAG, "allowed root to access protected setting " + protSetting.key());
                     return;
                 }


### PR DESCRIPTION
Small code nit fix for consistency