### PR TITLE
disable the notification cooldown feature

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5822,6 +5822,7 @@ public final class Settings {
          * @hide
          */
         @Readable
+        @Protected(immutableValue = "0")
         public static final String NOTIFICATION_COOLDOWN_ENABLED =
             "notification_cooldown_enabled";
 


### PR DESCRIPTION
Notification cooldown feature breaks the full-screen incoming call notification, see https://github.com/GrapheneOS/os-issue-tracker/issues/5854

Depends on https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/369

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/5854