### PR TITLE
fix empty end session button on owner profile

### DIFF
--- a/packages/SystemUI/multivalentTests/src/com/android/keyguard/KeyguardPinViewControllerTest.kt
+++ b/packages/SystemUI/multivalentTests/src/com/android/keyguard/KeyguardPinViewControllerTest.kt
@@ -252,7 +252,6 @@ class KeyguardPinViewControllerTest : SysuiTestCase() {
 
     @Test
     fun testOnViewAttached_secondaryWithAutoPinConfirmationFailedPasswordAttemptsLessThan5() {
-        `when`(featureFlags.isEnabled(Flags.AUTO_PIN_CONFIRMATION)).thenReturn(true)
         `when`(lockPatternUtils.getPinLength(anyInt(), eq(Secondary))).thenReturn(6)
         `when`(lockPatternUtils.isAutoPinConfirmEnabled(anyInt(), eq(Secondary))).thenReturn(true)
         `when`(lockPatternUtils.getCurrentFailedPasswordAttempts(anyInt(), eq(Secondary)))
@@ -287,7 +286,6 @@ class KeyguardPinViewControllerTest : SysuiTestCase() {
 
     @Test
     fun testOnViewAttached_secondaryWithAutoPinConfirmationFailedPasswordAttemptsMoreThan5() {
-        `when`(featureFlags.isEnabled(Flags.AUTO_PIN_CONFIRMATION)).thenReturn(true)
         `when`(lockPatternUtils.getPinLength(anyInt(), eq(Secondary))).thenReturn(6)
         `when`(lockPatternUtils.isAutoPinConfirmEnabled(anyInt(), eq(Secondary))).thenReturn(true)
         `when`(lockPatternUtils.getCurrentFailedPasswordAttempts(anyInt(), eq(Secondary)))
@@ -342,7 +340,6 @@ class KeyguardPinViewControllerTest : SysuiTestCase() {
 
     @Test
     fun onUserInput_secondaryAutoConfirmation_attemptsUnlock() {
-        whenever(featureFlags.isEnabled(Flags.AUTO_PIN_CONFIRMATION)).thenReturn(true)
         whenever(lockPatternUtils.getPinLength(anyInt(), eq(Secondary))).thenReturn(6)
         whenever(lockPatternUtils.isAutoPinConfirmEnabled(anyInt(), eq(Secondary))).thenReturn(true)
         whenever(passwordTextView.text).thenReturn("000000")

--- a/packages/SystemUI/multivalentTests/src/com/android/systemui/statusbar/phone/BiometricsUnlockControllerTest.java
+++ b/packages/SystemUI/multivalentTests/src/com/android/systemui/statusbar/phone/BiometricsUnlockControllerTest.java
@@ -202,7 +202,8 @@ public class BiometricsUnlockControllerTest extends SysuiTestCase {
         mBiometricUnlockController.onBiometricAuthenticated(UserHandle.USER_CURRENT,
                 BiometricSourceType.FINGERPRINT, true, Enabled);
 
-        verify(mStatusBarKeyguardViewManager).showPrimaryBouncer(anyBoolean());
+        verify(mStatusBarKeyguardViewManager).showPrimaryBouncer(anyBoolean(),
+                eq("BiometricUnlockController#MODE_SHOW_BOUNCER"));
         verify(mStatusBarKeyguardViewManager, never()).notifyKeyguardAuthenticated(anyBoolean());
         assertThat(mBiometricUnlockController.getMode())
                 .isEqualTo(BiometricUnlockController.MODE_SHOW_BOUNCER);
@@ -227,7 +228,8 @@ public class BiometricsUnlockControllerTest extends SysuiTestCase {
         mBiometricUnlockController.onBiometricAuthenticated(UserHandle.USER_CURRENT,
                 BiometricSourceType.FINGERPRINT, true, Enabled);
 
-        verify(mStatusBarKeyguardViewManager).showPrimaryBouncer(anyBoolean());
+        verify(mStatusBarKeyguardViewManager).showPrimaryBouncer(anyBoolean(),
+                eq("BiometricUnlockController#MODE_SHOW_BOUNCER"));
         verify(mStatusBarKeyguardViewManager, never()).notifyKeyguardAuthenticated(anyBoolean());
         assertThat(mBiometricUnlockController.getMode())
                 .isEqualTo(BiometricUnlockController.MODE_SHOW_BOUNCER);
@@ -394,7 +396,7 @@ public class BiometricsUnlockControllerTest extends SysuiTestCase {
     public void onBiometricAuthenticated_whenFaceAndDreaming_dontDismissKeyguard() {
         when(mUpdateMonitor.isDeviceInteractive()).thenReturn(true);
         when(mUpdateMonitor.isDreaming()).thenReturn(true);
-        when(mUpdateMonitor.isUnlockingWithBiometricAllowed(anyBoolean())).thenReturn(true);
+        when(mUpdateMonitor.isUnlockingWithBiometricAllowedSafe(anyBoolean())).thenReturn(true);
         // the value of isStrongBiometric doesn't matter here since we only care about the returned
         // value of isUnlockingWithBiometricAllowed()
         mBiometricUnlockController.onBiometricAuthenticated(UserHandle.USER_CURRENT,

--- a/packages/SystemUI/multivalentTests/src/com/android/systemui/statusbar/phone/BiometricsUnlockControllerTest.java
+++ b/packages/SystemUI/multivalentTests/src/com/android/systemui/statusbar/phone/BiometricsUnlockControllerTest.java
@@ -412,7 +412,7 @@ public class BiometricsUnlockControllerTest extends SysuiTestCase {
     public void onBiometricAuthenticated_whenFaceOnBouncerAndDreaming_dismissKeyguard() {
         when(mUpdateMonitor.isDeviceInteractive()).thenReturn(true);
         when(mUpdateMonitor.isDreaming()).thenReturn(true);
-        when(mUpdateMonitor.isUnlockingWithBiometricAllowed(anyBoolean())).thenReturn(true);
+        when(mUpdateMonitor.isUnlockingWithBiometricAllowedSafe(anyBoolean())).thenReturn(true);
         when(mStatusBarKeyguardViewManager.primaryBouncerIsOrWillBeShowing()).thenReturn(true);
         // the value of isStrongBiometric doesn't matter here since we only care about the returned
         // value of isUnlockingWithBiometricAllowed()

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardIndicationTextView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardIndicationTextView.java
@@ -86,6 +86,7 @@ public class KeyguardIndicationTextView extends DoubleShadowTextView {
         }
         mMessage = "";
         setText("");
+        clearBackgroundAndIcon();
     }
 
     /**
@@ -256,6 +257,12 @@ public class KeyguardIndicationTextView extends DoubleShadowTextView {
             setCompoundDrawablesRelativeWithIntrinsicBounds(icon, null, null, null);
             forceAssertiveAccessibilityLiveRegion =
                 mKeyguardIndicationInfo.getForceAssertiveAccessibilityLiveRegion();
+        } else {
+            // null mKeyguardIndicationInfo indicates a hideIndication call or INDICATION_TYPE_NONE
+            // being used. When this happens, upstream currently only removes the text via the
+            // setText(mMessage) call below (mMessage will be null whenever mKeyguardIndicationInfo
+            // is null), but they don't remove the background.
+            clearBackgroundAndIcon();
         }
         if (!forceAssertiveAccessibilityLiveRegion) {
             setAccessibilityLiveRegion(ACCESSIBILITY_LIVE_REGION_NONE);
@@ -267,6 +274,15 @@ public class KeyguardIndicationTextView extends DoubleShadowTextView {
         if (mAlwaysAnnounceText) {
             announceForAccessibility(mMessage);
         }
+    }
+
+    private void clearBackgroundAndIcon() {
+        // setNextIndication will set everything again on a new mKeyguardIndicationInfo, so it
+        // should be fine to do this. Note that AOSP doesn't use an icon anywhere yet
+        setBackground(null);
+        setOnClickListener(null);
+        setClickable(false);
+        setCompoundDrawablesRelativeWithIntrinsicBounds(null, null, null, null);
     }
 
     private AnimatorSet getInAnimator() {


### PR DESCRIPTION
Fixes issue of shape appearing at bottom of lock screen for owner and intermittently for secondary users (looks like the end session button without the end session text)

<img src="https://github.com/user-attachments/assets/ce58806d-302e-44c7-a317-ec7dbeaff7c5" width="25%" />

Also contains fixups to get SystemUITests to compile

Closes GrapheneOS/os-issue-tracker#4485
Closes GrapheneOS/os-issue-tracker#885