### PR TITLE
bluejay battery replacement notification

### DIFF
--- a/packages/SettingsLib/src/com/android/settingslib/fuelgauge/BatteryStatus.java
+++ b/packages/SettingsLib/src/com/android/settingslib/fuelgauge/BatteryStatus.java
@@ -59,6 +59,8 @@ public class BatteryStatus {
     public final int maxChargingWattage;
     public final boolean present;
     public final Optional<Boolean> incompatibleCharger;
+    /** Added in July update, might conflict */
+    public final int health;
 
     public static BatteryStatus create(Context context, boolean incompatibleCharger) {
         final Intent batteryChangedIntent = BatteryUtils.getBatteryIntent(context);
@@ -75,6 +77,7 @@ public class BatteryStatus {
         this.maxChargingWattage = maxChargingWattage;
         this.present = present;
         this.incompatibleCharger = Optional.empty();
+        this.health = BatteryManager.BATTERY_HEALTH_UNKNOWN;
     }
 
 
@@ -90,6 +93,8 @@ public class BatteryStatus {
         status = batteryChangedIntent.getIntExtra(EXTRA_STATUS, BATTERY_STATUS_UNKNOWN);
         plugged = batteryChangedIntent.getIntExtra(EXTRA_PLUGGED, 0);
         level = getBatteryLevel(batteryChangedIntent);
+        health = batteryChangedIntent.getIntExtra(
+                BatteryManager.EXTRA_HEALTH, BatteryManager.BATTERY_HEALTH_UNKNOWN);
         chargingStatus = batteryChangedIntent.getIntExtra(EXTRA_CHARGING_STATUS,
                 CHARGING_POLICY_DEFAULT);
         present = batteryChangedIntent.getBooleanExtra(EXTRA_PRESENT, true);

--- a/packages/SystemUI/res/drawable/ic_battery_alert_fill.xml
+++ b/packages/SystemUI/res/drawable/ic_battery_alert_fill.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:tint="?attr/colorControlNormal"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M440,560L520,560L520,320L440,320L440,560ZM480,720Q497,720 508.5,708.5Q520,697 520,680Q520,663 508.5,651.5Q497,640 480,640Q463,640 451.5,651.5Q440,663 440,680Q440,697 451.5,708.5Q463,720 480,720ZM320,880Q303,880 291.5,868.5Q280,857 280,840L280,200Q280,183 291.5,171.5Q303,160 320,160L400,160L400,80L560,80L560,160L640,160Q657,160 668.5,171.5Q680,183 680,200L680,840Q680,857 668.5,868.5Q657,880 640,880L320,880Z"/>
+</vector>

--- a/packages/SystemUI/res/values/strings_google.xml
+++ b/packages/SystemUI/res/values/strings_google.xml
@@ -3,4 +3,10 @@
     <string name="keyguard_indication_charging_time_charge_limit"/>
     <string name="keyguard_indication_charging_time_charge_limit_v1"/>
     <string name="keyguard_indication_charging_time_reach_charge_limit"/>
+    <string name="battery_management_action"/>
+    <string name="battery_replacement_early_notify_des"/>
+    <string name="battery_replacement_notify_des"/>
+    <string name="battery_replacement_notify_help_url"/>
+    <string name="battery_replacement_notify_title"/>
+    <string name="battery_health_notify_learn_more"/>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/power/PowerNotificationWarnings.java
+++ b/packages/SystemUI/src/com/android/systemui/power/PowerNotificationWarnings.java
@@ -186,7 +186,6 @@ public class PowerNotificationWarnings implements PowerUI.WarningsUI {
 
     /**
      */
-    @Inject
     public PowerNotificationWarnings(
             Context context,
             ActivityStarter activityStarter,

--- a/packages/SystemUI/src/com/android/systemui/power/dagger/PowerModule.java
+++ b/packages/SystemUI/src/com/android/systemui/power/dagger/PowerModule.java
@@ -16,16 +16,34 @@
 
 package com.android.systemui.power.dagger;
 
+import android.content.Context;
+import android.ext.power.BatteryChargeLimit;
+import android.os.Handler;
+
+import com.android.internal.logging.UiEventLogger;
 import com.android.systemui.CoreStartable;
+import com.android.systemui.animation.DialogTransitionAnimator;
+import com.android.systemui.broadcast.BroadcastDispatcher;
+import com.android.systemui.broadcast.BroadcastSender;
+import com.android.systemui.dagger.SysUISingleton;
+import com.android.systemui.dagger.qualifiers.Main;
+import com.android.systemui.plugins.ActivityStarter;
 import com.android.systemui.power.EnhancedEstimates;
 import com.android.systemui.power.EnhancedEstimatesImpl;
 import com.android.systemui.power.PowerNotificationWarnings;
 import com.android.systemui.power.PowerUI;
 import com.android.systemui.power.data.repository.PowerRepositoryModule;
+import com.android.systemui.settings.UserTracker;
+import com.android.systemui.statusbar.phone.SystemUIDialog;
+import com.android.systemui.statusbar.policy.BatteryController;
 import com.android.systemui.statusbar.policy.ConfigurationController;
 
+import com.google.android.systemui.power.PowerNotificationWarningsGoogleImpl;
+
 import dagger.Binds;
+import dagger.Lazy;
 import dagger.Module;
+import dagger.Provides;
 import dagger.multibindings.ClassKey;
 import dagger.multibindings.IntoMap;
 import dagger.multibindings.IntoSet;
@@ -55,4 +73,48 @@ public interface PowerModule {
     /** */
     @Binds
     PowerUI.WarningsUI provideWarningsUi(PowerNotificationWarnings controllerImpl);
+
+    @Provides
+    @SysUISingleton
+    static PowerNotificationWarnings providePowerNotificationWarnings(
+            Context context,
+            ActivityStarter activityStarter,
+            BroadcastSender broadcastSender,
+            Lazy<BatteryController> batteryControllerLazy,
+            DialogTransitionAnimator dialogTransitionAnimator,
+            UiEventLogger uiEventLogger,
+            UserTracker userTracker,
+            SystemUIDialog.Factory systemUIDialogFactory,
+            BroadcastDispatcher broadcastDispatcher,
+            @Main Handler mainHandler) {
+        PowerNotificationWarnings pNW;
+        // maybe can refactor this check into more generic class instead of "BatteryChargeLimit",
+        // but doesn't matter
+        if (BatteryChargeLimit.isGoogleDevice()) {
+            pNW = new PowerNotificationWarningsGoogleImpl(
+                    context,
+                    activityStarter,
+                    broadcastSender,
+                    batteryControllerLazy,
+                    dialogTransitionAnimator,
+                    uiEventLogger,
+                    userTracker,
+                    systemUIDialogFactory,
+                    broadcastDispatcher,
+                    mainHandler
+            );
+        } else {
+            pNW = new PowerNotificationWarnings(
+                    context,
+                    activityStarter,
+                    broadcastSender,
+                    batteryControllerLazy,
+                    dialogTransitionAnimator,
+                    uiEventLogger,
+                    userTracker,
+                    systemUIDialogFactory
+            );
+        }
+        return pNW;
+    }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
@@ -1162,6 +1162,11 @@ public class KeyguardIndicationController {
         if (mPowerCharged) {
             return mContext.getResources().getString(R.string.keyguard_charged);
         }
+        String percentage = NumberFormat.getPercentInstance().format(mBatteryLevel / 100f);
+        if (mBatteryDead) {
+            return mContext.getResources().getString(R.string.keyguard_plugged_in, percentage);
+        }
+
         final boolean hasChargingTime = mChargingTimeRemaining > 0;
         int chargingId;
         if (mPowerPluggedInWired) {
@@ -1196,7 +1201,6 @@ public class KeyguardIndicationController {
                     : R.string.keyguard_plugged_in;
         }
 
-        String percentage = NumberFormat.getPercentInstance().format(mBatteryLevel / 100f);
         if (hasChargingTime) {
             String chargingTimeFormatted = Formatter.formatShortElapsedTimeRoundingUpToMinutes(
                     mContext, mChargingTimeRemaining);
@@ -1356,6 +1360,9 @@ public class KeyguardIndicationController {
             mBatteryLevel = status.level;
             mBatteryPresent = status.present;
             mBatteryDefender = isBatteryDefender(status);
+            // stock OS uses batteryStatus.health != 4 as the condition for some reason, which seems
+            // wrong (4 corresponds to BatteryManager.BATTERY_HEALTH_DEAD)
+            mBatteryDead = status.health == BatteryManager.BATTERY_HEALTH_DEAD;
             // when the battery is overheated, device doesn't charge so only guard on pluggedIn:
             mEnableBatteryDefender = mBatteryDefender && status.isPluggedIn();
             mIncompatibleCharger = status.incompatibleCharger.orElse(false);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
@@ -226,6 +226,8 @@ public class KeyguardIndicationController {
     private int mBatteryLevel = -1;
     private boolean mBatteryPresent = true;
     protected long mChargingTimeRemaining;
+    /** Added in July 2025 patch, might conflict when tags get pushed */
+    protected boolean mBatteryDead;
     private Pair<String, BiometricSourceType> mBiometricErrorMessageToShowOnScreenOn;
     private Set<Integer> mCoExFaceAcquisitionMsgIdsToShow;
     private final FaceHelpMessageDeferral mFaceAcquiredMessageDeferral;

--- a/packages/SystemUI/src/com/google/android/systemui/power/BatteryReplacementNotification.java
+++ b/packages/SystemUI/src/com/google/android/systemui/power/BatteryReplacementNotification.java
@@ -1,0 +1,175 @@
+package com.google.android.systemui.power;
+
+import static android.content.Context.MODE_PRIVATE;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.BatteryManager;
+import android.os.Bundle;
+import android.os.UserHandle;
+import android.text.Html;
+import android.util.Log;
+
+import com.android.settingslib.Utils;
+import com.android.systemui.res.R;
+import com.android.systemui.util.NotificationChannels;
+
+import androidx.core.app.NotificationCompat;
+
+import java.time.Clock;
+import java.time.Duration;
+
+/**
+ * Based on SystemUIGoogle
+ */
+public final class BatteryReplacementNotification {
+    private static final String TAG = "BatteryReplacementNotification";
+    private static final int BLUEJAY_CYCLE_COUNT_EARLY_RECOMMENDATION_THRESHOLD = 375;
+    private static final int MAX_EARLY_RECOMMENDATION_TRIGGER_NOTIFICATIONS = 1;
+    private static final int MAX_RECOMMENDATION_NOTIFICATIONS = 3;
+    private static final long RECOMMENDATION_INTERVAL_MS = Duration.ofDays(14).toMillis();
+
+    /**
+     * An undocumented constant value for {@link BatteryManager#EXTRA_HEALTH}.
+     * It's defined in
+     * frameworks/native/services/batteryservice/include/batteryservice/BatteryServiceConstants.h
+     * but not exposed in frameworks {@link android.os.BatteryManager}
+     */
+    private static final int BATTERY_HEALTH_FAIR = 8;
+
+    private static final String NOTIFICATION_TAG = "battery_replacement";
+    public static final String PREF_EARLY_RECOMMENDATION_TRIGGER_TIMES_KEY =
+            "early_recommendation_trigger_times";
+    public static final String PREF_RECOMMENDATION_TRIGGER_TIMES_KEY =
+            "recommendation_trigger_times";
+    public static final String PREF_LAST_RECOMMENDATION_TIMESTAMP_MS_KEY =
+            "last_recommendation_timestamp_ms";
+    public static final String BATTERY_REPLACEMENT_SHARED_PREFS_NAME =
+            "battery_replacement_shared_prefs";
+    private final Clock mClock;
+    private final Context mContext;
+    private SharedPreferences mSharedPreferences;
+    private long mLastRecommendationTimestampMs = -1;
+    private int mRecommendationTriggerTimes = -1;
+    private int mEarlyRecommendationTriggerTimes = -1;
+
+    public BatteryReplacementNotification(Context context, Clock clock) {
+        this.mContext = context;
+        this.mClock = clock;
+    }
+
+    private SharedPreferences getSharedPreferences() {
+        if (this.mSharedPreferences == null) {
+            this.mSharedPreferences = this.mContext.getApplicationContext()
+                    .getSharedPreferences(BATTERY_REPLACEMENT_SHARED_PREFS_NAME, MODE_PRIVATE);
+        }
+        return this.mSharedPreferences;
+    }
+
+    private PendingIntent createBatterySettingsPendingIntentAsUser() {
+        return PendingIntent.getActivityAsUser(
+                mContext, 0, new Intent(Intent.ACTION_POWER_USAGE_SUMMARY),
+                PendingIntent.FLAG_IMMUTABLE, null, UserHandle.CURRENT);
+    }
+
+    private PendingIntent createHelpArticlePendingIntentAsUser(int urlResId) {
+        return PendingIntent.getActivityAsUser(mContext, 0,
+                new Intent(Intent.ACTION_VIEW, Uri.parse(mContext.getString(urlResId))),
+                PendingIntent.FLAG_IMMUTABLE, null, UserHandle.CURRENT);
+    }
+
+    private void overrideNotificationAppName(NotificationCompat.Builder builder) {
+        Bundle bundle = new Bundle(1);
+        // Replace "System UI" app name with "Android System"
+        bundle.putString(Notification.EXTRA_SUBSTITUTE_APP_NAME,
+                mContext.getString(com.android.internal.R.string.android_system_label));
+        builder.addExtras(bundle);
+    }
+    
+    public void onBatteryInfoChanged(int batteryHealth, int cycleCount) {
+        // Log.w(TAG, "batteryHealth " + batteryHealth + ", cycleCount " + cycleCount);
+        if (batteryHealth == BatteryManager.BATTERY_HEALTH_DEAD) {
+            if (mRecommendationTriggerTimes == -1 || mLastRecommendationTimestampMs == -1) {
+                SharedPreferences sharedPreferences = getSharedPreferences();
+                mRecommendationTriggerTimes = sharedPreferences.getInt(
+                        PREF_RECOMMENDATION_TRIGGER_TIMES_KEY, 0);
+                mLastRecommendationTimestampMs = sharedPreferences.getLong(
+                        PREF_LAST_RECOMMENDATION_TIMESTAMP_MS_KEY, 0L);
+            }
+            long millis = mClock.millis();
+            if (mRecommendationTriggerTimes < MAX_RECOMMENDATION_NOTIFICATIONS &&
+                    millis - mLastRecommendationTimestampMs > RECOMMENDATION_INTERVAL_MS) {
+                Log.w(TAG, "recommendation, count: " + mRecommendationTriggerTimes
+                        + ", last: " + mLastRecommendationTimestampMs);
+                sendNotification(mContext.getString(R.string.battery_replacement_notify_title),
+                        Html.fromHtml(
+                                mContext.getString(R.string.battery_replacement_notify_des), 0),
+                        false);
+
+                mRecommendationTriggerTimes = mRecommendationTriggerTimes + 1;
+                mLastRecommendationTimestampMs = millis;
+                getSharedPreferences()
+                        .edit()
+                        .putInt(PREF_RECOMMENDATION_TRIGGER_TIMES_KEY,
+                                mRecommendationTriggerTimes)
+                        .putLong(PREF_LAST_RECOMMENDATION_TIMESTAMP_MS_KEY,
+                                mLastRecommendationTimestampMs)
+                        .apply();
+            }
+        } else if (batteryHealth == BATTERY_HEALTH_FAIR &&
+                cycleCount >= BLUEJAY_CYCLE_COUNT_EARLY_RECOMMENDATION_THRESHOLD) {
+            if (mEarlyRecommendationTriggerTimes == -1) {
+                mEarlyRecommendationTriggerTimes = getSharedPreferences()
+                        .getInt(PREF_EARLY_RECOMMENDATION_TRIGGER_TIMES_KEY, 0);
+            }
+            if (mEarlyRecommendationTriggerTimes < MAX_EARLY_RECOMMENDATION_TRIGGER_NOTIFICATIONS) {
+                Log.w(TAG, "early recommendation, count: " + mEarlyRecommendationTriggerTimes);
+                sendNotification(
+                        mContext.getString(R.string.battery_replacement_notify_title),
+                        Html.fromHtml(
+                                mContext.getString(R.string.battery_replacement_early_notify_des),
+                                0),
+                        true);
+
+                mEarlyRecommendationTriggerTimes = mEarlyRecommendationTriggerTimes + 1;
+                getSharedPreferences()
+                        .edit()
+                        .putInt(
+                                PREF_EARLY_RECOMMENDATION_TRIGGER_TIMES_KEY,
+                                mEarlyRecommendationTriggerTimes
+                        ).apply();
+            }
+        }
+    }
+
+    private void sendNotification(String title, CharSequence contentText,
+            boolean addBatteryManagementAction) {
+        NotificationManager notificationManager = mContext.getSystemService(NotificationManager.class);
+        var builder = new NotificationCompat.Builder(mContext, NotificationChannels.BATTERY);
+        builder.setSmallIcon(R.drawable.ic_battery_alert_fill);
+        builder.setColor(Utils.getColorAttrDefaultColor(mContext, android.R.attr.colorError));
+        builder.setContentTitle(title);
+        builder.setContentText(contentText);
+        builder.setContentIntent(createBatterySettingsPendingIntentAsUser());
+        builder.setStyle(new NotificationCompat.BigTextStyle().bigText(contentText));
+        builder.setSilent(true);
+        builder.addAction(
+                0,
+                mContext.getString(R.string.battery_health_notify_learn_more),
+                createHelpArticlePendingIntentAsUser(R.string.battery_replacement_notify_help_url));
+        if (addBatteryManagementAction) {
+            builder.addAction(
+                    0,
+                    mContext.getString(R.string.battery_management_action),
+                    createBatterySettingsPendingIntentAsUser());
+        }
+        overrideNotificationAppName(builder);
+        notificationManager.notifyAsUser(NOTIFICATION_TAG,
+                R.string.battery_replacement_notify_title, builder.build(), UserHandle.CURRENT);
+    }
+}

--- a/packages/SystemUI/src/com/google/android/systemui/power/PowerNotificationWarningsGoogleImpl.java
+++ b/packages/SystemUI/src/com/google/android/systemui/power/PowerNotificationWarningsGoogleImpl.java
@@ -1,0 +1,73 @@
+package com.google.android.systemui.power;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Handler;
+import android.os.HandlerExecutor;
+import android.os.UserHandle;
+import android.util.Log;
+
+import com.android.internal.logging.UiEventLogger;
+import com.android.systemui.animation.DialogTransitionAnimator;
+import com.android.systemui.broadcast.BroadcastDispatcher;
+import com.android.systemui.broadcast.BroadcastSender;
+import com.android.systemui.plugins.ActivityStarter;
+import com.android.systemui.power.PowerNotificationWarnings;
+import com.android.systemui.settings.UserTracker;
+import com.android.systemui.statusbar.phone.SystemUIDialog;
+import com.android.systemui.statusbar.policy.BatteryController;
+
+import dagger.Lazy;
+
+public class PowerNotificationWarningsGoogleImpl extends PowerNotificationWarnings {
+    private static final String TAG = "PNWGoogleImpl";
+
+    private final Context mContext;
+
+    private final BroadcastDispatcher mBroadcastDispatcher;
+
+    private final Handler mMainHandler;
+
+    private final Receiver mReceiver;
+
+    public PowerNotificationWarningsGoogleImpl(Context context,
+            ActivityStarter activityStarter,
+            BroadcastSender broadcastSender,
+            Lazy<BatteryController> batteryControllerLazy,
+            DialogTransitionAnimator dialogTransitionAnimator,
+            UiEventLogger uiEventLogger,
+            UserTracker userTracker,
+            SystemUIDialog.Factory systemUIDialogFactory,
+            BroadcastDispatcher broadcastDispatcher,
+            Handler mainHandler) {
+        super(context, activityStarter, broadcastSender, batteryControllerLazy,
+                dialogTransitionAnimator, uiEventLogger, userTracker, systemUIDialogFactory);
+        mContext = context;
+        mBroadcastDispatcher = broadcastDispatcher;
+        mMainHandler = mainHandler;
+        mReceiver = new Receiver();
+        mainHandler.post(() -> {
+            mReceiver.init();
+        });
+    }
+
+    private final class Receiver extends BroadcastReceiver {
+
+        public void init() {
+            final var intentFilter = new IntentFilter();
+            mBroadcastDispatcher.registerReceiver(
+                    this, intentFilter, new HandlerExecutor(mMainHandler),
+                    UserHandle.ALL, Context.RECEIVER_EXPORTED);
+        }
+
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (intent == null) return;
+            final String action = intent.getAction();
+            if (action == null) return;
+            Log.d(TAG, "onReceive: " + action);
+        }
+    }
+}

--- a/packages/SystemUI/src/com/google/android/systemui/power/PowerNotificationWarningsGoogleImpl.java
+++ b/packages/SystemUI/src/com/google/android/systemui/power/PowerNotificationWarningsGoogleImpl.java
@@ -4,10 +4,14 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.BatteryManager;
+import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerExecutor;
 import android.os.UserHandle;
 import android.util.Log;
+
+import androidx.annotation.Nullable;
 
 import com.android.internal.logging.UiEventLogger;
 import com.android.systemui.animation.DialogTransitionAnimator;
@@ -21,8 +25,10 @@ import com.android.systemui.statusbar.policy.BatteryController;
 
 import dagger.Lazy;
 
+import java.time.Clock;
+
 public class PowerNotificationWarningsGoogleImpl extends PowerNotificationWarnings {
-    private static final String TAG = "PNWGoogleImpl";
+    private static final String TAG = "PowerNotifWrnGoogleImpl";
 
     private final Context mContext;
 
@@ -31,6 +37,9 @@ public class PowerNotificationWarningsGoogleImpl extends PowerNotificationWarnin
     private final Handler mMainHandler;
 
     private final Receiver mReceiver;
+
+    @Nullable
+    private BatteryReplacementNotification mBatteryReplacementNotification = null;
 
     public PowerNotificationWarningsGoogleImpl(Context context,
             ActivityStarter activityStarter,
@@ -49,17 +58,35 @@ public class PowerNotificationWarningsGoogleImpl extends PowerNotificationWarnin
         mMainHandler = mainHandler;
         mReceiver = new Receiver();
         mainHandler.post(() -> {
-            mReceiver.init();
+            if ("bluejay".equals(Build.DEVICE)) {
+                Log.d(TAG, "enabling mBatteryReplacementNotification");
+                mBatteryReplacementNotification = new BatteryReplacementNotification(mContext,
+                        Clock.systemUTC());
+                // TODO: If we end up porting more things from PowerNotificationWarningsGoogleImpl
+                //  that are not device-specific, then take this init outside of this bluejay path.
+                //  Currently, this is the only thing we're taking from stock OS, so it's fine to
+                //  only init if on bluejay
+                mReceiver.init();
+            }
         });
     }
 
     private final class Receiver extends BroadcastReceiver {
-
         public void init() {
+            Log.d(TAG, "init mReceiver");
             final var intentFilter = new IntentFilter();
+            intentFilter.addAction(Intent.ACTION_BATTERY_CHANGED);
+
+            // registerReceiverWithHandler is deprecated
             mBroadcastDispatcher.registerReceiver(
                     this, intentFilter, new HandlerExecutor(mMainHandler),
                     UserHandle.ALL, Context.RECEIVER_EXPORTED);
+            // stock OS does this presumably to set the state ASAP
+            var stickyIntent = mContext.registerReceiver(null,
+                    new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+            if (stickyIntent != null) {
+                onReceive(mContext, stickyIntent);
+            }
         }
 
         @Override
@@ -68,6 +95,16 @@ public class PowerNotificationWarningsGoogleImpl extends PowerNotificationWarnin
             final String action = intent.getAction();
             if (action == null) return;
             Log.d(TAG, "onReceive: " + action);
+
+            // dropped the additional AND condition from stock OS:
+            //      && mSecureSettings.getInt(0, "barrel_forcibly_disabled") == 0
+            if (mBatteryReplacementNotification != null) {
+                if (Intent.ACTION_BATTERY_CHANGED.equals(action)) {
+                    int batteryHealth = intent.getIntExtra(BatteryManager.EXTRA_HEALTH, 1);
+                    int cycleCount = intent.getIntExtra(BatteryManager.EXTRA_CYCLE_COUNT, -1);
+                    mBatteryReplacementNotification.onBatteryInfoChanged(batteryHealth, cycleCount);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Review with:
- https://github.com/GrapheneOS/adevtool/pull/253
- https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/376

Shows battery replacement notification for bluejay if the kernel code detects that the device has an affected battery. This doesn't add a setting to opt out; it just reflects the battery health state reported by the kernel.

This is based on the stock OS logic. An early warning is shown if the battery health is reported as "fair" and charge cycles is >= 375. If the battery health is reported as "dead", it will tell the user that the battery capacity and charging performance are reduced.

Almost all of this code in the stock OS are in Google-specific classes, so we don't expect much of this to show up in 16QPR1 AOSP code.

<img src="https://github.com/user-attachments/assets/0c85388c-56c3-4c32-a5c2-f52ba161d6b2" width=50%/>