### PR TITLE
fix race condition for GMS flag overrides

### DIFF
--- a/core/java/com/android/internal/gmscompat/flags/PhenotypeFlags.java
+++ b/core/java/com/android/internal/gmscompat/flags/PhenotypeFlags.java
@@ -3,7 +3,6 @@ package com.android.internal.gmscompat.flags;
 import android.app.compat.gms.GmsCompat;
 import android.content.Intent;
 import android.ext.PackageId;
-import android.provider.Settings;
 import android.util.ArrayMap;
 import android.util.Log;
 
@@ -19,13 +18,6 @@ public class PhenotypeFlags {
 
     public static void applyOverrides(GmsCompatConfig config) {
         ArrayMap<String, ArrayMap<String, GmsFlag>> packageFlagMap = config.flags;
-
-        var deleteIntent = new Intent("com.google.android.gms.phenotype.FLAG_OVERRIDE");
-        deleteIntent.setPackage(PackageId.GMS_CORE_NAME);
-        deleteIntent.putExtra("action", "delete");
-        Log.d(TAG, "sending delete overrides broadcast");
-        GmsCompat.appContext().sendBroadcast(deleteIntent);
-
         for (int packageIdx = 0; packageIdx < packageFlagMap.size(); ++packageIdx) {
             Collection<GmsFlag> configFlags = packageFlagMap.valueAt(packageIdx).values();
             var overridenFlags = new ArrayList<GmsFlag>(configFlags.size());


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/5868

The delete flag overrides broadcast appears to have some race condition with the send flag override broadcasts. This seems very evident in the logcat where the log line for `Successfully deleted flag overrides` is almost always printed after the series of `Successfully set flag overrides?` lines:

```bash
$ adb logcat -v tag FlagOverrideChimeraRcv:V *:S
--------- beginning of main
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully deleted flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully set flag overrides? %b
I/FlagOverrideChimeraRcv: (REDACTED) Successfully deleted flag overrides? %b
```

Revert the delete flag overrides commit for now