### PR TITLE
fix system_server crash in NotificationHistory.getPooledStringsToWrite()

### DIFF
--- a/core/java/android/app/NotificationHistory.java
+++ b/core/java/android/app/NotificationHistory.java
@@ -314,11 +314,15 @@ public final class NotificationHistory implements Parcelable {
         mStringsToWrite.clear();
         for (int i = 0; i < mNotificationsToWrite.size(); i++) {
             final HistoricalNotification notification = mNotificationsToWrite.get(i);
-            mStringsToWrite.add(notification.getPackage());
+            if (!TextUtils.isEmpty(notification.getPackage())) {
+                mStringsToWrite.add(notification.getPackage());
+            }
             if (!TextUtils.isEmpty(notification.getChannelName())) {
                 mStringsToWrite.add(notification.getChannelName());
             }
-            mStringsToWrite.add(notification.getChannelId());
+            if (!TextUtils.isEmpty(notification.getChannelId())) {
+                mStringsToWrite.add(notification.getChannelId());
+            }
             if (!TextUtils.isEmpty(notification.getConversationId())) {
                 mStringsToWrite.add(notification.getConversationId());
             }


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/6815
