### PR TITLE
add a workaround for WallpaperManagerService.hasPermission() crash

### DIFF
--- a/services/core/java/com/android/server/wallpaper/WallpaperData.java
+++ b/services/core/java/com/android/server/wallpaper/WallpaperData.java
@@ -26,6 +26,7 @@ import static com.android.server.wallpaper.WallpaperUtils.WALLPAPER_LOCK_ORIG;
 import static com.android.server.wallpaper.WallpaperUtils.getWallpaperDir;
 
 import android.annotation.NonNull;
+import android.annotation.Nullable;
 import android.app.IWallpaperManagerCallback;
 import android.app.WallpaperColors;
 import android.app.WallpaperManager.ScreenOrientation;
@@ -239,7 +240,8 @@ class WallpaperData {
         return result;
     }
 
-    @NonNull ComponentName getComponent() {
+    @Nullable
+    ComponentName getComponent() {
         return mDescription.getComponent();
     }
 

--- a/services/core/java/com/android/server/wallpaper/WallpaperManagerService.java
+++ b/services/core/java/com/android/server/wallpaper/WallpaperManagerService.java
@@ -2412,10 +2412,14 @@ public class WallpaperManagerService extends IWallpaperManager.Stub
     }
 
     private boolean hasPermission(WallpaperData data, String permission) {
+        ComponentName component = data.getComponent();
+        if (component == null) {
+            return false;
+        }
         try {
             return PackageManager.PERMISSION_GRANTED == mIPackageManager.checkPermission(
                     permission,
-                    data.getComponent().getPackageName(),
+                    component.getPackageName(),
                     data.userId);
         } catch (RemoteException e) {
             Slog.e(TAG, "Failed to check wallpaper service permission", e);


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/6813