### PR TITLE
Restore back proper setting of quiet mode when user is starting and restoring

### DIFF
--- a/services/core/java/com/android/server/pm/UserManagerService.java
+++ b/services/core/java/com/android/server/pm/UserManagerService.java
@@ -821,21 +821,31 @@ public class UserManagerService extends IUserManager.Stub {
         }
     }
 
+    private record QuietModeEnabledParams(boolean alwaysLockImmediately) {
+    }
+
     @VisibleForTesting
     void setQuietModeEnabledAsync(@UserIdInt int userId, boolean enableQuietMode,
             IntentSender target, @Nullable String callingPackage) {
+        setQuietModeEnabledAsync(userId, enableQuietMode, target, callingPackage,
+                new QuietModeEnabledParams(false));
+    }
+
+    void setQuietModeEnabledAsync(@UserIdInt int userId, boolean enableQuietMode,
+            IntentSender target, @Nullable String callingPackage,
+            QuietModeEnabledParams quietModeEnabledParams) {
         if (android.multiuser.Flags.moveQuietModeOperationsToSeparateThread()) {
             // Call setQuietModeEnabled on a separate thread. Calling this operation on the main
             // thread can cause ANRs, posting on a BackgroundThread can result in delays
             Slog.d(LOG_TAG, "Calling setQuietModeEnabled for user " + userId
                     + " on a separate thread");
             mInternalExecutor.execute(() -> setQuietModeEnabled(userId, enableQuietMode, target,
-                    callingPackage));
+                    callingPackage, quietModeEnabledParams));
         } else {
             // Call setQuietModeEnabled on bg thread to avoid ANR
             BackgroundThread.getHandler().post(
                     () -> setQuietModeEnabled(userId, enableQuietMode, target,
-                            callingPackage)
+                            callingPackage, quietModeEnabledParams)
             );
         }
     }
@@ -1000,6 +1010,7 @@ public class UserManagerService extends IUserManager.Stub {
                             && targetUser.isFull()) {
                         mUms.setLastEnteredForegroundTimeToNow(user);
                     }
+                    maybeSetQuietModeOnProfilesAndStop(user, "user is starting");
                 }
             }
         }
@@ -1035,6 +1046,27 @@ public class UserManagerService extends IUserManager.Stub {
                 if (user != null) {
                     user.startRealtime = 0;
                     user.unlockRealtime = 0;
+                    maybeSetQuietModeOnProfilesAndStop(user, "user is stopping");
+                }
+            }
+        }
+
+
+        private void maybeSetQuietModeOnProfilesAndStop(@Nullable UserData user, String reason) {
+            if (user != null) {
+                if (mUms.isAutoLockingPrivateSpaceOnRestartsEnabled()
+                        && user.info.id != UserHandle.USER_SYSTEM
+                        && !user.info.isMain() && user.info.isFull()) {
+                    final int privateProfileUserId =
+                            mUms.getPrivateProfileUserId(user.info.id);
+                    if (privateProfileUserId != UserHandle.USER_NULL) {
+                        Slog.i(LOG_TAG, "Auto-locking private space with user-id "
+                                + privateProfileUserId + " reason: " + reason);
+                        mUms.setQuietModeEnabledAsync(privateProfileUserId,
+                                /* enableQuietMode */true, /* target */ null,
+                                mUms.mContext.getPackageName(),
+                                new QuietModeEnabledParams(true));
+                    }
                 }
             }
         }
