### PR TITLE
add lockscreen synchronisation failsafe

### DIFF
--- a/packages/SystemUI/src/com/android/keyguard/KeyguardSecurityViewFlipperController.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardSecurityViewFlipperController.java
@@ -20,6 +20,7 @@ import static android.content.res.Configuration.ORIENTATION_LANDSCAPE;
 import static com.android.internal.widget.LockDomain.Secondary;
 import static com.android.systemui.flags.Flags.LOCKSCREEN_ENABLE_LANDSCAPE;
 
+import android.os.Looper;
 import android.util.Log;
 import android.view.LayoutInflater;
 
@@ -119,6 +120,12 @@ public class KeyguardSecurityViewFlipperController
     void getSecurityView(SecurityMode securityMode,
             KeyguardSecurityCallback keyguardSecurityCallback,
             OnViewInflatedCallback onViewInflatedCallback) {
+        if (!Looper.getMainLooper().isCurrentThread()) {
+            throw new IllegalStateException(
+                    "KeyguardSecurityViewFlipperController#getSecurityView must be called from main"
+                            + " thread");
+        }
+
         for (KeyguardInputViewController<KeyguardInputView> child : mChildren) {
             if (child.getSecurityMode() == securityMode) {
                 onViewInflatedCallback.onViewInflated(child);


### PR DESCRIPTION
Upstream commit fae5190856cbe844b1a441d99215345953b32dac adds synchronisation to KeyguardSecurityViewFlipperController. This should not be needed, so it was removed as part of 2FA. This commit adds a failsafe in case we got it wrong.

Note that upstream's synchronisation is not sufficient to prevent race conditions, so it is likely that they don't understand this code. They ae likely experiencing issues due to not properly clearing async inflation jobs in KSVFC#clearViews, and are incorrectly concluding that these are caused by KSVFC#getSecurityView being called from multiple threads.