### PR TITLE
fix end session button not working in certain cases

### DIFF
--- a/services/devicepolicy/java/com/android/server/devicepolicy/DevicePolicyManagerService.java
+++ b/services/devicepolicy/java/com/android/server/devicepolicy/DevicePolicyManagerService.java
@@ -3941,9 +3941,6 @@ public class DevicePolicyManagerService extends IDevicePolicyManager.Stub {
             preferentialNetworkServiceConfigs = owner != null
                     ? owner.mPreferentialNetworkServiceConfigs
                     : List.of(PreferentialNetworkServiceConfig.DEFAULT);
-            if (owner == null && userId != UserHandle.USER_SYSTEM) {
-                setLogoutUserIdLocked(UserHandle.USER_SYSTEM);
-            }
         }
         updateNetworkPreferenceForUser(userId, preferentialNetworkServiceConfigs);
 
@@ -3964,6 +3961,19 @@ public class DevicePolicyManagerService extends IDevicePolicyManager.Stub {
 
     void handleOnUserSwitching(int fromUserId, int toUserId) {
         showNewUserDisclaimerIfNecessary(toUserId);
+
+        synchronized (getLockObject()) {
+            ActiveAdmin owner = getDeviceOrProfileOwnerAdminLocked(toUserId);
+            if (owner == null) {
+                Slog.d(LOG_TAG, "setting logout user id in absence of device / profile admin");
+                if (toUserId == UserHandle.USER_SYSTEM) {
+                    // don't show end session for owner user
+                    setLogoutUserIdLocked(UserHandle.USER_NULL);
+                } else {
+                    setLogoutUserIdLocked(UserHandle.USER_SYSTEM);
+                }
+            }
+        }
     }
 
     void handleStopUser(int userId) {


### PR DESCRIPTION
- Fixes end session buttons (keyguard and hold power button) being displayed on owner after switching back to owner from a secondary user without ending the secondary user
- Fixes end session button not appearing if you end the session of a secondary user and then switch to another user that's currently running. Current code only sets `setLogoutUserIdLocked` inside of `handleStartUser`, but `handleStartUser` isn't called when switching to a running user. There is upstream code that clears the logout userId when a user is logged out, so the logout userId remains cleared if switching to a running user