### PR TITLE
Treat settings guarding unwanted upstream features as read-only

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13237,6 +13237,7 @@ public final class Settings {
          * @hide
          */
         @Readable
+        @Protected(restrictReads = false, readWrite = {})
         public static final String ADD_USERS_WHEN_LOCKED = "add_users_when_locked";
 
         /**

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -17879,6 +17879,7 @@ public final class Settings {
          * @hide
          */
         @Readable
+        @Protected(restrictReads = false, readWrite = {})
         public static final String ENABLE_EPHEMERAL_FEATURE = "enable_ephemeral_feature";
 
         /**


### PR DESCRIPTION
These settings used to disable features are not meant to be re-enabled outside of testing by other apps.