### PR TITLE
switch AppOpsService.getPackagesForOpsForDevice() to ParceledListSlice

### DIFF
--- a/core/java/android/app/AppOpsManager.java
+++ b/core/java/android/app/AppOpsManager.java
@@ -8371,7 +8371,7 @@ public class AppOpsManager {
         }
         final List<AppOpsManager.PackageOps> result;
         try {
-            result = mService.getPackagesForOpsForDevice(opCodes, persistentDeviceId);
+            result = mService.getPackagesForOpsForDevice(opCodes, persistentDeviceId).getList();
         } catch (RemoteException e) {
             throw e.rethrowFromSystemServer();
         }
@@ -8395,7 +8395,7 @@ public class AppOpsManager {
     public List<AppOpsManager.PackageOps> getPackagesForOps(int[] ops) {
         try {
             return mService.getPackagesForOpsForDevice(ops,
-                    VirtualDeviceManager.PERSISTENT_DEVICE_ID_DEFAULT);
+                    VirtualDeviceManager.PERSISTENT_DEVICE_ID_DEFAULT).getList();
         } catch (RemoteException e) {
             throw e.rethrowFromSystemServer();
         }

--- a/core/java/com/android/internal/app/IAppOpsService.aidl
+++ b/core/java/com/android/internal/app/IAppOpsService.aidl
@@ -162,6 +162,6 @@ interface IAppOpsService {
             int attributionFlags, int attributionChainId);
     void finishOperationForDevice(IBinder clientId, int code, int uid, String packageName,
             @nullable String attributionTag, int virtualDeviceId);
-   List<AppOpsManager.PackageOps> getPackagesForOpsForDevice(in int[] ops, String persistentDeviceId);
+   ParceledListSlice<AppOpsManager.PackageOps> getPackagesForOpsForDevice(in int[] ops, String persistentDeviceId);
    oneway void noteOperationsInBatch(in Map batchedNoteOps);
 }

--- a/services/core/java/com/android/server/appop/AppOpsService.java
+++ b/services/core/java/com/android/server/appop/AppOpsService.java
@@ -111,6 +111,7 @@ import android.content.IntentFilter;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManagerInternal;
+import android.content.pm.ParceledListSlice;
 import android.content.pm.PermissionInfo;
 import android.content.pm.UserInfo;
 import android.database.ContentObserver;
@@ -1826,12 +1827,26 @@ public class AppOpsService extends IAppOpsService.Stub {
 
     @Override
     public List<AppOpsManager.PackageOps> getPackagesForOps(int[] ops) {
-        return getPackagesForOpsForDevice(ops, PERSISTENT_DEVICE_ID_DEFAULT);
+        // This method was intentionally not switched to ParceledListSlice to avoid breaking
+        // app compat, since it's a part of the allowlisted hidden API list.
+        //
+        // This method doesn't get used by the OS anymore, it exists for app compatibility.
+        //
+        // Also, third-party apps can't have the privileged GET_APP_OPS_STATS permissions, which means
+        // that only their own ops will be returned to them, which makes use of ParceledListSlice
+        // mostly redundant in this case.
+        return getPackagesForOpsForDeviceInner(ops, PERSISTENT_DEVICE_ID_DEFAULT);
     }
 
     @Override
-    public List<AppOpsManager.PackageOps> getPackagesForOpsForDevice(int[] ops,
+    public ParceledListSlice<AppOpsManager.PackageOps> getPackagesForOpsForDevice(int[] ops,
             @NonNull String persistentDeviceId) {
+        List<AppOpsManager.PackageOps> res = getPackagesForOpsForDeviceInner(ops, persistentDeviceId);
+        return new ParceledListSlice<>(res);
+    }
+
+    private List<AppOpsManager.PackageOps> getPackagesForOpsForDeviceInner(int[] ops,
+        @NonNull String persistentDeviceId) {
         final int callingUid = Binder.getCallingUid();
         final boolean hasAllPackageAccess = mContext.checkPermission(
                 Manifest.permission.GET_APP_OPS_STATS, Binder.getCallingPid(),


### PR DESCRIPTION
getPackagesForOpsForDevice() returns a list with size that depends on the number of installed packages across all users. Size of this list can be larger than the max Binder transaction size.