### PR TITLE
add the single missing patch from August ASB (CVE-2025-48533)

### DIFF
--- a/core/java/android/window/flags/windowing_frontend.aconfig
+++ b/core/java/android/window/flags/windowing_frontend.aconfig
@@ -448,17 +448,6 @@ flag {
 }
 
 flag {
-    name: "keep_app_window_hide_while_locked"
-    namespace: "windowing_frontend"
-    description: "Do not let app window visible while device is locked"
-    is_fixed_read_only: true
-    bug: "378088391"
-    metadata {
-        purpose: PURPOSE_BUGFIX
-    }
-}
-
-flag {
     name: "use_rt_frame_callback_for_splash_screen_transfer"
     namespace: "windowing_frontend"
     description: "report SplashscreenView shown after RtFrame commit"

--- a/services/core/java/com/android/server/wm/ActivityRecord.java
+++ b/services/core/java/com/android/server/wm/ActivityRecord.java
@@ -2708,7 +2708,8 @@ final class ActivityRecord extends WindowToken {
      * This prevents briefly appearing the app context and causing secure concern.
      */
     void deferStartingWindowRemovalForKeyguardUnoccluding() {
-        if (mStartingData.mRemoveAfterTransaction != AFTER_TRANSITION_FINISH
+        if (mStartingData != null
+                && mStartingData.mRemoveAfterTransaction != AFTER_TRANSITION_FINISH
                 && isKeyguardLocked() && !canShowWhenLockedInner(this) && !isVisibleRequested()
                 && mTransitionController.inTransition(this)) {
             mStartingData.mRemoveAfterTransaction = AFTER_TRANSITION_FINISH;

--- a/services/core/java/com/android/server/wm/WindowState.java
+++ b/services/core/java/com/android/server/wm/WindowState.java
@@ -2774,7 +2774,7 @@ class WindowState extends WindowContainer<WindowState> implements WindowManagerP
             final boolean wasShowWhenLocked = (sa.flags & FLAG_SHOW_WHEN_LOCKED) != 0;
             final boolean removeShowWhenLocked = (mAttrs.flags & FLAG_SHOW_WHEN_LOCKED) == 0;
             sa.flags = (sa.flags & ~mask) | (mAttrs.flags & mask);
-            if (Flags.keepAppWindowHideWhileLocked() && wasShowWhenLocked && removeShowWhenLocked) {
+            if (wasShowWhenLocked && removeShowWhenLocked) {
                 // Trigger unoccluding animation if needed.
                 mActivityRecord.checkKeyguardFlagsChanged();
                 mActivityRecord.deferStartingWindowRemovalForKeyguardUnoccluding();


### PR DESCRIPTION
There's just 2 Android 16 CVEs in August ASB: CVE-2025-48533 and CVE-2025-48530.

The fix for CVE-2025-48530 is already included in android-16.0.0_r1, i.e. it was present since the very first Android 16 release.