### PR TITLE
[temporary] make AOSP dialer call notifications not groupable

### DIFF
--- a/services/core/java/com/android/server/notification/GroupHelper.java
+++ b/services/core/java/com/android/server/notification/GroupHelper.java
@@ -2024,6 +2024,13 @@ public class GroupHelper {
                 return false;
             }
 
+            // temporary until Dialer gets CallStyle set
+            if ("com.android.dialer".equals(record.getSbn().getPackageName())
+                    && Notification.CATEGORY_CALL.equals(
+                            record.getSbn().getNotification().category)) {
+                return false;
+            }
+
             if (record.getSbn().getNotification().isMediaNotification()) {
                 return false;
             }


### PR DESCRIPTION
Temporary until Dialer gets CallStyle set for calling notifications. If the Dialer has two or more ungrouped notifications, autogrouping will occur. It just so happens that legacy voicemail notification is also ungrouped.

Autogrouping call notifications will result in `Notification.FLAG_SILENT` being added to incoming call notifications, and that will prevent the fullScreenIntent from showing.