### PR TITLE
Revert "Add a config to state whether a device supports increased touch sensitivity"

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -4225,9 +4225,6 @@
          sleep. -->
     <bool name="config_supportDoubleTapSleep">false</bool>
 
-    <!-- Whether device supports increased touch sensitvity -->
-    <bool name="config_supportGloveMode">false</bool>
-
     <!-- The RadioAccessFamilies supported by the device.
          Empty is viewed as "all".  Only used on devices which
          don't support RIL_REQUEST_GET_RADIO_CAPABILITY

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -3152,7 +3152,6 @@
   <java-symbol type="layout" name="chooser_row_direct_share" />
   <java-symbol type="bool" name="config_supportDoubleTapWake" />
   <java-symbol type="bool" name="config_supportDoubleTapSleep" />
-  <java-symbol type="bool" name="config_supportGloveMode" />
   <java-symbol type="drawable" name="ic_perm_device_info" />
   <java-symbol type="string" name="config_radio_access_family" />
   <java-symbol type="string" name="notification_inbox_ellipsis" />

--- a/packages/SystemUI/res/values/strings_google.xml
+++ b/packages/SystemUI/res/values/strings_google.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="charge_limit_discovery_notification_enable_button"/>
-    <string name="charge_limit_discovery_notification_help_url"/>
-    <string name="charge_limit_discovery_notification_text"/>
-    <string name="charge_limit_discovery_notification_title"/>
     <string name="keyguard_indication_charging_time_charge_limit"/>
     <string name="keyguard_indication_charging_time_charge_limit_v1"/>
     <string name="keyguard_indication_charging_time_reach_charge_limit"/>


### PR DESCRIPTION
This is handled by a synthetic resource overlay now.
