### PR TITLE
make subset of keyguard / auth tests pass, and fix minor 2FA-related bug

### DIFF
--- a/core/tests/coretests/src/com/android/internal/widget/LockPatternUtilsTest.java
+++ b/core/tests/coretests/src/com/android/internal/widget/LockPatternUtilsTest.java
@@ -103,7 +103,7 @@ public class LockPatternUtilsTest {
         when(context.getContentResolver()).thenReturn(cr);
         Settings.Global.putInt(cr, Settings.Global.DEVICE_DEMO_MODE, deviceDemoMode);
 
-        when(mLockSettings.getCredentialType(DEMO_USER_ID)).thenReturn(
+        when(mLockSettings.getCredentialType(DEMO_USER_ID, LockDomain.Primary)).thenReturn(
                 isSecure ? LockPatternUtils.CREDENTIAL_TYPE_PASSWORD
                          : LockPatternUtils.CREDENTIAL_TYPE_NONE);
         when(mLockSettings.getLong("lockscreen.password_type", PASSWORD_QUALITY_UNSPECIFIED,

--- a/core/tests/coretests/src/com/android/internal/widget/LockPatternUtilsTest.java
+++ b/core/tests/coretests/src/com/android/internal/widget/LockPatternUtilsTest.java
@@ -432,7 +432,8 @@ public class LockPatternUtilsTest {
     @EnableFlags(Flags.FLAG_HIDE_LAST_CHAR_WITH_PHYSICAL_INPUT)
     public void isPinEnhancedPrivacyEnabled_noDevicesAttached() throws RemoteException {
         InputManagerGlobal.TestSession session = configureExternalHardwareTest(new InputDevice[0]);
-        assertFalse(mLockPatternUtils.isPinEnhancedPrivacyEnabled(USER_ID));
+        // GrapheneOS change: PIN enhanced privacy defaults to true, regardless of hw keyboard
+        assertTrue(mLockPatternUtils.isPinEnhancedPrivacyEnabled(USER_ID));
         session.close();
     }
 
@@ -443,7 +444,8 @@ public class LockPatternUtilsTest {
         builder.setEnabled(false);
         InputManagerGlobal.TestSession session =
                 configureExternalHardwareTest(new InputDevice[]{builder.build()});
-        assertFalse(mLockPatternUtils.isPinEnhancedPrivacyEnabled(USER_ID));
+        // GrapheneOS change: PIN enhanced privacy defaults to true, regardless of hw keyboard
+        assertTrue(mLockPatternUtils.isPinEnhancedPrivacyEnabled(USER_ID));
         session.close();
     }
 
@@ -454,7 +456,8 @@ public class LockPatternUtilsTest {
         builder.setEnabled(true).setSources(InputDevice.SOURCE_TOUCHSCREEN);
         InputManagerGlobal.TestSession session =
                 configureExternalHardwareTest(new InputDevice[]{builder.build()});
-        assertFalse(mLockPatternUtils.isPinEnhancedPrivacyEnabled(USER_ID));
+        // GrapheneOS change: PIN enhanced privacy defaults to true, regardless of hw keyboard
+        assertTrue(mLockPatternUtils.isPinEnhancedPrivacyEnabled(USER_ID));
         session.close();
     }
 
@@ -468,7 +471,8 @@ public class LockPatternUtilsTest {
                 .setKeyboardType(InputDevice.KEYBOARD_TYPE_NON_ALPHABETIC);
         InputManagerGlobal.TestSession session =
                 configureExternalHardwareTest(new InputDevice[]{builder.build()});
-        assertFalse(mLockPatternUtils.isPinEnhancedPrivacyEnabled(USER_ID));
+        // GrapheneOS change: PIN enhanced privacy defaults to true, regardless of hw keyboard
+        assertTrue(mLockPatternUtils.isPinEnhancedPrivacyEnabled(USER_ID));
         session.close();
     }
 
@@ -482,7 +486,8 @@ public class LockPatternUtilsTest {
                 .setKeyboardType(InputDevice.KEYBOARD_TYPE_ALPHABETIC);
         InputManagerGlobal.TestSession session =
                 configureExternalHardwareTest(new InputDevice[]{builder.build()});
-        assertFalse(mLockPatternUtils.isPinEnhancedPrivacyEnabled(USER_ID));
+        // GrapheneOS change: PIN enhanced privacy defaults to true, regardless of hw keyboard
+        assertTrue(mLockPatternUtils.isPinEnhancedPrivacyEnabled(USER_ID));
         session.close();
     }
 

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
@@ -2394,6 +2394,22 @@ public class SettingsProvider extends ContentProvider {
             return;
         }
 
+        if (Build.IS_DEBUGGABLE) {
+            if (isRead && "com.android.systemui.tests".equals(callingPackage)) {
+                ApplicationInfo ai = getCallingApplicationInfoOrThrow();
+                if (ai.isSignedWithPlatformKey() && (ai.flags & ApplicationInfo.FLAG_TEST_ONLY) != 0) {
+                    // SystemUI tests run SystemUI code, so it should be able to read
+                    // SystemUI-readable settings
+                    for (int id : protSetting.readableBy()) {
+                        if (ksp.systemUi.equals(ksp.getById(id))) {
+                            Slog.d(LOG_TAG, "allowed com.android.systemui.tests to access protected setting " + protSetting.key());
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+
         throw new SecurityException(callingPackage + " is not allowed to access protected setting " + protSetting.key());
     }
 

--- a/packages/SystemUI/multivalentTests/src/com/android/keyguard/KeyguardPinBasedInputViewControllerTest.java
+++ b/packages/SystemUI/multivalentTests/src/com/android/keyguard/KeyguardPinBasedInputViewControllerTest.java
@@ -36,6 +36,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.SmallTest;
 
 import com.android.internal.util.LatencyTracker;
+import com.android.internal.widget.LockDomain;
 import com.android.internal.widget.LockPatternUtils;
 import com.android.keyguard.KeyguardSecurityModel.SecurityMode;
 import com.android.keyguard.domain.interactor.KeyguardKeyboardInteractor;
@@ -127,7 +128,7 @@ public class KeyguardPinBasedInputViewControllerTest extends SysuiTestCase {
                 new KeyguardKeyboardInteractor(new FakeKeyboardRepository());
         FakeFeatureFlags featureFlags = new FakeFeatureFlags();
         mSetFlagsRule.enableFlags(com.android.systemui.Flags.FLAG_REVAMPED_BOUNCER_MESSAGES);
-        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt())).thenReturn(false);
+        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt(), any(LockDomain.class))).thenReturn(false);
         mKeyguardPinViewController = new KeyguardPinBasedInputViewController(mPinBasedInputView,
                 mKeyguardUpdateMonitor, mSecurityMode, mLockPatternUtils, mKeyguardSecurityCallback,
                 mKeyguardMessageAreaControllerFactory, mLatencyTracker,
@@ -162,7 +163,7 @@ public class KeyguardPinBasedInputViewControllerTest extends SysuiTestCase {
     @Test
     @EnableFlags(FLAG_HIDE_LAST_CHAR_WITH_PHYSICAL_INPUT)
     public void updateAnimations_addDevice_notKeyboard() {
-        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt())).thenReturn(false);
+        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt(), any(LockDomain.class))).thenReturn(false);
         verify(mPasswordEntry, times(1)).setShowPassword(true);
         mKeyguardPinViewController.onViewAttached();
         mKeyguardPinViewController.onInputDeviceAdded(1);
@@ -172,7 +173,7 @@ public class KeyguardPinBasedInputViewControllerTest extends SysuiTestCase {
     @Test
     @EnableFlags(FLAG_HIDE_LAST_CHAR_WITH_PHYSICAL_INPUT)
     public void updateAnimations_addDevice_keyboard() {
-        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt())).thenReturn(true);
+        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt(), any(LockDomain.class))).thenReturn(true);
         verify(mPasswordEntry, times(1)).setShowPassword(true);
         mKeyguardPinViewController.onViewAttached();
         mKeyguardPinViewController.onInputDeviceAdded(1);
@@ -182,7 +183,7 @@ public class KeyguardPinBasedInputViewControllerTest extends SysuiTestCase {
     @Test
     @EnableFlags(FLAG_HIDE_LAST_CHAR_WITH_PHYSICAL_INPUT)
     public void updateAnimations_addDevice_multipleKeyboards() {
-        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt())).thenReturn(true);
+        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt(), any(LockDomain.class))).thenReturn(true);
         verify(mPasswordEntry, times(1)).setShowPassword(true);
         mKeyguardPinViewController.onViewAttached();
         mKeyguardPinViewController.onInputDeviceAdded(1);
@@ -194,7 +195,7 @@ public class KeyguardPinBasedInputViewControllerTest extends SysuiTestCase {
     @Test
     @EnableFlags(FLAG_HIDE_LAST_CHAR_WITH_PHYSICAL_INPUT)
     public void updateAnimations_removeDevice_notKeyboard() {
-        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt())).thenReturn(false);
+        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt(), any(LockDomain.class))).thenReturn(false);
         verify(mPasswordEntry, times(1)).setShowPassword(true);
         mKeyguardPinViewController.onViewAttached();
         mKeyguardPinViewController.onInputDeviceRemoved(1);
