### PR TITLE
fixup! Support forwarding notifications from other users

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -11034,6 +11034,7 @@ public final class Settings {
          *
          * @hide
          */
+        @Protected(readWrite = KnownSystemPackage.SETTINGS)
         public static final String SEND_CENSORED_NOTIFICATIONS_TO_CURRENT_USER =
                 "send_censored_notifications_to_current_user";
 


### PR DESCRIPTION
Only Settings app is needed for read/write access to this setting, outside of system_server and for debugging, shell.