### PR TITLE
Enable 5G SA

### DIFF
--- a/telephony/java/android/telephony/CarrierConfigManager.java
+++ b/telephony/java/android/telephony/CarrierConfigManager.java
@@ -136,7 +136,7 @@ public class CarrierConfigManager {
      * Indicates CARRIER_NR_AVAILABILITY_NSA determine that the carrier enable the non-standalone
      * (NSA) mode of 5G NR.
      */
-    public static final int CARRIER_NR_AVAILABILITY_NSA = 1;
+    public static final int CARRIER_NR_AVAILABILITY_NSA = 2;
 
     /**
      * Indicates CARRIER_NR_AVAILABILITY_SA determine that the carrier enable the standalone (SA)


### PR DESCRIPTION
Only a single incorrectly placed digit in the carrier configuration under “carrier_nr_availability_int_array” prevents 5G SA in O2 / Movistar (maybe on more operators).

Tested in Spain and Germany with 02,

CARRIER_NR_AVAILABILITY_NSA = 2

fixes this.