@@ -204,7 +205,7 @@ public class KeyguardPinBasedInputViewControllerTest extends SysuiTestCase {
     @Test
     @EnableFlags(FLAG_HIDE_LAST_CHAR_WITH_PHYSICAL_INPUT)
     public void updateAnimations_removeDevice_keyboard() {
-        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt())).thenReturn(true, false);
+        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt(), any(LockDomain.class))).thenReturn(true, false);
         verify(mPasswordEntry, times(1)).setShowPassword(true);
         verify(mPasswordEntry, times(0)).setShowPassword(false);
         mKeyguardPinViewController.onViewAttached();
@@ -218,7 +219,7 @@ public class KeyguardPinBasedInputViewControllerTest extends SysuiTestCase {
     @Test
     @EnableFlags(FLAG_HIDE_LAST_CHAR_WITH_PHYSICAL_INPUT)
     public void updateAnimations_removeDevice_multipleKeyboards() {
-        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt())).thenReturn(true, true);
+        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt(), any(LockDomain.class))).thenReturn(true, true);
         verify(mPasswordEntry, times(1)).setShowPassword(true);
         verify(mPasswordEntry, times(0)).setShowPassword(false);
         mKeyguardPinViewController.onViewAttached();
@@ -232,7 +233,7 @@ public class KeyguardPinBasedInputViewControllerTest extends SysuiTestCase {
     @Test
     @EnableFlags(FLAG_HIDE_LAST_CHAR_WITH_PHYSICAL_INPUT)
     public void updateAnimations_updateDevice_notKeyboard() {
-        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt())).thenReturn(false);
+        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt(), any(LockDomain.class))).thenReturn(false);
         verify(mPasswordEntry, times(1)).setShowPassword(true);
         mKeyguardPinViewController.onViewAttached();
         mKeyguardPinViewController.onInputDeviceChanged(1);
