### PR TITLE
disable notification summaries and organizer

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -7671,7 +7671,10 @@
 
     <!-- Array containing the notification assistant service adjustments that are not supported by
      default on this device-->
-    <string-array translatable="false" name="config_notificationDefaultUnsupportedAdjustments" />
+    <string-array translatable="false" name="config_notificationDefaultUnsupportedAdjustments">
+        <item>key_summarization</item>
+        <item>key_type</item>
+    </string-array>
 
     <!-- Preference name of bugreport-->
     <string name="prefs_bugreport" translatable="false">bugreports</string>

--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -13821,7 +13821,11 @@ public class NotificationManagerService extends SystemService {
                     || android.app.Flags.nmSummarization())) {
                 return new HashSet<>();
             }
-            return mNasUnsupported.getOrDefault(userId, new HashSet<>());
+            var result = mNasUnsupported.getOrDefault(userId, new HashSet<>());
+            // Note that mDefaultUnsupportedAdjustments, loaded from
+            // config_notificationDefaultUnsupportedAdjustments, was empty before GrapheneOS change.
+            // For users that have already updated to alpha, empty set could be persisted to disk.
+            return result.isEmpty() ? new HashSet<>(List.of(mDefaultUnsupportedAdjustments)) : result;
         }
 
         void setNasUnsupportedDefaults(@UserIdInt int userId) {

--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -517,9 +517,9 @@ public class NotificationManagerService extends SystemService {
             Adjustment.KEY_IMPORTANCE_PROPOSAL,
             Adjustment.KEY_SENSITIVE_CONTENT,
             Adjustment.KEY_RANKING_SCORE,
-            Adjustment.KEY_NOT_CONVERSATION,
-            Adjustment.KEY_TYPE,
-            Adjustment.KEY_SUMMARIZATION
+            Adjustment.KEY_NOT_CONVERSATION
+            // Adjustment.KEY_TYPE,
+            // Adjustment.KEY_SUMMARIZATION
     };
 
     static final Integer[] DEFAULT_ALLOWED_ADJUSTMENT_KEY_TYPES = new Integer[] {


### PR DESCRIPTION
This should also hide the onboarding UI for notification summaries in SystemUI's notification shade and the various AI notification settings in Settings