### PR TITLE
fix Keyguard slice

### DIFF
--- a/packages/SystemUI/multivalentTests/src/com/android/keyguard/KeyguardSliceViewControllerTest.java
+++ b/packages/SystemUI/multivalentTests/src/com/android/keyguard/KeyguardSliceViewControllerTest.java
@@ -71,7 +71,7 @@ public class KeyguardSliceViewControllerTest extends SysuiTestCase {
         when(mView.getContext()).thenReturn(mContext);
         mController = new KeyguardSliceViewController(mHandler, mBgHandler, mView,
                 mActivityStarter, mConfigurationController, mDumpManager,
-                mDisplayTracker);
+                mDisplayTracker, null, null);
         mController.setupUri(KeyguardSliceProvider.KEYGUARD_SLICE_URI);
     }
 

--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/KeyguardSliceViewSection.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/KeyguardSliceViewSection.kt
@@ -30,8 +30,10 @@ import com.android.systemui.customization.R as customR
 import com.android.systemui.dagger.qualifiers.Background
 import com.android.systemui.dagger.qualifiers.Main
 import com.android.systemui.dump.DumpManager
+import com.android.systemui.keyguard.domain.interactor.KeyguardInteractor
 import com.android.systemui.keyguard.shared.model.KeyguardSection
 import com.android.systemui.plugins.ActivityStarter
+import com.android.systemui.power.domain.interactor.PowerInteractor
 import com.android.systemui.res.R
 import com.android.systemui.settings.DisplayTracker
 import com.android.systemui.statusbar.lockscreen.LockscreenSmartspaceController
@@ -50,6 +52,8 @@ constructor(
     val configurationController: ConfigurationController,
     val dumpManager: DumpManager,
     val displayTracker: DisplayTracker,
+    val keyguardInteractor: KeyguardInteractor,
+    val powerInteractor: PowerInteractor,
 ) : KeyguardSection() {
     private lateinit var sliceView: KeyguardSliceView
 
@@ -73,6 +77,8 @@ constructor(
                 configurationController,
                 dumpManager,
                 displayTracker,
+                keyguardInteractor,
+                powerInteractor,
             )
         controller.init()
     }


### PR DESCRIPTION
Upstream refactor in commit 1f73b12d5dd4db6ebcad5d444c79ac18cc59e3c3 removed too much and as a result the legacy Keyguard slice code was broken. This adds back the needed elements.