@@ -242,7 +243,7 @@ public class KeyguardPinBasedInputViewControllerTest extends SysuiTestCase {
     @Test
     @EnableFlags(FLAG_HIDE_LAST_CHAR_WITH_PHYSICAL_INPUT)
     public void updateAnimations_updateDevice_keyboard() {
-        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt())).thenReturn(true, false);
+        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt(), any(LockDomain.class))).thenReturn(true, false);
         verify(mPasswordEntry, times(1)).setShowPassword(true);
         verify(mPasswordEntry, times(0)).setShowPassword(false);
         mKeyguardPinViewController.onViewAttached();
@@ -256,7 +257,7 @@ public class KeyguardPinBasedInputViewControllerTest extends SysuiTestCase {
     @Test
     @EnableFlags(FLAG_HIDE_LAST_CHAR_WITH_PHYSICAL_INPUT)
     public void updateAnimations_updateDevice_multipleKeyboards() {
-        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt())).thenReturn(true, true);
+        when(mLockPatternUtils.isPinEnhancedPrivacyEnabled(anyInt(), any(LockDomain.class))).thenReturn(true, true);
         verify(mPasswordEntry, times(1)).setShowPassword(true);
         verify(mPasswordEntry, times(0)).setShowPassword(false);
         mKeyguardPinViewController.onViewAttached();

