### PR TITLE
fixup! add workaround for upstream async dexopt bug

### DIFF
--- a/services/core/java/com/android/server/pm/InstallPackageHelper.java
+++ b/services/core/java/com/android/server/pm/InstallPackageHelper.java
@@ -1046,13 +1046,13 @@ final class InstallPackageHelper {
 
             if (shouldProceed) {
                 for (InstallRequest request : requests) {
-                    // getName() returns the package name. It should never be null after
-                    // prepareInstallPackages() returns true.
-                    Objects.requireNonNull(request.getName());
+                    // getManifestPackageName() should never be null after prepareInstallPackages()
+                    // returns true.
+                    Objects.requireNonNull(request.getManifestPackageName());
                 }
                 synchronized (mBusyPackages) {
                     for (InstallRequest request : requests) {
-                        String pkgName = request.getName();
+                        String pkgName = request.getManifestPackageName();
                         if (mBusyPackages.contains(pkgName)) {
                             Slogf.d(TAG_BUSY_PACKAGES, "%s is already being installed, calling InstallRequest.setError(INSTALL_FAILED_INTERNAL_ERROR)", pkgName);
                             request.setError(PackageManager.INSTALL_FAILED_INTERNAL_ERROR, pkgName + " is already being installed");
@@ -1062,7 +1062,7 @@ final class InstallPackageHelper {
                     }
                     if (shouldProceed) {
                         for (InstallRequest request : requests) {
-                            String pkgName = request.getName();
+                            String pkgName = request.getManifestPackageName();
                             Slogf.d(TAG_BUSY_PACKAGES, "adding %s to mBusyPackages", pkgName);
                             if (!mBusyPackages.add(pkgName)) {
                                 throw new IllegalStateException(pkgName + " is already present in mBusyPackages");
@@ -1122,7 +1122,7 @@ final class InstallPackageHelper {
     private void removeFromBusyPackages(List<InstallRequest> requests) {
         synchronized (mBusyPackages) {
             for (InstallRequest request : requests) {
-                String pkgName = Objects.requireNonNull(request.getName());
+                String pkgName = Objects.requireNonNull(request.getManifestPackageName());
                 Slogf.d(TAG_BUSY_PACKAGES, "removing %s from mBusyPackages", pkgName);
                 if (!mBusyPackages.remove(pkgName)) {
                     throw new IllegalStateException(pkgName + " is missing from mBusyPackages");
@@ -1646,6 +1646,7 @@ final class InstallPackageHelper {
 
         String pkgName = parsedPackage.getPackageName();
         request.setName(pkgName);
+        request.setManifestPackageName(parsedPackage.getManifestPackageName());
         if (parsedPackage.isTestOnly()) {
             if ((installFlags & PackageManager.INSTALL_ALLOW_TEST) == 0) {
                 throw new PrepareFailure(INSTALL_FAILED_TEST_ONLY,

--- a/services/core/java/com/android/server/pm/InstallRequest.java
+++ b/services/core/java/com/android/server/pm/InstallRequest.java
@@ -819,6 +819,16 @@ final class InstallRequest {
         mName = packageName;
     }
 
+    private String mManifestPackageName;
+
+    void setManifestPackageName(String name) {
+        mManifestPackageName = name;
+    }
+
+    String getManifestPackageName() {
+        return mManifestPackageName;
+    }
+
     public void setOriginUsers(int[] userIds) {
         mOrigUsers = userIds;
     }


### PR DESCRIPTION
Add missing handling for packages that are renamed by the original-package system.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/5926