### PR TITLE
add workaround for upstream async dexopt bug

### DIFF
--- a/services/core/java/com/android/server/pm/InstallPackageHelper.java
+++ b/services/core/java/com/android/server/pm/InstallPackageHelper.java
@@ -186,6 +186,7 @@ import com.android.server.pm.pkg.AndroidPackage;
 import com.android.server.pm.pkg.PackageStateInternal;
 import com.android.server.pm.pkg.SharedLibraryWrapper;
 import com.android.server.rollback.RollbackManagerInternal;
+import com.android.server.utils.Slogf;
 import com.android.server.utils.WatchedArrayMap;
 import com.android.server.utils.WatchedLongSparseArray;
 
@@ -205,6 +206,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -1006,6 +1008,11 @@ final class InstallPackageHelper {
         return false;
     }
 
+    private static final String TAG_BUSY_PACKAGES = "BusyPackages";
+
+    @GuardedBy("mBusyPackages")
+    private final ArraySet<String> mBusyPackages = new ArraySet<>();
+
     /**
      * Installs one or more packages atomically. This operation is broken up into four phases:
      * <ul>
@@ -1032,10 +1039,41 @@ final class InstallPackageHelper {
         final Map<String, Boolean> createdAppId = new ArrayMap<>(requests.size());
         final Map<String, Settings.VersionInfo> versionInfos = new ArrayMap<>(requests.size());
         final long acquireTime = acquireWakeLock(requests.size());
+        boolean shouldRemoveFromBusyPackages = false;
         try {
             CriticalEventLog.getInstance().logInstallPackagesStarted();
-            if (prepareInstallPackages(requests)
-                    && scanInstallPackages(requests, createdAppId, versionInfos)) {
+            boolean shouldProceed = prepareInstallPackages(requests);
+
+            if (shouldProceed) {
+                for (InstallRequest request : requests) {
+                    // getName() returns the package name. It should never be null after
+                    // prepareInstallPackages() returns true.
+                    Objects.requireNonNull(request.getName());
+                }
+                synchronized (mBusyPackages) {
+                    for (InstallRequest request : requests) {
+                        String pkgName = request.getName();
+                        if (mBusyPackages.contains(pkgName)) {
+                            Slogf.d(TAG_BUSY_PACKAGES, "%s is already being installed, calling InstallRequest.setError(INSTALL_FAILED_INTERNAL_ERROR)", pkgName);
+                            request.setError(PackageManager.INSTALL_FAILED_INTERNAL_ERROR, pkgName + " is already being installed");
+                            shouldProceed = false;
+                            break;
+                        }
+                    }
+                    if (shouldProceed) {
+                        for (InstallRequest request : requests) {
+                            String pkgName = request.getName();
+                            Slogf.d(TAG_BUSY_PACKAGES, "adding %s to mBusyPackages", pkgName);
+                            if (!mBusyPackages.add(pkgName)) {
+                                throw new IllegalStateException(pkgName + " is already present in mBusyPackages");
+                            }
+                        }
+                        shouldRemoveFromBusyPackages = true;
+                    }
+                }
+            }
+
+            if (shouldProceed && scanInstallPackages(requests, createdAppId, versionInfos)) {
                 List<ReconciledPackage> reconciledPackages =
                         reconcileInstallPackages(requests, versionInfos);
                 if (reconciledPackages == null) {
@@ -1046,10 +1084,17 @@ final class InstallPackageHelper {
                     // rename before dexopt because art will encoded the path in the odex/vdex file
                     if (Flags.improveInstallFreeze()) {
                         pendingForDexopt = true;
-                        final Runnable actionsAfterDexopt = () ->
+                        final Runnable actionsAfterDexopt = () -> {
+                            try {
                                 doPostDexopt(reconciledPackages, requests,
                                         createdAppId, moveInfo, acquireTime);
+                            } finally {
+                                Slog.d(TAG_BUSY_PACKAGES, "calling removeFromBusyPackages() from actionsAfterDexopt");
+                                removeFromBusyPackages(requests);
+                            }
+                        };
                         prepPerformDexoptIfNeeded(reconciledPackages, actionsAfterDexopt);
+                        shouldRemoveFromBusyPackages = false;
                     } else {
                         if (commitInstallPackages(reconciledPackages)) {
                             success = true;
@@ -1058,11 +1103,30 @@ final class InstallPackageHelper {
                 }
             }
         } finally {
-            if (!pendingForDexopt) {
-                completeInstallProcess(requests, createdAppId, success);
-                Trace.traceEnd(TRACE_TAG_PACKAGE_MANAGER);
-                doPostInstall(requests, moveInfo);
-                releaseWakeLock(acquireTime, requests.size());
+            try {
+                if (!pendingForDexopt) {
+                    completeInstallProcess(requests, createdAppId, success);
+                    Trace.traceEnd(TRACE_TAG_PACKAGE_MANAGER);
+                    doPostInstall(requests, moveInfo);
+                    releaseWakeLock(acquireTime, requests.size());
+                }
+            } finally {
+                if (shouldRemoveFromBusyPackages) {
+                    Slog.d(TAG_BUSY_PACKAGES, "calling removeFromBusyPackages() from installPackagesTraced()");
+                    removeFromBusyPackages(requests);
+                }
+            }
+        }
+    }
+
+    private void removeFromBusyPackages(List<InstallRequest> requests) {
+        synchronized (mBusyPackages) {
+            for (InstallRequest request : requests) {
+                String pkgName = Objects.requireNonNull(request.getName());
+                Slogf.d(TAG_BUSY_PACKAGES, "removing %s from mBusyPackages", pkgName);
+                if (!mBusyPackages.remove(pkgName)) {
+                    throw new IllegalStateException(pkgName + " is missing from mBusyPackages");
+                }
             }
         }
     }


### PR DESCRIPTION
Async dexopt was added in Android 16. It has introduced a bug in handling of concurrent installs of the same package. Such installs started to corrupt the internal PackageManager state of the affected packages, which led to system_server crashes when attempting to uninstall them.

As a workaround, this commit makes the package installer reject install requests for packages that are already being installed (package updates are considered to be installs too).

For more info, see https://github.com/GrapheneOS/platform_frameworks_base/pull/230
Based on https://github.com/GrapheneOS/platform_frameworks_base/pull/234

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/5782