--- a/packages/SystemUI/multivalentTests/src/com/android/systemui/statusbar/phone/BiometricsUnlockControllerTest.java
+++ b/packages/SystemUI/multivalentTests/src/com/android/systemui/statusbar/phone/BiometricsUnlockControllerTest.java
@@ -280,6 +280,7 @@ public class BiometricsUnlockControllerTest extends SysuiTestCase {
     }
 
     @Test
+    @org.junit.Ignore("GrapheneOS commit 'protect against upstream bugs bypassing 2FA' doesn't return MODE_WAKE_AND_UNLOCK")
     public void onBiometricAuthenticated_whenDeviceIsAlreadyUnlocked_wakeAndUnlock() {
         reset(mUpdateMonitor);
         reset(mStatusBarKeyguardViewManager);

--- a/packages/SystemUI/multivalentTests/src/com/android/systemui/statusbar/phone/BiometricsUnlockControllerTest.java
+++ b/packages/SystemUI/multivalentTests/src/com/android/systemui/statusbar/phone/BiometricsUnlockControllerTest.java
@@ -203,7 +203,7 @@ public class BiometricsUnlockControllerTest extends SysuiTestCase {
                 BiometricSourceType.FINGERPRINT, true, Enabled);
 
         verify(mStatusBarKeyguardViewManager).showPrimaryBouncer(anyBoolean(),
-                "BiometricUnlockController#MODE_SHOW_BOUNCER");
+                eq("BiometricUnlockController#MODE_SHOW_BOUNCER"));
         verify(mStatusBarKeyguardViewManager, never()).notifyKeyguardAuthenticated(anyBoolean());
         assertThat(mBiometricUnlockController.getMode())
                 .isEqualTo(BiometricUnlockController.MODE_SHOW_BOUNCER);
@@ -229,7 +229,7 @@ public class BiometricsUnlockControllerTest extends SysuiTestCase {
                 BiometricSourceType.FINGERPRINT, true, Enabled);
 
         verify(mStatusBarKeyguardViewManager).showPrimaryBouncer(anyBoolean(),
-                "BiometricUnlockController#MODE_SHOW_BOUNCER");
+                eq("BiometricUnlockController#MODE_SHOW_BOUNCER"));
         verify(mStatusBarKeyguardViewManager, never()).notifyKeyguardAuthenticated(anyBoolean());
         assertThat(mBiometricUnlockController.getMode())
                 .isEqualTo(BiometricUnlockController.MODE_SHOW_BOUNCER);

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardPinBasedInputViewController.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardPinBasedInputViewController.java
@@ -117,7 +117,8 @@ public abstract class KeyguardPinBasedInputViewController<T extends KeyguardPinB
 
         if (showAnimations == null) {
             showAnimations = !mLockPatternUtils
-                .isPinEnhancedPrivacyEnabled(mSelectedUserInteractor.getSelectedUserId());
+                .isPinEnhancedPrivacyEnabled(mSelectedUserInteractor.getSelectedUserId(),
+                        mLockDomain);
         }
         if (mShowAnimations != null && showAnimations.equals(mShowAnimations)) return;
         mShowAnimations = showAnimations;
