### PR TITLE
add workaround for UsageStatsDatabase OOM system_server crash; add workaround for WindowContext.finalize() system_server crash

### DIFF
--- a/core/java/android/window/WindowContext.java
+++ b/core/java/android/window/WindowContext.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 import android.annotation.NonNull;
 import android.annotation.Nullable;
 import android.annotation.UiContext;
+import android.app.ActivityThread;
 import android.content.ComponentCallbacks;
 import android.content.ComponentCallbacksController;
 import android.content.Context;
@@ -142,7 +143,7 @@ public class WindowContext extends ContextWrapper implements WindowProvider,
     @Override
     protected void finalize() throws Throwable {
         try {
-            release();
+            getMainThreadHandler().post(this::release);
         } finally {
             super.finalize();
         }

--- a/services/core/java/com/android/server/ext/DropBoxMonitor.java
+++ b/services/core/java/com/android/server/ext/DropBoxMonitor.java
@@ -256,17 +256,20 @@ public class DropBoxMonitor {
                 if (line.startsWith(bootReasonPrefix)) {
                     String bootReason = line.substring(bootReasonPrefix.length());
 
-                    switch (bootReason) {
-                        case "reboot":
-                        case "reboot,shell":
-                        case "PowerKey":
-                        case "normal":
-                        case "recovery":
-                        // device was forcibly rebooted by long-pressing the power key
-                        case "reboot,longkey":
-                        case "reboot,longkey,master_dc":
-                            Slog.d(TAG, "skipping last_kmsg, its boot reason is " + bootReason);
-                            return;
+                    boolean shouldSkip = bootReason.equals("reboot") || bootReason.startsWith("reboot,");
+
+                    if (!shouldSkip) {
+                        switch (bootReason) {
+                            case "PowerKey":
+                            case "normal":
+                            case "recovery":
+                                shouldSkip = true;
+                        }
+                    }
+
+                    if (shouldSkip) {
+                        Slog.d(TAG, "skipping last_kmsg, its boot reason is " + bootReason);
+                        return;
                     }
 
                     break;

--- a/services/usage/java/com/android/server/usage/UsageStatsDatabase.java
+++ b/services/usage/java/com/android/server/usage/UsageStatsDatabase.java
@@ -1105,7 +1105,12 @@ public class UsageStatsDatabase {
             Slog.wtf(TAG, "Reading UsageStats as XML; current database version: "
                     + mCurrentVersion);
         }
-        readLocked(file, statsOut, mCurrentVersion, mPackagesTokenData, skipEvents);
+        try {
+            readLocked(file, statsOut, mCurrentVersion, mPackagesTokenData, skipEvents);
+        } catch (OutOfMemoryError e) {
+            file.delete();
+            Slog.e(TAG, "unable to parse " + file, e);
+        }
     }
 
     /**


### PR DESCRIPTION
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/5590
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/6619