### PR TITLE
gmscompat: fix incorrect usage of createPackageContext()

### DIFF
--- a/core/java/com/android/internal/gmscompat/fileservice/GmsCoreFileServerClientHooks.java
+++ b/core/java/com/android/internal/gmscompat/fileservice/GmsCoreFileServerClientHooks.java
@@ -40,10 +40,9 @@ public class GmsCoreFileServerClientHooks {
     }
 
     public static void init() {
-        int userId = GmsCompat.appContext().getUserId();
         Context context;
         try {
-            context = GmsCompat.appContext().createPackageContext(PackageId.GMS_CORE_NAME, userId);
+            context = GmsCompat.appContext().createPackageContext(PackageId.GMS_CORE_NAME, 0);
         } catch (PackageManager.NameNotFoundException e) {
             throw new IllegalStateException(e);
         }


### PR DESCRIPTION
The second argument of (String, int) overload is a flags integer.

userId can by passed by using the (String, int, UserHandle) overload, but that's not needed in this case since the default userId is the app context userId.