### PR TITLE
allow GMS remote credential service to be used

### DIFF
--- a/services/core/java/com/android/server/pm/ext/GmsCoreUtils.java
+++ b/services/core/java/com/android/server/pm/ext/GmsCoreUtils.java
@@ -1,0 +1,55 @@
+package com.android.server.pm.ext;
+
+import android.annotation.UserIdInt;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.ext.PackageId;
+import android.util.Slog;
+
+public class GmsCoreUtils {
+    private static final String TAG = "GmsCoreUtils";
+
+    public static boolean isGmsRemoteCredentialsServiceComponent(ComponentName componentName) {
+        // FIDO2 is from "remote devices", so it's handed by the RemoteService
+        return componentName != null
+                && PackageId.GMS_CORE_NAME.equals(componentName.getPackageName())
+                && "com.google.android.gms.auth.api.credentials.credman.service.RemoteService"
+                    .equals(componentName.getClassName());
+    }
+
+    public static boolean shouldBypassRemoteEntryCredentialProviderRestrictions(
+            Context context, ComponentName remoteCredentialProvider, @UserIdInt int userId) {
+        if (!isGmsRemoteCredentialsServiceComponent(remoteCredentialProvider)) {
+            return false;
+        }
+
+        // Ensure GMS is installed for the user that the credential request is for
+        final ApplicationInfo gmsAppInfo;
+        try {
+            gmsAppInfo = context.getPackageManager().getApplicationInfoAsUser(
+                    remoteCredentialProvider.getPackageName(), 0, userId);
+        } catch (PackageManager.NameNotFoundException e) {
+            Slog.w(TAG, "failed to resolve " + remoteCredentialProvider, e);
+            return false;
+        }
+        // getApplicationInfoAsUser is @NonNull, but just mimicking upstream code from
+        // ProviderSession
+        if (gmsAppInfo != null) {
+            final int packageId = gmsAppInfo.ext().getPackageId();
+            // ensure it's from verified GMS core
+            if (packageId == PackageId.GMS_CORE) {
+                // Note: Not checking for Manifest.permission.PROVIDE_REMOTE_CREDENTIALS
+                // (signature|privileged|role); it seems FIDO2 works fine without granting that
+                // permission
+                return true;
+            } else {
+                Slog.w(TAG,"bad gmsAppInfo packageId " + packageId + " for "
+                        + remoteCredentialProvider);
+            }
+        }
+
+        return false;
+    }
+}

--- a/services/credentials/java/com/android/server/credentials/ProviderGetSession.java
+++ b/services/credentials/java/com/android/server/credentials/ProviderGetSession.java
@@ -44,6 +44,8 @@ import android.service.credentials.RemoteEntry;
 import android.util.Pair;
 import android.util.Slog;
 
