### PR TITLE
use shared bitmaps in MediaMetadata to avoid Binder failures

### DIFF
--- a/media/java/android/media/MediaMetadata.java
+++ b/media/java/android/media/MediaMetadata.java
@@ -963,11 +963,15 @@ public final class MediaMetadata implements Parcelable {
             if (mBitmapDimensionLimit != Integer.MAX_VALUE) {
                 for (String key : mBundle.keySet()) {
                     Object value = mBundle.get(key);
-                    if (value instanceof Bitmap) {
-                        Bitmap bmp = (Bitmap) value;
+                    if (value instanceof Bitmap bmp) {
+                        final Bitmap orig = bmp;
                         if (bmp.getHeight() > mBitmapDimensionLimit
                                 || bmp.getWidth() > mBitmapDimensionLimit) {
-                            putBitmap(key, scaleBitmap(bmp, mBitmapDimensionLimit));
+                            bmp = scaleBitmap(bmp, mBitmapDimensionLimit);
+                        }
+                        Bitmap sharedBmp = bmp.asShared();
+                        if (orig != sharedBmp) {
+                            putBitmap(key, sharedBmp);
                         }
                     }
                 }


### PR DESCRIPTION
MediaMetadata objects are transferred over Binder. Serialized heap bitmaps for media artwork are sometimes larger than the max Binder transaction size.

This commit switches MediaMetadata to shared bitmaps in order to avoid Binder transaction failures. Shared bitmaps are very small in serialized form.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/5246