### PR TITLE
fixup! switch AppOpsService.getPackagesForOpsForDevice() to ParceledListSlice

### DIFF
--- a/core/java/android/app/AppOpsManager.java
+++ b/core/java/android/app/AppOpsManager.java
@@ -8371,7 +8371,8 @@ public class AppOpsManager {
         }
         final List<AppOpsManager.PackageOps> result;
         try {
-            result = mService.getPackagesForOpsForDevice(opCodes, persistentDeviceId).getList();
+            var listSlice = mService.getPackagesForOpsForDevice(opCodes, persistentDeviceId);
+            result = listSlice != null ? listSlice.getList() : null;
         } catch (RemoteException e) {
             throw e.rethrowFromSystemServer();
         }
@@ -8394,8 +8395,9 @@ public class AppOpsManager {
     @UnsupportedAppUsage
     public List<AppOpsManager.PackageOps> getPackagesForOps(int[] ops) {
         try {
-            return mService.getPackagesForOpsForDevice(ops,
-                    VirtualDeviceManager.PERSISTENT_DEVICE_ID_DEFAULT).getList();
+            var listSlice = mService.getPackagesForOpsForDevice(ops,
+                    VirtualDeviceManager.PERSISTENT_DEVICE_ID_DEFAULT);
+            return listSlice != null ? listSlice.getList() : null;
         } catch (RemoteException e) {
             throw e.rethrowFromSystemServer();
         }

--- a/services/core/java/com/android/server/appop/AppOpsService.java
+++ b/services/core/java/com/android/server/appop/AppOpsService.java
@@ -1842,7 +1842,7 @@ public class AppOpsService extends IAppOpsService.Stub {
     public ParceledListSlice<AppOpsManager.PackageOps> getPackagesForOpsForDevice(int[] ops,
             @NonNull String persistentDeviceId) {
         List<AppOpsManager.PackageOps> res = getPackagesForOpsForDeviceInner(ops, persistentDeviceId);
-        return new ParceledListSlice<>(res);
+        return res != null ? new ParceledListSlice<>(res) : null;
     }
 
     private List<AppOpsManager.PackageOps> getPackagesForOpsForDeviceInner(int[] ops,


### PR DESCRIPTION
Fixes a crash when trying to open Developer options menu in the Settings app

`getPackagesForOpsForDeviceInner` can return a null List and apparently ParceledListSlice doesn't handle a null input argument well. Returning null for `getPackagesForOpsForDevice` seems fine, because callers AppOpsService#getPackagesForOpsForDevice and `AppOppsManager#getPackagesForOps` expect the return value to be nullable and already perform null checks on it.