@@ -1988,6 +2020,13 @@ public class UserManagerService extends IUserManager.Stub {
 
     private void setQuietModeEnabled(@UserIdInt int userId, boolean enableQuietMode,
             IntentSender target, @Nullable String callingPackage) {
+        setQuietModeEnabled(userId, enableQuietMode, target, callingPackage,
+                new QuietModeEnabledParams(false));
+    }
+
+    private void setQuietModeEnabled(@UserIdInt int userId, boolean enableQuietMode,
+            IntentSender target, @Nullable String callingPackage,
+            QuietModeEnabledParams quietModeEnabledParams) {
         final UserInfo profile, parent;
         final UserData profileUserData;
         synchronized (mUsersLock) {
@@ -1997,7 +2036,8 @@ public class UserManagerService extends IUserManager.Stub {
             if (profile == null || !profile.isProfile()) {
                 throw new IllegalArgumentException("User " + userId + " is not a profile");
             }
-            if (profile.isQuietModeEnabled() == enableQuietMode) {
+            if (profile.isQuietModeEnabled() == enableQuietMode
+                    && !quietModeEnabledParams.alwaysLockImmediately()) {
                 Slog.i(LOG_TAG, "Quiet mode is already " + enableQuietMode);
                 return;
             }
@@ -2015,7 +2055,7 @@ public class UserManagerService extends IUserManager.Stub {
 
         try {
             if (enableQuietMode) {
-                stopUserForQuietMode(userId);
+                stopUserForQuietMode(userId, quietModeEnabledParams);
                 LocalServices.getService(ActivityManagerInternal.class)
                         .killForegroundAppsForUser(userId);
             } else {
@@ -2044,8 +2084,9 @@ public class UserManagerService extends IUserManager.Stub {
         }
     }
 
-    private void stopUserForQuietMode(int userId) throws RemoteException {
+    private void stopUserForQuietMode(int userId, QuietModeEnabledParams quietModeEnabledParams) throws RemoteException {
         if (android.os.Flags.allowPrivateProfile()
+                && !quietModeEnabledParams.alwaysLockImmediately()
                 && android.multiuser.Flags.enableBiometricsToUnlockPrivateSpace()
                 && android.multiuser.Flags.enablePrivateSpaceFeatures()) {
             // Allow delayed locking since some profile types want to be able to unlock again via

--- a/services/core/java/com/android/server/pm/UserManagerService.java
+++ b/services/core/java/com/android/server/pm/UserManagerService.java
@@ -821,31 +821,21 @@ public class UserManagerService extends IUserManager.Stub {
         }
     }
 
-    private record QuietModeEnabledParams(boolean alwaysLockImmediately) {
-    }
-
     @VisibleForTesting
     void setQuietModeEnabledAsync(@UserIdInt int userId, boolean enableQuietMode,
             IntentSender target, @Nullable String callingPackage) {
-        setQuietModeEnabledAsync(userId, enableQuietMode, target, callingPackage,
-                new QuietModeEnabledParams(false));
-    }
-
-    void setQuietModeEnabledAsync(@UserIdInt int userId, boolean enableQuietMode,
-            IntentSender target, @Nullable String callingPackage,
-            QuietModeEnabledParams quietModeEnabledParams) {
         if (android.multiuser.Flags.moveQuietModeOperationsToSeparateThread()) {
             // Call setQuietModeEnabled on a separate thread. Calling this operation on the main
             // thread can cause ANRs, posting on a BackgroundThread can result in delays
             Slog.d(LOG_TAG, "Calling setQuietModeEnabled for user " + userId
                     + " on a separate thread");
             mInternalExecutor.execute(() -> setQuietModeEnabled(userId, enableQuietMode, target,
-                    callingPackage, quietModeEnabledParams));
+                    callingPackage));
         } else {
             // Call setQuietModeEnabled on bg thread to avoid ANR
             BackgroundThread.getHandler().post(
                     () -> setQuietModeEnabled(userId, enableQuietMode, target,
-                            callingPackage, quietModeEnabledParams)
+                            callingPackage)
             );
         }
     }
@@ -1020,20 +1010,6 @@ public class UserManagerService extends IUserManager.Stub {
                 final UserData user = mUms.getUserDataLU(targetUser.getUserIdentifier());
                 if (user != null) {
                     user.unlockRealtime = SystemClock.elapsedRealtime();
-                    if (mUms.isAutoLockingPrivateSpaceOnRestartsEnabled()
-                            && targetUser.getUserIdentifier() != UserHandle.USER_SYSTEM
-                            && !user.info.isMain() && user.info.isFull()) {
-                        final int privateProfileUserId =
-                                mUms.getPrivateProfileUserId(targetUser.getUserIdentifier());
-                        if (privateProfileUserId != UserHandle.USER_NULL) {
-                            Slog.i(LOG_TAG, "Auto-locking private space with user-id "
-                                    + privateProfileUserId + " now that user is unlocking");
-                            mUms.setQuietModeEnabledAsync(privateProfileUserId,
-                                    /* enableQuietMode */true, /* target */ null,
-                                    mUms.mContext.getPackageName(),
-                                    new QuietModeEnabledParams(true));
-                        }
-                    }
                 }
             }
             if (targetUser.getUserIdentifier() == UserHandle.USER_SYSTEM
@@ -1059,20 +1035,6 @@ public class UserManagerService extends IUserManager.Stub {
                 if (user != null) {
                     user.startRealtime = 0;
                     user.unlockRealtime = 0;
-                    if (mUms.isAutoLockingPrivateSpaceOnRestartsEnabled()
-                            && targetUser.getUserIdentifier() != UserHandle.USER_SYSTEM
-                            && !user.info.isMain() && user.info.isFull()) {
-                        final int privateProfileUserId =
-                                mUms.getPrivateProfileUserId(targetUser.getUserIdentifier());
-                        if (privateProfileUserId != UserHandle.USER_NULL) {
-                            Slog.i(LOG_TAG, "Auto-locking private space with user-id "
-                                    + privateProfileUserId + " now that user is stopping");
-                            mUms.setQuietModeEnabledAsync(privateProfileUserId,
-                                    /* enableQuietMode */true, /* target */ null,
-                                    mUms.mContext.getPackageName(),
-                                    new QuietModeEnabledParams(true));
-                        }
-                    }
                 }
             }
         }
@@ -2026,13 +1988,6 @@ public class UserManagerService extends IUserManager.Stub {
 
     private void setQuietModeEnabled(@UserIdInt int userId, boolean enableQuietMode,
             IntentSender target, @Nullable String callingPackage) {
-        setQuietModeEnabled(userId, enableQuietMode, target, callingPackage,
-                new QuietModeEnabledParams(false));
-    }
-
-    private void setQuietModeEnabled(@UserIdInt int userId, boolean enableQuietMode,
-            IntentSender target, @Nullable String callingPackage,
-            QuietModeEnabledParams quietModeEnabledParams) {
         final UserInfo profile, parent;
         final UserData profileUserData;
         synchronized (mUsersLock) {
@@ -2042,8 +1997,7 @@ public class UserManagerService extends IUserManager.Stub {
             if (profile == null || !profile.isProfile()) {
                 throw new IllegalArgumentException("User " + userId + " is not a profile");
             }
-            if (profile.isQuietModeEnabled() == enableQuietMode
-                    && !quietModeEnabledParams.alwaysLockImmediately()) {
+            if (profile.isQuietModeEnabled() == enableQuietMode) {
                 Slog.i(LOG_TAG, "Quiet mode is already " + enableQuietMode);
                 return;
             }
@@ -2061,7 +2015,7 @@ public class UserManagerService extends IUserManager.Stub {
 
         try {
             if (enableQuietMode) {
-                stopUserForQuietMode(userId, quietModeEnabledParams);
+                stopUserForQuietMode(userId);
                 LocalServices.getService(ActivityManagerInternal.class)
                         .killForegroundAppsForUser(userId);
             } else {
@@ -2090,9 +2044,8 @@ public class UserManagerService extends IUserManager.Stub {
         }
     }
 
-    private void stopUserForQuietMode(int userId, QuietModeEnabledParams quietModeEnabledParams) throws RemoteException {
+    private void stopUserForQuietMode(int userId) throws RemoteException {
         if (android.os.Flags.allowPrivateProfile()
-                && !quietModeEnabledParams.alwaysLockImmediately()
                 && android.multiuser.Flags.enableBiometricsToUnlockPrivateSpace()
                 && android.multiuser.Flags.enablePrivateSpaceFeatures()) {
             // Allow delayed locking since some profile types want to be able to unlock again via


### PR DESCRIPTION
Enabling quiet mode when user is unlocking causes some UX issues on requiring biometrics to use the app.