+import com.android.server.pm.ext.GmsCoreUtils;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -94,7 +96,7 @@ public final class ProviderGetSession extends ProviderSession<BeginGetCredential
         android.credentials.GetCredentialRequest filteredRequest =
                 filterOptions(providerInfo.getCapabilities(),
                         getRequestSession.mClientRequest,
-                        providerInfo, getRequestSession.mHybridService);
+                        providerInfo, getRequestSession.mHybridService, context, userId);
         if (filteredRequest != null) {
             Map<String, CredentialOption> beginGetOptionToCredentialOptionMap =
                     new HashMap<>();
@@ -130,7 +132,7 @@ public final class ProviderGetSession extends ProviderSession<BeginGetCredential
         android.credentials.GetCredentialRequest filteredRequest =
                 filterOptions(providerInfo.getCapabilities(),
                         getRequestSession.mClientRequest,
-                        providerInfo, getRequestSession.mHybridService);
+                        providerInfo, getRequestSession.mHybridService, context, userId);
         if (filteredRequest != null) {
             Map<String, CredentialOption> beginGetOptionToCredentialOptionMap =
                     new HashMap<>();
@@ -181,13 +183,22 @@ public final class ProviderGetSession extends ProviderSession<BeginGetCredential
             List<String> providerCapabilities,
             android.credentials.GetCredentialRequest clientRequest,
             CredentialProviderInfo info,
-            String hybridService) {
+            String hybridService,
+            Context context,
+            @UserIdInt int userId) {
         Slog.i(TAG, "Filtering request options for: " + info.getComponentName());
         if (android.credentials.flags.Flags.hybridFilterOptFixEnabled()) {
             ComponentName hybridComponentName = ComponentName.unflattenFromString(hybridService);
             if (hybridComponentName != null && hybridComponentName
                     .equals(info.getComponentName())) {
                 Slog.i(TAG, "Skipping filtering of options for hybrid service");
+                return clientRequest;
+            }
+            // Filter options are skipped on stock OS, since hybridComponentName corresponds to
+            // what's set in OEM config (GMS's RemoteService on stock Pixel)
+            if (GmsCoreUtils.shouldBypassRemoteEntryCredentialProviderRestrictions(
+                    context, info.getComponentName(), userId)) {
+                Slog.i(TAG, "Skipping filtering of options for hybrid service due to GMS core");
                 return clientRequest;
             }
             Slog.w(TAG, "Could not parse hybrid service while filtering options");

--- a/services/credentials/java/com/android/server/credentials/ProviderSession.java
+++ b/services/credentials/java/com/android/server/credentials/ProviderSession.java
@@ -33,6 +33,7 @@ import android.os.RemoteException;
 import android.util.Slog;
 
 import com.android.server.credentials.metrics.ProviderSessionMetric;
+import com.android.server.pm.ext.GmsCoreUtils;
 
 import java.util.UUID;
 
@@ -253,6 +254,15 @@ public abstract class ProviderSession<T, R>
 
     protected boolean enforceRemoteEntryRestrictions(
             @Nullable ComponentName expectedRemoteEntryProviderService) {
+        if (GmsCoreUtils.shouldBypassRemoteEntryCredentialProviderRestrictions(
+                mContext, mComponentName, mUserId)) {
+            // Bypassing a frameworks OEM config check and the permission grant check for
+            // Manifest.permission.PROVIDE_REMOTE_CREDENTIALS. GMS doesn't seem to require
+            // Manifest.permission.PROVIDE_REMOTE_CREDENTIALS for FIDO2 (NFC and USB) to work.
+            Slog.w(TAG, "Remote entry accepted from GmsCoreUtils bypass");
+            return true;
+        }
+
         // Check if the service is the one set by the OEM. If not silently reject this entry
         if (!mComponentName.equals(expectedRemoteEntryProviderService)) {
             Slog.w(TAG, "Remote entry being dropped as it is not from the service "


### PR DESCRIPTION
Currently, GMS allows passkeys via hardware keys ("remote credentials" from a "remote device") by its RemoteService, but this is being filtered as sandboxed Google Play doesn't result in system services. The RemoteService is also expected to be set as an OEM config value in frameworks-res (`config_defaultCredentialManagerHybridService`).

This will make it so that external devices (e.g. FIDO2 with NFC / USB) can be used with sandboxed Google Play to register hardware keys in Vanadium / Chrome, along with improving hardware key functionality in other apps that make credential requests with `android.credentials.CredentialManager` (`Context.CREDENTIAL_SERVICE`) directly instead of contacting Google Play services.

It still comes with the caveat that for some apps, Google has to be enabled as a credential service under Settings > Passwords, passkeys & accounts, as sandboxed GMS services are not system credential  providers and have to be explicitly enabled as user credential providers. Apps that contact GMS directly for credentials / passkeys still work without needing to enable Google as a credential  service (e.g., Vanadium / Chrome will fall back to contacting Play services directly if the  framework GetCredentialRequest fails which allows authentication to work without this patch, but  they don't such a fallback when creating credentials).

Appears to resolve issues like ones described at https://discuss.grapheneos.org/d/12056-fido2-security-keys-on-grapheneos-a-summary/24 (tested on `release-keys` `user` build), though Discord passkey sign-in was also broken on stock OS when I tested it:

> This is due to Sandboxed Google Play not displaying the option of choosing between security keys and password managers / local passkeys in Play's FIDO authentication dialog. This is possible for several months now on stock PixelOS, but Sandboxed Google Play seems to be displaying an older UI which does not have this option.

> For apps that don't call the default web browser for signing in/up with passkeys (such as Discord and Microsoft Teams), it doesn't seem possible to sign in with security keys unless they are used as MFA (in that case, you are probably not signing in with passkeys anyway).

Tests with Play services alpha 25.18.33 (260400-756823100), Vanadium 137.0.7151.72.1, Chrome Beta 138.0.7204.14, Brave 1.79.119:
- webauthn.io with various Advanced settings (such as Attachment set to cross-platform) on Vanadium, Chrome Beta, Brave with FIDO2 (USB and NFC)
- GitHub Passkey registration and passwordless sign-in ("Sign in with a passkey" button on sign in page) on Vanadium, Chrome Beta, Brave with FIDO2 (USB)
- Google account login via Play Store and google.com on Vanadium with FIDO2 (USB)
- Amazon Shopping and Microsoft Teams with "Sign in another way" toast pop-up at the bottom of the screen with FIDO2 (USB); able to sign in without specifying a password
- Discord security key enrollment and 2FA (but sign-in with passkey option seems broken on stock as well)

Note that Brave doesn't require Google to be set as a credential provider under Settings > Passwords, passkeys & accounts, but all the other tested browsers and most other apps require this.