@@ -161,7 +162,7 @@ public abstract class KeyguardPinBasedInputViewController<T extends KeyguardPinB
 
         boolean showAnimations = !mLockPatternUtils
                 .isPinEnhancedPrivacyEnabled(mSelectedUserInteractor.getSelectedUserId(),
-			mLockDomain);
+                        mLockDomain);
         if (hideLastCharWithPhysicalInput()) {
             mInputManager.registerInputDeviceListener(this, null);
             updateAnimations(showAnimations);

--- a/packages/SystemUI/tests/src/com/android/keyguard/KeyguardUpdateMonitorTest.java
+++ b/packages/SystemUI/tests/src/com/android/keyguard/KeyguardUpdateMonitorTest.java
@@ -2356,8 +2356,10 @@ public class KeyguardUpdateMonitorTest extends SysuiTestCase {
         Assert.assertFalse(mKeyguardUpdateMonitor.isUnlockingWithBiometricAllowedSafe(
                 BiometricSourceType.FINGERPRINT));
 
-        // THEN fingerprint detect gets called
-        verifyFingerprintDetectCall();
+        // THEN fingerprint detect never gets called
+        // GrapheneOS change: Adding stopListeningForFingerprint() to KeyguardUpdateMonitor
+        // ("fix upstream fingerprint mode change bug") results in this never being called.
+        verifyFingerprintDetectNeverCalled(); // verifyFingerprintDetectCall();
     }
 
     @Test


### PR DESCRIPTION
Running the tests below has discovered a minor bug related to 2FA due to new upstream code behind an aconfig flag `com.android.internal.widget.flags.hide_last_char_with_physical_input`; see the [bugfix] commit for more details.

This change results in the following test results:

Command:

```
atest SystemUITests:com.android.keyguard.KeyguardAbsKeyInputViewControllerTest \
SystemUITests:com.android.keyguard.KeyguardPinBasedInputViewControllerTest \
SystemUITests:com.android.keyguard.KeyguardPinViewControllerTest \
SystemUITests:com.android.keyguard.KeyguardSecurityContainerControllerTest \
SystemUITests:com.android.systemui.bouncer.domain.interactor.BouncerMessageInteractorTest \
SystemUITests:com.android.systemui.bouncer.domain.interactor.PrimaryBouncerInteractorTest \
SystemUITests:com.android.systemui.keyguard.data.repository.DeviceEntryFingerprintAuthRepositoryTest \
SystemUITests:com.android.systemui.keyguard.domain.interactor.DeviceEntrySideFpsOverlayInteractorTest \
SystemUITests:com.android.systemui.keyguard.util.IndicationHelperTest \
SystemUITests:com.android.systemui.statusbar.KeyguardIndicationControllerTest \
SystemUITests:com.android.systemui.statusbar.phone.BiometricsUnlockControllerTest \
SystemUITests:com.android.keyguard.KeyguardUpdateMonitorTest \
FrameworksServicesTests:com.android.server.biometrics.BiometricServiceTest \
FrameworksServicesTests:com.android.server.biometrics.log.BiometricContextProviderTest \
FrameworksServicesTests:com.android.server.biometrics.sensors.BiometricAuthTokenStoreTest \
FrameworksServicesTests:com.android.server.biometrics.sensors.fingerprint.aidl.FingerprintAuthenticationClientTest \
FrameworksServicesTests:com.android.server.devicepolicy.DevicePolicyManagerTest \
FrameworksServicesTests:com.android.server.locksettings.LockSettingsServiceTests \
FrameworksServicesTests:com.android.server.locksettings.SyntheticPasswordTests \
FrameworksServicesTests:com.android.server.locksettings.WeaverBasedSyntheticPasswordTests \
FrameworksServicesTests:com.android.server.security.authenticationpolicy.AuthenticationPolicyServiceTest \
FrameworksCoreTests:com.android.internal.widget.LockPatternUtilsTest
```

Results:

```
Summary (Test executed with 1 devices.)
-------
x86_64 FrameworksCoreTests: Passed: 34, Failed: 0, Ignored: 0, Assumption Failed: 0
x86_64 FrameworksServicesTests: Passed: 670, Failed: 0, Ignored: 34, Assumption Failed: 14
x86_64 SystemUITests: Passed: 535, Failed: 1, Ignored: 1, Assumption Failed: 0

1 test failed
--------------
com.android.keyguard.KeyguardSecurityContainerControllerTest#dismissesKeyguard_whenSceneChangesToGone
```

Test failure reason: `java.lang.IllegalStateException: Compose bouncer support has not been added to Graphene's MFA!`