### PR TITLE
fix an upstream infinite loop bug in ProtoFieldFilter.skipBytes()

### DIFF
--- a/core/java/android/util/proto/ProtoFieldFilter.java
+++ b/core/java/android/util/proto/ProtoFieldFilter.java
@@ -307,7 +307,7 @@ public class ProtoFieldFilter {
             while (bytesRemaining > 0) {
                 int bytesToRead = (int) Math.min(bytesRemaining, mBuffer.length);
                 int bytesRead = in.read(mBuffer, 0, bytesToRead);
-                if (bytesRemaining < 0) {
+                if (bytesRead < 0) {
                     throw new IOException("EOF while skipping bytes");
                 }
                 bytesRemaining -= bytesRead;


### PR DESCRIPTION
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/6942
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/7003