### PR TITLE
add back support for enabling location access indicators

### DIFF
--- a/core/java/android/permission/PermissionUsageHelper.java
+++ b/core/java/android/permission/PermissionUsageHelper.java
@@ -116,6 +116,11 @@ public class PermissionUsageHelper implements AppOpsManager.OnOpActiveChangedLis
                 RUNNING_ACCESS_TIME_MS, DEFAULT_RUNNING_TIME_MS);
     }
 
+    private static final List<String> LOCATION_OPS = List.of(
+            OPSTR_COARSE_LOCATION,
+            OPSTR_FINE_LOCATION
+    );
+
     private static final List<String> MIC_OPS = List.of(
             OPSTR_PHONE_CALL_MICROPHONE,
             OPSTR_RECEIVE_AMBIENT_TRIGGER_AUDIO,
@@ -284,6 +289,9 @@ public class PermissionUsageHelper implements AppOpsManager.OnOpActiveChangedLis
         }
 
         List<String> ops = new ArrayList<>(CAMERA_OPS);
+        if (android.location.flags.Flags.locationIndicatorsEnabled()) {
+            ops.addAll(LOCATION_OPS);
+        }
         if (includeMicrophoneUsage) {
             ops.addAll(MIC_OPS);
         }

--- a/packages/SystemUI/src/com/android/systemui/privacy/PrivacyItemController.kt
+++ b/packages/SystemUI/src/com/android/systemui/privacy/PrivacyItemController.kt
@@ -63,7 +63,7 @@ class PrivacyItemController @Inject constructor(
     val micCameraAvailable
         get() = privacyConfig.micCameraAvailable
     val locationAvailable
-        get() = true
+        get() = privacyConfig.locationAvailable
     val allIndicatorsAvailable
         get() = micCameraAvailable && locationAvailable && privacyConfig.mediaProjectionAvailable
 


### PR DESCRIPTION
It was removed, seemingly accidentally, by 275480f4940f44dc7c4fc809c83395314295381f