### PR TITLE
gmscompat: fix phenotype flags not working in GmsCore clients; add MEDIA_CONTENT_CONTROL uses-permission to Android Auto

### DIFF
--- a/core/java/android/app/NotificationManager.java
+++ b/core/java/android/app/NotificationManager.java
@@ -53,6 +53,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ParceledListSlice;
 import android.content.pm.ShortcutInfo;
+import android.ext.PackageId;
 import android.graphics.drawable.Icon;
 import android.net.Uri;
 import android.os.Binder;
@@ -2180,7 +2181,9 @@ public class NotificationManager {
      */
     public boolean isNotificationListenerAccessGranted(ComponentName listener) {
         if (GmsCompat.isAndroidAuto()) {
-            return true;
+            if (PackageId.ANDROID_AUTO_NAME.equals(listener.getPackageName())) {
+                return true;
+            }
         }
 
         INotificationManager service = service();

--- a/core/java/android/app/compat/gms/GmsCompat.java
+++ b/core/java/android/app/compat/gms/GmsCompat.java
@@ -24,6 +24,8 @@ import android.util.Log;
 import com.android.internal.gmscompat.GmsCompatLib;
 import com.android.internal.gmscompat.GmsHooks;
 import com.android.internal.gmscompat.GmsInfo;
+import com.android.internal.gmscompat.dynamite.GmsDynamiteClientHooks;
+import com.android.internal.gmscompat.fileservice.GmsCoreFileServerClientHooks;
 import com.android.internal.util.ArrayUtils;
 
 /**
@@ -136,6 +138,10 @@ public final class GmsCompat {
         if (isEligibleForClientCompat && GmsCompatLib.get() == null) {
             GmsCompatLib.init(appCtx, Application.getProcessName());
         }
+
+        if (GmsCompat.isClientOfGmsCore()) {
+            GmsCoreFileServerClientHooks.init();
+        }
     }
 
     public static boolean isEnabledFor(@NonNull ApplicationInfo app) {
@@ -229,9 +235,13 @@ public final class GmsCompat {
             userId = UserHandle.myUserId();
         }
 
-        Context ctx = AppGlobals.getInitialApplication();
+        Context ctx = appContext;
         if (ctx == null) {
-            return false;
+            ctx = AppGlobals.getInitialApplication();
+        }
+
+        if (ctx == null) {
+            throw new IllegalStateException("GmsCompat.isEnabledFor: Context is null");
         }
 
         PackageManager pm = ctx.getPackageManager();

--- a/core/java/android/os/ParcelFileDescriptor.java
+++ b/core/java/android/os/ParcelFileDescriptor.java
@@ -50,7 +50,7 @@ import android.util.CloseGuard;
 import android.util.Log;
 import android.util.Slog;
 
-import com.android.internal.gmscompat.dynamite.GmsDynamiteClientHooks;
+import com.android.internal.gmscompat.fileservice.GmsCoreFileServerClientHooks;
 
 import dalvik.system.VMRuntime;
 
@@ -353,8 +353,8 @@ public class ParcelFileDescriptor implements Parcelable, Closeable {
 
         final String path = file.getPath();
 
-        if (GmsDynamiteClientHooks.enabled()) {
-            FileDescriptor override = GmsDynamiteClientHooks.openFileDescriptor(path);
+        if (GmsCoreFileServerClientHooks.isEnabled()) {
+            FileDescriptor override = GmsCoreFileServerClientHooks.openParcelFileDescriptorHook(path);
             if (override != null) {
                 return override;
             }

--- a/core/java/com/android/internal/gmscompat/GmsCompatApp.java
+++ b/core/java/com/android/internal/gmscompat/GmsCompatApp.java
@@ -33,7 +33,7 @@ import android.provider.Settings;
 import android.util.ArraySet;
 import android.util.Log;
 
-import com.android.internal.gmscompat.dynamite.server.FileProxyService;
+import com.android.internal.gmscompat.fileservice.FileProxyService;
 
 import static com.android.internal.gmscompat.GmsHooks.inPersistentGmsCoreProcess;
 
@@ -47,7 +47,7 @@ public final class GmsCompatApp {
     // written to fields to prevent GC from collecting them
     private static BinderGca2Gms binderGca2Gms;
     @SuppressWarnings("FieldCanBeLocal")
-    private static FileProxyService dynamiteFileProxyService;
+    private static FileProxyService gmsCoreFileProxyService;
 
     private static IGms2Gca binderGms2Gca;
 
@@ -64,11 +64,11 @@ public final class GmsCompatApp {
             if (GmsCompat.isGmsCore()) {
                 FileProxyService fileProxyService = null;
                 if (inPersistentGmsCoreProcess) {
-                    // FileProxyService binder needs to be always available to the Dynamite clients.
+                    // FileProxyService binder needs to be always available to the GmsCore clients.
                     // "persistent" process launches at bootup and is kept alive by the ServiceConnection
                     // from the GmsCompatApp, which makes it fit for the purpose of hosting the FileProxyService
                     fileProxyService = new FileProxyService(ctx);
-                    dynamiteFileProxyService = fileProxyService;
+                    gmsCoreFileProxyService = fileProxyService;
 
                     Handler handler = ctx.getMainThreadHandler();
                     handler.postDelayed(GmsCompatApp::maybeShowContactsSyncNotification, 3000L);

--- a/core/java/com/android/internal/gmscompat/IClientOfGmsCore2Gca.aidl
+++ b/core/java/com/android/internal/gmscompat/IClientOfGmsCore2Gca.aidl
@@ -2,13 +2,13 @@ package com.android.internal.gmscompat;
 
 import android.os.BinderDef;
 
-import com.android.internal.gmscompat.dynamite.server.IFileProxyService;
+import com.android.internal.gmscompat.fileservice.IFileProxyService;
 
 // calls from clients of GMS Core to GmsCompatApp
 interface IClientOfGmsCore2Gca {
     @nullable BinderDef maybeGetBinderDef(String callerPkg, int processState, String ifaceName);
 
-    IFileProxyService getDynamiteFileProxyService();
+    IFileProxyService getGmsCoreFileProxyService();
 
     oneway void showMissingAppNotification(String pkgName);
 

--- a/core/java/com/android/internal/gmscompat/IGms2Gca.aidl
+++ b/core/java/com/android/internal/gmscompat/IGms2Gca.aidl
@@ -9,7 +9,7 @@ import android.os.BinderDef;
 
 import com.android.internal.gmscompat.GmsCompatConfig;
 import com.android.internal.gmscompat.IGca2Gms;
-import com.android.internal.gmscompat.dynamite.server.IFileProxyService;
+import com.android.internal.gmscompat.fileservice.IFileProxyService;
 
 // calls from GMS components to GmsCompatApp
 interface IGms2Gca {

--- a/core/java/com/android/internal/gmscompat/dynamite/GmsDynamiteClientHooks.java
+++ b/core/java/com/android/internal/gmscompat/dynamite/GmsDynamiteClientHooks.java
@@ -1,47 +1,17 @@
-/*
- * Copyright (C) 2022 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.android.internal.gmscompat.dynamite;
 
 import android.app.compat.gms.GmsCompat;
 import android.content.res.ApkAssets;
 import android.content.res.loader.AssetsProvider;
-import android.os.Environment;
-import android.os.IBinder;
-import android.os.ParcelFileDescriptor;
-import android.os.RemoteException;
-import android.system.ErrnoException;
-import android.system.Os;
-import android.util.ArrayMap;
-import android.util.Log;
 
-import com.android.internal.annotations.GuardedBy;
-import com.android.internal.gmscompat.GmsCompatApp;
-import com.android.internal.gmscompat.GmsInfo;
-import com.android.internal.gmscompat.dynamite.server.IFileProxyService;
+import com.android.internal.gmscompat.fileservice.GmsCoreFileServerClientHooks;
 
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.regex.Pattern;
 
 import dalvik.system.DelegateLastClassLoader;
-
-import static android.system.OsConstants.F_DUPFD_CLOEXEC;
 
 public final class GmsDynamiteClientHooks {
     static final String TAG = "GmsCompat/DynamiteClient";
@@ -49,9 +19,6 @@ public final class GmsDynamiteClientHooks {
 
     // written last in the init sequence, "volatile" to publish all the preceding writes
     private static volatile boolean enabled;
-    private static String gmsCoreDataPrefix;
-    private static ArrayMap<String, ParcelFileDescriptor> pfdCache;
-    private static ArrayList<ParcelFileDescriptor> pastCachedFds;
 
     public static boolean enabled() {
         return enabled;
@@ -69,14 +36,7 @@ public final class GmsDynamiteClientHooks {
             if (!GmsCompat.isClientOfGmsCore()) {
                 return;
             }
-            // faster than ctx.createPackageContext().createDeviceProtectedStorageContext().getDataDir()
-            int userId = GmsCompat.appContext().getUserId();
-            String deDataDirectory = Environment.getDataUserDeDirectory(null, userId).getPath();
-            gmsCoreDataPrefix = deDataDirectory + '/' + GmsInfo.PACKAGE_GMS_CORE + '/';
-            pfdCache = new ArrayMap<>(20);
-            pastCachedFds = new ArrayList<>();
 
-            File.lastModifiedHook = GmsDynamiteClientHooks::getFileLastModified;
             DelegateLastClassLoader.modifyClassLoaderPathHook = GmsDynamiteClientHooks::maybeModifyClassLoaderPath;
             enabled = true;
         }
@@ -84,42 +44,15 @@ public final class GmsDynamiteClientHooks {
 
     // ApkAssets#loadFromPath(String, int, AssetsProvider)
     public static ApkAssets loadAssetsFromPath(String path, int flags, AssetsProvider assets) throws IOException {
-        if (!path.startsWith(gmsCoreDataPrefix)) {
+        if (!GmsCoreFileServerClientHooks.isInGmsCoreDeDataDir(path)) {
             return null;
         }
-        FileDescriptor fd = modulePathToFd(path);
+        FileDescriptor fd = GmsCoreFileServerClientHooks.openFile(path);
+        if (fd == null) {
+            throw new IOException("unable to open " + path);
+        }
         // no need to dup the fd, ApkAssets does it itself
         return ApkAssets.loadFromFd(fd, path, flags, assets);
-    }
-
-    // To fix false-positive "Module APK has been modified" check
-    // File#lastModified()
-    public static long getFileLastModified(File file) {
-        final String path = file.getPath();
-
-        if (enabled && path.startsWith(gmsCoreDataPrefix)) {
-            String fdPath = "/proc/self/fd/" + modulePathToFd(path).getInt$();
-            return new File(fdPath).lastModified();
-        }
-        return 0L;
-    }
-
-    public static FileDescriptor openFileDescriptor(String path) {
-        if (!path.startsWith(gmsCoreDataPrefix)) {
-            return null;
-        }
-
-        FileDescriptor fd = modulePathToFd(path);
-        int dupFd;
-        try {
-            dupFd = Os.fcntlInt(fd, F_DUPFD_CLOEXEC, 0);
-        } catch (ErrnoException e) {
-            throw new RuntimeException(e);
-        }
-
-        var dupJfd = new FileDescriptor();
-        dupJfd.setInt$(dupFd);
-        return dupJfd;
     }
 
     // Replaces file paths of Dynamite modules with "/proc/self/fd" file descriptor references
@@ -137,7 +70,7 @@ public final class GmsDynamiteClientHooks {
 
         for (int i = 0; i < pathParts.length; ++i) {
             String pathPart = pathParts[i];
-            if (!pathPart.startsWith(gmsCoreDataPrefix)) {
+            if (!GmsCoreFileServerClientHooks.isInGmsCoreDeDataDir(pathPart)) {
                 continue;
             }
             // defined in bionic/linker/linker_utils.cpp kZipFileSeparator
@@ -153,7 +86,11 @@ public final class GmsDynamiteClientHooks {
                 filePath = pathPart;
                 nativeLibRelPath = null;
             }
-            String fdFilePath = "/gmscompat_fd_" + modulePathToFd(filePath).getInt$();
+            FileDescriptor fd = GmsCoreFileServerClientHooks.openFile(filePath);
+            if (fd == null) {
+                throw new IllegalStateException("unable to open " + filePath);
+            }
+            String fdFilePath = "/gmscompat_fd_" + fd.getInt$();
 
             pathParts[i] = nativeLibsPath ?
                 fdFilePath + zipFileSeparator + nativeLibRelPath :
@@ -165,67 +102,6 @@ public final class GmsDynamiteClientHooks {
             return path;
         }
         return String.join(File.pathSeparator, pathParts);
-    }
-
-    // Returned file descriptor should never be closed, because it may be dup()-ed at any time by the native code
-    private static FileDescriptor modulePathToFd(String path) {
-        if (DEBUG) {
-            Log.d(TAG, "path " + path, new Throwable());
-        }
-        try {
-            ArrayMap<String, ParcelFileDescriptor> cache = pfdCache;
-            // this lock isn't contended, favor simplicity, not making the critical section shorter
-            synchronized (cache) {
-                ParcelFileDescriptor pfd = cache.get(path);
-                if (pfd == null) {
-                    pfd = getFileProxyService().openFile(path);
-                    if (pfd == null) {
-                        throw new IllegalStateException("unable to open " + path);
-                    }
-                    // ParcelFileDescriptor owns the underlying file descriptor
-                    cache.put(path, pfd);
-                }
-                return pfd.getFileDescriptor();
-            }
-        } catch (RemoteException e) {
-            // FileProxyService never forwards exceptions to minimize the information leaks,
-            // this is a very rare "binder died" exception
-            throw e.rethrowAsRuntimeException();
-        }
-    }
-
-    private static volatile IFileProxyService fileProxyService;
-
-    @GuardedBy("pfdCache")
-    private static IFileProxyService getFileProxyService() {
-        IFileProxyService cache = fileProxyService;
-        if (cache != null) {
-            return cache;
-        }
-        try {
-            IFileProxyService service = GmsCompatApp.iClientOfGmsCore2Gca().getDynamiteFileProxyService();
-            fileProxyService = service;
-            IBinder.DeathRecipient serviceDeathCallback = () -> {
-                fileProxyService = null;
-                Log.d(TAG, "FileProxyService died");
-                synchronized (pfdCache) {
-                    // It's not safe to close cached file descriptors, they might still be in use
-                    // at this point. Simply clearing the cache would make cached ParcelFileDescriptors
-                    // collectable by GC, which would close the underlying file descriptors via
-                    // ParcelFileDescriptor#finalize()
-                    //
-                    // pastCachedFds list is effectively a file descriptor leak, but it's small and
-                    // rare. File descriptor count limit (RLIMIT_NOFILE) is set to 32768 as of Android 15.
-                    pastCachedFds.addAll(pfdCache.values());
-                    pfdCache.clear();
-                }
-            };
-            service.asBinder().linkToDeath(serviceDeathCallback, 0);
-            return service;
-        } catch (RemoteException e) {
-            Log.e(TAG, "unable to obtain FileProxyService", e);
-            throw e.rethrowAsRuntimeException();
-        }
     }
 
     private GmsDynamiteClientHooks() {}

--- a/core/java/com/android/internal/gmscompat/fileservice/FileProxyService.java
+++ b/core/java/com/android/internal/gmscompat/fileservice/FileProxyService.java
@@ -1,22 +1,8 @@
-/*
- * Copyright (C) 2021 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+package com.android.internal.gmscompat.fileservice;
 
-package com.android.internal.gmscompat.dynamite.server;
-
+import android.app.compat.gms.GmsCompat;
 import android.content.Context;
+import android.os.Binder;
 import android.os.ParcelFileDescriptor;
 import android.system.ErrnoException;
 import android.system.Os;
@@ -28,48 +14,57 @@ import java.io.FileDescriptor;
 import java.io.IOException;
 
 public final class FileProxyService extends IFileProxyService.Stub {
-    public static final String TAG = "GmsCompat/DynamiteServer";
-    private static final String CHIMERA_REL_PATH = "app_chimera/m/";
+    public static final String TAG = "GmsCompat/FileProxyService";
 
-    private final String chimeraRoot;
+    private final String deDataPrefix; // device-encrypted data dir
+    private final String ceDataPrefix; // credential-encrypted data dir
 
     public FileProxyService(Context context) {
-        File deDataRoot = context.createDeviceProtectedStorageContext().getDataDir();
-        chimeraRoot = deDataRoot.getPath() + "/" + CHIMERA_REL_PATH;
+        try {
+            deDataPrefix = context.createDeviceProtectedStorageContext().getDataDir().getCanonicalPath() + "/";
+            ceDataPrefix = context.getDataDir().getCanonicalPath() + "/";
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+        Log.d(TAG, "allowed locations: " + deDataPrefix + " and " + ceDataPrefix);
     }
 
     @Override
     public ParcelFileDescriptor openFile(String rawPath) {
         try {
-            String path = sanitizeModulePath(rawPath);
+            String path = sanitizeFilePath(rawPath);
             if (path != null) {
                 FileDescriptor fd = Os.open(path, OsConstants.O_RDONLY | OsConstants.O_CLOEXEC, 0);
-//                Log.d(TAG, "Opened " + rawPath + " for remote, fd " + fd.getInt$());
+                Log.d(TAG, "Opened " + rawPath + " for caller UID " + Binder.getCallingUid());
                 return new ParcelFileDescriptor(fd);
             }
         } catch (IOException | ErrnoException e) {
-            Log.d(TAG, "failed security check", e);
+            Log.d(TAG, "openFile failed for " + rawPath, e);
         } catch (Throwable t) {
-            Log.d(TAG, "unexpected error", t);
+            GmsCompat.appContext().getMainThreadHandler().post(() -> {
+                throw new IllegalStateException(t);
+            });
         }
         // don't forward exceptions to the untrusted caller to minimize the information leaks
         return null;
     }
 
-    private String sanitizeModulePath(String rawPath) throws IOException, ErrnoException {
+    private String sanitizeFilePath(String rawPath) throws IOException, ErrnoException {
         // Normalize path for security checks
         String path = new File(rawPath).getCanonicalPath();
 
-        // Modules can only be in DE Chimera storage
-        if (!path.startsWith(chimeraRoot)) {
-            Log.d(TAG, "Path " + rawPath + " is not in " + chimeraRoot);
+        String allowedPrefix = null;
+        if (path.startsWith(deDataPrefix)) {
+            allowedPrefix = deDataPrefix;
+        } else if (path.startsWith(ceDataPrefix)) {
+            allowedPrefix = ceDataPrefix;
+        }
+
+        if (allowedPrefix == null) {
+            Log.d(TAG, "Path " + rawPath + " is not in an allowed location, realpath is " + path);
             return null;
         }
 
-        if (!path.endsWith(".apk")) {
-            Log.d(TAG, "Path " + rawPath + " is not an APK file");
-            return null;
-        }
         // Make sure that all path components below chimeraRoot are world-accessible
         {
             // Check full path first to simplify checks of its parents
@@ -81,7 +76,7 @@ public final class FileProxyService extends IFileProxyService.Stub {
                 return null;
             }
         }
-        for (int i = chimeraRoot.length(), m = path.length(); i < m; ++i) {
+        for (int i = allowedPrefix.length(), m = path.length(); i < m; ++i) {
             if (path.charAt(i) != '/') {
                 continue;
             }

--- a/core/java/com/android/internal/gmscompat/fileservice/GmsCoreFileServerClientHooks.java
+++ b/core/java/com/android/internal/gmscompat/fileservice/GmsCoreFileServerClientHooks.java
@@ -1,0 +1,174 @@
+package com.android.internal.gmscompat.fileservice;
+
+import android.annotation.Nullable;
+import android.app.compat.gms.GmsCompat;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.ext.PackageId;
+import android.os.IBinder;
+import android.os.ParcelFileDescriptor;
+import android.os.RemoteException;
+import android.system.ErrnoException;
+import android.system.Os;
+import android.util.ArrayMap;
+import android.util.Log;
+
+import com.android.internal.annotations.GuardedBy;
+import com.android.internal.gmscompat.GmsCompatApp;
+
+import java.io.File;
+import java.io.FileDescriptor;
+import java.util.ArrayList;
+
+import libcore.io.IoBridge;
+
+import static android.system.OsConstants.F_DUPFD_CLOEXEC;
+
+public class GmsCoreFileServerClientHooks {
+    private static final String TAG = "GmsCoreFileServerClientHooks";
+    private static final boolean DEBUG = false;
+
+    private static boolean isEnabled;
+    private static String gmsCoreDeDataPrefix;
+    private static String gmsCoreCeDataPrefix;
+    private static volatile IFileProxyService fileProxyService;
+    private static ArrayMap<String, ParcelFileDescriptor> pfdCache;
+    private static ArrayList<ParcelFileDescriptor> pastCachedFds;
+
+    public static boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public static void init() {
+        int userId = GmsCompat.appContext().getUserId();
+        Context context;
+        try {
+            context = GmsCompat.appContext().createPackageContext(PackageId.GMS_CORE_NAME, userId);
+        } catch (PackageManager.NameNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+        gmsCoreDeDataPrefix = context.createDeviceProtectedStorageContext().getDataDir().getAbsolutePath() + "/";
+        gmsCoreCeDataPrefix = context.getDataDir().getAbsolutePath() + "/";
+        pfdCache = new ArrayMap<>(20);
+        pastCachedFds = new ArrayList<>();
+
+        File.lastModifiedHook = GmsCoreFileServerClientHooks::getFileLastModified;
+        IoBridge.openFdInterceptor = new IoBridge.OpenFdInterceptor() {
+            @Override
+            public FileDescriptor maybeInterceptOpenFd(String path, int flags) throws ErrnoException {
+                if (path.startsWith(gmsCoreDeDataPrefix) || path.startsWith(gmsCoreCeDataPrefix)) {
+                    FileDescriptor fd = openFile(path);
+                    if (fd == null) {
+                        return null;
+                    }
+                    return Os.dup(fd);
+                }
+                return null;
+            }
+        };
+        isEnabled = true;
+    }
+
+    public static long getFileLastModified(File file) {
+        final String path = file.getPath();
+
+        if (isInGmsCoreDataDir(path)) {
+            FileDescriptor fd = openFile(path);
+            if (fd != null) {
+                String fdPath = "/proc/self/fd/" + fd.getInt$();
+                return new File(fdPath).lastModified();
+            }
+        }
+        return 0L;
+    }
+
+    public static boolean isInGmsCoreDeDataDir(String path) {
+        return path.startsWith(gmsCoreDeDataPrefix);
+    }
+
+    public static boolean isInGmsCoreDataDir(String path) {
+        return path.startsWith(gmsCoreDeDataPrefix) || path.startsWith(gmsCoreCeDataPrefix);
+    }
+
+    public static FileDescriptor openParcelFileDescriptorHook(String path) {
+        if (!isInGmsCoreDataDir(path)) {
+            return null;
+        }
+
+        FileDescriptor fd = openFile(path);
+        if (fd == null) {
+            return null;
+        }
+
+        int dupFd;
+        try {
+            dupFd = Os.fcntlInt(fd, F_DUPFD_CLOEXEC, 0);
+        } catch (ErrnoException e) {
+            throw new RuntimeException(e);
+        }
+
+        var dupJfd = new FileDescriptor();
+        dupJfd.setInt$(dupFd);
+        return dupJfd;
+    }
+
+    // Returned file descriptor should never be closed because it may be accessed at any time by the native code
+    @Nullable
+    public static FileDescriptor openFile(String path) {
+        if (DEBUG) {
+            Log.d(TAG, "path " + path, new Throwable());
+        }
+        try {
+            ArrayMap<String, ParcelFileDescriptor> cache = pfdCache;
+            // this lock isn't contended, favor simplicity, not making the critical section shorter
+            synchronized (cache) {
+                ParcelFileDescriptor pfd = cache.get(path);
+                if (pfd == null) {
+                    pfd = getFileProxyService().openFile(path);
+                    if (pfd == null) {
+                        return null;
+                    }
+                    // ParcelFileDescriptor owns the underlying file descriptor
+                    cache.put(path, pfd);
+                }
+                return pfd.getFileDescriptor();
+            }
+        } catch (RemoteException e) {
+            // FileProxyService never forwards exceptions to minimize the information leaks,
+            // this is a very rare "binder died" exception
+            throw e.rethrowAsRuntimeException();
+        }
+    }
+
+    @GuardedBy("pfdCache")
+    private static IFileProxyService getFileProxyService() {
+        IFileProxyService cache = fileProxyService;
+        if (cache != null) {
+            return cache;
+        }
+        try {
+            IFileProxyService service = GmsCompatApp.iClientOfGmsCore2Gca().getGmsCoreFileProxyService();
+            fileProxyService = service;
+            IBinder.DeathRecipient serviceDeathCallback = () -> {
+                fileProxyService = null;
+                Log.d(TAG, "FileProxyService died");
+                synchronized (pfdCache) {
+                    // It's not safe to close cached file descriptors, they might still be in use
+                    // at this point. Simply clearing the cache would make cached ParcelFileDescriptors
+                    // collectable by GC, which would close the underlying file descriptors via
+                    // ParcelFileDescriptor#finalize()
+                    //
+                    // pastCachedFds list is effectively a file descriptor leak, but it's small and
+                    // rare. File descriptor count limit (RLIMIT_NOFILE) is set to 32768 as of Android 15.
+                    pastCachedFds.addAll(pfdCache.values());
+                    pfdCache.clear();
+                }
+            };
+            service.asBinder().linkToDeath(serviceDeathCallback, 0);
+            return service;
+        } catch (RemoteException e) {
+            Log.e(TAG, "unable to obtain FileProxyService", e);
+            throw e.rethrowAsRuntimeException();
+        }
+    }
+}

--- a/core/java/com/android/internal/gmscompat/fileservice/IFileProxyService.aidl
+++ b/core/java/com/android/internal/gmscompat/fileservice/IFileProxyService.aidl
@@ -1,4 +1,4 @@
-package com.android.internal.gmscompat.dynamite.server;
+package com.android.internal.gmscompat.fileservice;
 
 interface IFileProxyService {
     ParcelFileDescriptor openFile(String path);

--- a/services/core/java/com/android/server/pm/ext/AndroidAutoHooks.java
+++ b/services/core/java/com/android/server/pm/ext/AndroidAutoHooks.java
@@ -25,6 +25,9 @@ public class AndroidAutoHooks extends PackageHooks {
                     Manifest.permission.ASSOCIATE_COMPANION_DEVICES_RESTRICTED,
                     Manifest.permission.BLUETOOTH_PRIVILEGED_ANDROID_AUTO,
                     Manifest.permission.MANAGE_USB_ANDROID_AUTO,
+                    // MEDIA_CONTENT_CONTROL permission allows Android Auto to control media
+                    // playback without holding the broad notification listener permission
+                    Manifest.permission.MEDIA_CONTENT_CONTROL,
                     Manifest.permission.READ_DEVICE_SERIAL_NUMBER,
                     Manifest.permission.READ_PRIVILEGED_PHONE_STATE_ANDROID_AUTO,
                     Manifest.permission.WIFI_PRIVILEGED_ANDROID_AUTO
@@ -69,6 +72,7 @@ public class AndroidAutoHooks extends PackageHooks {
             /** @see android.app.UiModeManager#enableCarMode(int, int) */
             case Manifest.permission.ENTER_CAR_MODE_PRIORITIZED:
             case Manifest.permission.MANAGE_USB_ANDROID_AUTO:
+            case Manifest.permission.MEDIA_CONTENT_CONTROL:
             // allows to enable/disable dark mode
             case Manifest.permission.MODIFY_DAY_NIGHT_MODE:
             // allows to asssociate only with DEVICE_PROFILE_AUTOMOTIVE_PROJECTION


### PR DESCRIPTION
Depends on:
https://github.com/GrapheneOS/platform_libcore/pull/26
https://github.com/GrapheneOS/platform_packages_apps_GmsCompat/pull/267

Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/6355
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/6770