### PR TITLE
Possibly fix NPE

### DIFF
--- a/telecomm/java/android/telecom/CallerInfo.java
+++ b/telecomm/java/android/telecom/CallerInfo.java
@@ -697,12 +697,13 @@ public class CallerInfo {
                     + Log.pii(number) + "'");
         }
 
-        if (pn != null) {
+        if (pn == null || locale == null) {
+            Log.w(TAG, "pn and/or locale was null in getGeoDescription");
+            return null;
+        } else {
             String description = geocoder.getDescriptionForNumber(pn, locale);
             if (VDBG) Log.v(TAG, "- got description: '" + description + "'");
             return description;
-        } else {
-            return null;
         }
     }
 


### PR DESCRIPTION
This relates to https://github.com/GrapheneOS/os-issue-tracker/issues/6233. I'm not sure why locale would be null, but the stacktrace is as follows:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.util.Locale.getLanguage()' on a null object reference
	at com.android.i18n.phonenumbers.geocoding.PhoneNumberOfflineGeocoder.getDescriptionForValidNumber(PhoneNumberOfflineGeocoder.java:116)
	at com.android.i18n.phonenumbers.geocoding.PhoneNumberOfflineGeocoder.getDescriptionForNumber(PhoneNumberOfflineGeocoder.java:199)
	at android.telecom.CallerInfo.getGeoDescription(CallerInfo.java:701)
	at android.telecom.CallerInfoAsyncQuery$CallerInfoAsyncQueryHandler$CallerInfoWorkerHandler.handleGeoDescription(CallerInfoAsyncQuery.java:235)
	at android.telecom.CallerInfoAsyncQuery$CallerInfoAsyncQueryHandler$CallerInfoWorkerHandler.handleMessage(CallerInfoAsyncQuery.java:223)
	at android.os.Handler.dispatchMessage(Handler.java:110)
	at android.os.Looper.loopOnce(Looper.java:248)
	at android.os.Looper.loop(Looper.java:338)
	at android.os.HandlerThread.run(HandlerThread.java:85)
```
This seems to be where getDescriptionForNumber was called and given a null object reference. The solution may need to be in getDescriptionForNumber, but that function [does not exist in the GrapheneOS repositories](https://github.com/search?q=org%3AGrapheneOS%20getDescriptionForNumber&type=code) and I assume is from a dependency.