### PR TITLE
pm/install: wait for dexopt to finish before prepPerformDexoptIfNeede…

### DIFF
--- a/services/core/java/com/android/server/pm/InstallPackageHelper.java
+++ b/services/core/java/com/android/server/pm/InstallPackageHelper.java
@@ -1231,10 +1231,9 @@ final class InstallPackageHelper {
             CompletableFuture<Void> allFutures =
                     CompletableFuture.allOf(
                             completableFutures.toArray(CompletableFuture[]::new));
-            var unused = allFutures.thenRun(() -> mPm.mHandler.post(actionsAfterDexopt));
-        } else {
-            actionsAfterDexopt.run();
+            allFutures.join();
         }
+        actionsAfterDexopt.run();
     }
 
     private boolean renameAndUpdatePaths(List<InstallRequest> requests) {


### PR DESCRIPTION
…d returns

In Android 16, dexopt was made asynchronous. This caused installPackagesTraced() to return before commitInstallPackages() ran. When multiple install sessions of the same APK were started (e.g. by double-tapping install button or running adb install in parallel), the installation steps from different sessions interleaved. This led to various issues (if device was not rebooted after install):
- duplicate intent filters
- duplicated app entry
- system crash on app uninstall

This change blocks in prepPerformDexoptIfNeeded() until dexopt is finished and then runs doPostDexopt (actionsAfterReboot) synchronously. All package installation steps now complete before installPackagesTraced() returns.

Test: Run multiple adb installs of the same app.
- Check adb shell dumpsys package <pkgname>: no duplicates
- Uninstall the app: no system crash

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/5782