### PR TITLE
Avoid auto-granting special permissions to unarchived apps

### DIFF
--- a/services/core/java/com/android/server/pm/InstallPackageHelper.java
+++ b/services/core/java/com/android/server/pm/InstallPackageHelper.java
@@ -157,6 +157,7 @@ import android.util.Log;
 import android.util.Pair;
 import android.util.Slog;
 import android.util.SparseArray;
+import android.util.SparseBooleanArray;
 import android.util.SparseIntArray;
 
 import com.android.internal.annotations.GuardedBy;
@@ -2623,7 +2624,13 @@ final class InstallPackageHelper {
                     }
                 }
 
+                final SparseBooleanArray archivedInUserIds = new SparseBooleanArray();
+
                 if (userId != UserHandle.USER_ALL) {
+                    if (PackageArchiver.isArchived(ps.getUserStateOrDefault(userId))) {
+                        archivedInUserIds.put(userId, true);
+                    }
+
                     // It's implied that when a user requests installation, they want the app to
                     // be installed and enabled. The caller, however, can explicitly specify to
                     // keep the existing enabled state.
@@ -2634,6 +2641,10 @@ final class InstallPackageHelper {
                     // The caller explicitly specified INSTALL_ALL_USERS flag.
                     // Thus, updating the settings to install the app for all users.
                     for (int currentUserId : allUsers) {
+                        if (PackageArchiver.isArchived(ps.getUserStateOrDefault(currentUserId))) {
+                            archivedInUserIds.put(currentUserId, true);
+                        }
+
                         // If the app is already installed for the currentUser,
                         // keep it as installed as we might be updating the app at this place.
                         // If not currently installed, check if the currentUser is restricted by
@@ -2697,12 +2708,16 @@ final class InstallPackageHelper {
                         if (!previousUserIds.contains(currentUserId)
                                 && ps.getInstalled(currentUserId)) {
                             ps.setInstallReason(installReason, currentUserId);
-                            permissionParamsBuilder.setNewlyInstalledInUserId(currentUserId);
+                            if (!archivedInUserIds.get(currentUserId, false)) {
+                                permissionParamsBuilder.setNewlyInstalledInUserId(currentUserId);
+                            }
                         }
                     }
                 } else if (!previousUserIds.contains(userId)) {
                     ps.setInstallReason(installReason, userId);
-                    permissionParamsBuilder.setNewlyInstalledInUserId(userId);
+                    if (!archivedInUserIds.get(userId, false)) {
+                        permissionParamsBuilder.setNewlyInstalledInUserId(userId);
+                    }
                 }
 
                 // TODO(b/169721400): generalize Incremental States and create a Callback object


### PR DESCRIPTION
Avoid calling `setNewlyInstalledInUserId()` when restoring an archived app to ensure that the special permission auto-granting logic does not reset the user's previous permission state.

Fixes: GrapheneOS/os-issue-tracker#5256

---

Tested:
- All 4 combinations of INERNET on/off (install prompt) and OTHER_SENSORS on/off ("Allow Sensors permission to apps by default" global setting) when installing a new app from the Play Store
- All 8 combinations of INTERNET on/off, OTHER_SENSORS on/off, and POST_NOTIFICATIONS on/off when archiving and restoring an app
  * (POST_NOTIFICATIONS to test a non-`SpecialRuntimePermUtils` permission)