### PR TITLE
fix backported apps not being installed

### DIFF
--- a/core/java/com/android/internal/pm/pkg/parsing/ParsingPackageUtils.java
+++ b/core/java/com/android/internal/pm/pkg/parsing/ParsingPackageUtils.java
@@ -356,6 +356,13 @@ public class ParsingPackageUtils {
         if ((flags & PARSE_APEX) != 0) {
             liteParseFlags |= PARSE_APEX;
         }
+        // For some reason, upstream doesn't add the PARSE_IS_SYSTEM_DIR flag if it was there.
+        // The only thing PARSE_IS_SYSTEM_DIR is checked in ApkLiteParseUtils is behind a
+        // PARSE_COLLECT_CERTIFICATES check, which won't get triggered by this code path since
+        // PARSE_COLLECT_CERTIFICATES is also ignored for liteParseFlags
+        if ((flags & PARSE_IS_SYSTEM_DIR) != 0) {
+            liteParseFlags |= PARSE_IS_SYSTEM_DIR;
+        }
         final ParseResult<PackageLite> liteResult =
                 ApkLiteParseUtils.parseClusterPackageLite(input, packageDir, liteParseFlags);
         if (liteResult.isError()) {


### PR DESCRIPTION
Should make backported apps (and hence VoLTE) work again. Current issue is that the guard never passed because of this upstream code neglecting this flag for whatever reason

The alternate route would be to remove the `isSystemDir` guard (originally removed the guard in my first PR since it wasn't clear if upstream was applying `PARSE_IS_SYSTEM_DIR` correctly in all cases, given that this PR is necessary to fix an issue with the flag)