### PR TITLE
allow system apps to opt-out of edge-to-edge enforcement

### DIFF
--- a/core/java/com/android/internal/policy/PhoneWindow.java
+++ b/core/java/com/android/internal/policy/PhoneWindow.java
@@ -475,6 +475,10 @@ public class PhoneWindow extends Window implements MenuBuilder.Callback {
      * whether the app declares style to opt out.
      */
     public static boolean isOptOutEdgeToEdgeEnabled(ApplicationInfo info, boolean local) {
+        if (info.isSystemApp()) {
+            return true;
+        }
+
         final boolean disabled = Flags.disableOptOutEdgeToEdge()
                 && (local
                         // Calling this doesn't require a permission.


### PR DESCRIPTION
Edge-to-edge is still not supported in many AOSP UIs and in LogViewer.