### PR TITLE
add workaround for KeySetManagerService system_server crash; add a missing null check to permission self-check spoofing change

### DIFF
--- a/core/java/android/permission/PermissionManager.java
+++ b/core/java/android/permission/PermissionManager.java
@@ -2018,7 +2018,7 @@ public final class PermissionManager {
         }
 
         if (res != PERMISSION_GRANTED) {
-            if (pkgName.equals(ActivityThread.currentPackageName())
+            if (pkgName != null && pkgName.equals(ActivityThread.currentPackageName())
                     && userId == UserHandle.myUserId()
                     && AppPermissionUtils.shouldSpoofSelfCheck(permName))
             {

--- a/services/core/java/com/android/server/pm/KeySetManagerService.java
+++ b/services/core/java/com/android/server/pm/KeySetManagerService.java
@@ -853,7 +853,14 @@ public class KeySetManagerService {
             ArraySet<Long> pubKeys = mKeySetMapping.valueAt(i);
             final int pkSize = pubKeys.size();
             for (int j = 0; j < pkSize; j++) {
-                mPublicKeys.get(pubKeys.valueAt(j)).incrRefCountLPw();
+                long pubKeyId = pubKeys.valueAt(j);
+                PublicKeyHandle key = mPublicKeys.get(pubKeyId);
+                if (key == null) {
+                    // match the logic of decrementPublicKeyLPw() above
+                    Slog.wtf(TAG, "addRefCountsFromSavedPackagesLPw: no public key with identifier " + pubKeyId);
+                } else {
+                    key.incrRefCountLPw();
+                }
             }
         }
         final int numOrphans = orphanedKeySets.size();


### PR DESCRIPTION
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/6868
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/6869