### PR TITLE
fix the "save discrete app-op history for more permissions" change

### DIFF
--- a/core/api/system-current.txt
+++ b/core/api/system-current.txt
@@ -679,6 +679,7 @@ package android.app {
   }
 
   public class AppOpsManager {
+    method public void checkHistoricalRegistryConfig(@NonNull String[]);
     method @Nullable @RequiresPermission(android.Manifest.permission.GET_APP_OPS_STATS) public android.app.RuntimeAppOpAccessMessage collectRuntimeAppOpAccessMessage();
     method @RequiresPermission(android.Manifest.permission.GET_APP_OPS_STATS) public void getHistoricalOps(@NonNull android.app.AppOpsManager.HistoricalOpsRequest, @NonNull java.util.concurrent.Executor, @NonNull java.util.function.Consumer<android.app.AppOpsManager.HistoricalOps>);
     method public static String[] getOpStrs();

--- a/core/java/android/app/AppOpsManager.java
+++ b/core/java/android/app/AppOpsManager.java
@@ -10256,6 +10256,16 @@ public class AppOpsManager {
         }
     }
 
+    /** @hide */
+    @SystemApi
+    public void checkHistoricalRegistryConfig(@NonNull String[] extraPermissions) {
+        try {
+            mService.checkHistoricalRegistryConfig(extraPermissions);
+        } catch (RemoteException e) {
+            e.rethrowFromSystemServer();
+        }
+    }
+
     /**
      * @deprecated Use {@link PackageManager#getPackageUid} instead
      */

--- a/core/java/com/android/internal/app/IAppOpsService.aidl
+++ b/core/java/com/android/internal/app/IAppOpsService.aidl
@@ -77,6 +77,7 @@ interface IAppOpsService {
     // Deprecated, use finishProxyOperationWithState instead.
     void finishProxyOperation(IBinder clientId, int code, in AttributionSource attributionSource,
             boolean skipProxyOperation);
+    void checkHistoricalRegistryConfig(in String[] extraPermissions);
     int checkPackage(int uid, String packageName);
     RuntimeAppOpAccessMessage collectRuntimeAppOpAccessMessage();
     MessageSamplingConfig reportRuntimeAppOpAccessMessageAndGetConfig(String packageName,

--- a/services/core/java/com/android/server/appop/AppOpsService.java
+++ b/services/core/java/com/android/server/appop/AppOpsService.java
@@ -2014,6 +2014,11 @@ public class AppOpsService extends IAppOpsService.Stub {
     }
 
     @Override
+    public void checkHistoricalRegistryConfig(String[] extraPermissions) {
+        HistoricalRegistryExt.checkConfig(mContext, mHistoricalRegistry, extraPermissions);
+    }
+
+    @Override
     public void getHistoricalOpsFromDiskRaw(int uid, String packageName, String attributionTag,
             List<String> opNames, int dataType, int filter, long beginTimeMillis,
             long endTimeMillis, int flags, RemoteCallback callback) {

--- a/services/core/java/com/android/server/appop/DiscreteOpsRegistry.java
+++ b/services/core/java/com/android/server/appop/DiscreteOpsRegistry.java
@@ -107,14 +107,6 @@ abstract class DiscreteOpsRegistry {
             OP_MONITOR_LOCATION
     };
 
-    // Legacy ops captured in discrete database.
-    private static final String LEGACY_OPS = OP_FINE_LOCATION + "," + OP_COARSE_LOCATION
-            + "," + OP_EMERGENCY_LOCATION + "," + OP_CAMERA + "," + OP_RECORD_AUDIO + ","
-            + OP_PHONE_CALL_MICROPHONE + "," + OP_PHONE_CALL_CAMERA + ","
-            + OP_RECEIVE_AMBIENT_TRIGGER_AUDIO + "," + OP_RECEIVE_SANDBOX_TRIGGER_AUDIO
-            + "," + OP_READ_HEART_RATE + "," + OP_READ_OXYGEN_SATURATION + ","
-            + OP_READ_SKIN_TEMPERATURE + "," + OP_RESERVED_FOR_TESTING;
-
     static final long DEFAULT_DISCRETE_HISTORY_CUTOFF = Duration.ofDays(7).toMillis();
     static final long MAXIMUM_DISCRETE_HISTORY_CUTOFF = Duration.ofDays(30).toMillis();
     // The duration for which the data is kept, default is 7 days and max 30 days enforced.
@@ -245,7 +237,7 @@ abstract class DiscreteOpsRegistry {
     }
 
     private static int[] getDefaultLegacyOps() {
-        return parseOpsList(LEGACY_OPS);
+        throw new IllegalStateException("getDefaultLegacyOps() is expected to never be called");
     }
 
     private static int[] parseOpsList(String opsList) {

--- a/services/core/java/com/android/server/appop/DiscreteOpsRegistry.java
+++ b/services/core/java/com/android/server/appop/DiscreteOpsRegistry.java
@@ -16,18 +16,9 @@
 
 package com.android.server.appop;
 
-import static android.app.AppOpsManager.OP_ACCEPT_HANDOVER;
 import static android.app.AppOpsManager.OP_ACCESS_ACCESSIBILITY;
-import static android.app.AppOpsManager.OP_ACCESS_MEDIA_LOCATION;
 import static android.app.AppOpsManager.OP_ACCESS_NOTIFICATIONS;
-import static android.app.AppOpsManager.OP_ACTIVITY_RECOGNITION;
-import static android.app.AppOpsManager.OP_ADD_VOICEMAIL;
-import static android.app.AppOpsManager.OP_ANSWER_PHONE_CALLS;
 import static android.app.AppOpsManager.OP_BIND_ACCESSIBILITY_SERVICE;
-import static android.app.AppOpsManager.OP_BLUETOOTH_ADVERTISE;
-import static android.app.AppOpsManager.OP_BLUETOOTH_CONNECT;
-import static android.app.AppOpsManager.OP_BLUETOOTH_SCAN;
-import static android.app.AppOpsManager.OP_CALL_PHONE;
 import static android.app.AppOpsManager.OP_CAMERA;
 import static android.app.AppOpsManager.OP_COARSE_LOCATION;
 import static android.app.AppOpsManager.OP_EMERGENCY_LOCATION;
@@ -35,40 +26,20 @@ import static android.app.AppOpsManager.OP_FINE_LOCATION;
 import static android.app.AppOpsManager.OP_FLAG_SELF;
 import static android.app.AppOpsManager.OP_FLAG_TRUSTED_PROXIED;
 import static android.app.AppOpsManager.OP_FLAG_TRUSTED_PROXY;
-import static android.app.AppOpsManager.OP_GET_ACCOUNTS;
 import static android.app.AppOpsManager.OP_GPS;
 import static android.app.AppOpsManager.OP_MONITOR_HIGH_POWER_LOCATION;
 import static android.app.AppOpsManager.OP_MONITOR_LOCATION;
 import static android.app.AppOpsManager.OP_PHONE_CALL_CAMERA;
 import static android.app.AppOpsManager.OP_PHONE_CALL_MICROPHONE;
-import static android.app.AppOpsManager.OP_PROCESS_OUTGOING_CALLS;
-import static android.app.AppOpsManager.OP_READ_CALENDAR;
-import static android.app.AppOpsManager.OP_READ_CALL_LOG;
-import static android.app.AppOpsManager.OP_READ_CELL_BROADCASTS;
-import static android.app.AppOpsManager.OP_READ_CONTACTS;
 import static android.app.AppOpsManager.OP_READ_DEVICE_IDENTIFIERS;
-import static android.app.AppOpsManager.OP_READ_EXTERNAL_STORAGE;
 import static android.app.AppOpsManager.OP_READ_HEART_RATE;
 import static android.app.AppOpsManager.OP_READ_OXYGEN_SATURATION;
-import static android.app.AppOpsManager.OP_READ_PHONE_NUMBERS;
-import static android.app.AppOpsManager.OP_READ_PHONE_STATE;
 import static android.app.AppOpsManager.OP_READ_SKIN_TEMPERATURE;
-import static android.app.AppOpsManager.OP_READ_SMS;
 import static android.app.AppOpsManager.OP_RECEIVE_AMBIENT_TRIGGER_AUDIO;
-import static android.app.AppOpsManager.OP_RECEIVE_MMS;
 import static android.app.AppOpsManager.OP_RECEIVE_SANDBOX_TRIGGER_AUDIO;
-import static android.app.AppOpsManager.OP_RECEIVE_SMS;
-import static android.app.AppOpsManager.OP_RECEIVE_WAP_PUSH;
 import static android.app.AppOpsManager.OP_RECORD_AUDIO;
 import static android.app.AppOpsManager.OP_RESERVED_FOR_TESTING;
 import static android.app.AppOpsManager.OP_RUN_IN_BACKGROUND;
-import static android.app.AppOpsManager.OP_SEND_SMS;
-import static android.app.AppOpsManager.OP_USE_SIP;
-import static android.app.AppOpsManager.OP_UWB_RANGING;
-import static android.app.AppOpsManager.OP_WRITE_CALENDAR;
-import static android.app.AppOpsManager.OP_WRITE_CALL_LOG;
-import static android.app.AppOpsManager.OP_WRITE_CONTACTS;
-import static android.app.AppOpsManager.OP_WRITE_EXTERNAL_STORAGE;
 
 import static java.lang.Long.min;
 import static java.lang.Math.max;
@@ -142,44 +113,7 @@ abstract class DiscreteOpsRegistry {
             + OP_PHONE_CALL_MICROPHONE + "," + OP_PHONE_CALL_CAMERA + ","
             + OP_RECEIVE_AMBIENT_TRIGGER_AUDIO + "," + OP_RECEIVE_SANDBOX_TRIGGER_AUDIO
             + "," + OP_READ_HEART_RATE + "," + OP_READ_OXYGEN_SATURATION + ","
-            + OP_READ_SKIN_TEMPERATURE + "," + OP_RESERVED_FOR_TESTING
-            /*
-             * Keep track of more app ops for privacy dashboard display.
-             *
-             * Important: When the flags android.permission.flags.record_all_runtime_appops_sqlite
-             * and android.permission.flags.enable_sqlite_appops_accesses are enabled upstream, this
-             * LEGACY_OPS string might be removed entirely.
-             *
-             * From AppOpsManager.RUNTIME_AND_APPOP_PERMISSIONS_OPS:
-             * Location: COARSE_LOCATION, FINE_LOCATION
-             * Camera: CAMERA
-             * Microphone: RECORD_AUDIO
-             * Calendar: READ_CALENDAR, WRITE_CALENDAR
-             * Call logs: READ_CALL_LOG, WRITE_CALL_LOG
-             * Contacts: READ_CONTACTS, WRITE_CONTACTS, GET_ACCOUNTS
-             * Files and media: READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE, ACCESS_MEDIA_LOCATION
-             * Nearby devices: BLUETOOTH_SCAN, BLUETOOTH_CONNECT, BLUETOOTH_ADVERTISE, UWB_RANGING
-             * Phone: READ_PHONE_STATE, READ_PHONE_NUMBERS, CALL_PHONE, READ_CALL_LOG, WRITE_CALL_LOG, ADD_VOICEMAIL, USE_SIP, PROCESS_OUTGOING_CALLS, ANSWER_PHONE_CALLS, ACCEPT_HANDOVER
-             * Body sensors: ACTIVITY_RECOGNITION
-             * SMS: SEND_SMS, RECEIVE_SMS, READ_SMS, RECEIVE_WAP_PUSH, RECEIVE_MMS, READ_CELL_BROADCASTS
-             *
-             * From PrivacyItemController:
-             * Camera: PHONE_CALL_CAMERA
-             * Microphone: PHONE_CALL_MICROPHONE
-             */
-            + "," + OP_READ_CALENDAR + "," +
-            OP_WRITE_CALENDAR + "," + OP_READ_CALL_LOG + "," +
-            OP_READ_CONTACTS + "," + OP_WRITE_CONTACTS + "," + OP_GET_ACCOUNTS + "," +
-            OP_READ_EXTERNAL_STORAGE + "," + OP_WRITE_EXTERNAL_STORAGE + "," +
-            OP_ACCESS_MEDIA_LOCATION + "," + OP_BLUETOOTH_SCAN + "," + OP_BLUETOOTH_CONNECT + "," +
-            OP_BLUETOOTH_ADVERTISE + "," + OP_UWB_RANGING + "," + OP_READ_PHONE_STATE + "," +
-            OP_READ_PHONE_NUMBERS + "," + OP_CALL_PHONE + "," +
-            OP_WRITE_CALL_LOG + "," + OP_ADD_VOICEMAIL + "," + OP_USE_SIP + "," +
-            OP_PROCESS_OUTGOING_CALLS + "," + OP_ANSWER_PHONE_CALLS + "," + OP_ACCEPT_HANDOVER +
-            "," + OP_ACTIVITY_RECOGNITION + "," + OP_SEND_SMS + "," + OP_RECEIVE_SMS + "," +
-            OP_READ_SMS + "," + OP_RECEIVE_WAP_PUSH + "," + OP_RECEIVE_MMS + "," +
-            OP_READ_CELL_BROADCASTS
-            ;
+            + OP_READ_SKIN_TEMPERATURE + "," + OP_RESERVED_FOR_TESTING;
 
     static final long DEFAULT_DISCRETE_HISTORY_CUTOFF = Duration.ofDays(7).toMillis();
     static final long MAXIMUM_DISCRETE_HISTORY_CUTOFF = Duration.ofDays(30).toMillis();

--- a/services/core/java/com/android/server/appop/HistoricalRegistry.java
+++ b/services/core/java/com/android/server/appop/HistoricalRegistry.java
@@ -148,7 +148,7 @@ public class HistoricalRegistry implements HistoricalRegistryInterface {
             "discrete_history_ops_cslist";
 
     // These ops are recorded in short interval ops database for better fidelity.
-    private static final int[] SHORT_INTERVAL_OPS = new int[]{
+    public static final int[] SHORT_INTERVAL_OPS = new int[]{
             OP_PHONE_CALL_MICROPHONE,
             OP_RECEIVE_AMBIENT_TRIGGER_AUDIO,
             OP_RECEIVE_SANDBOX_TRIGGER_AUDIO,
@@ -165,7 +165,7 @@ public class HistoricalRegistry implements HistoricalRegistryInterface {
     };
     // These app ops are deemed important for detecting a malicious app, and are recorded
     // in short interval ops database too for better fidelity.
-    private static final int[] IMPORTANT_OPS_FOR_SECURITY = new int[]{
+    public static final int[] IMPORTANT_OPS_FOR_SECURITY = new int[]{
             OP_GPS,
             OP_ACCESS_NOTIFICATIONS,
             OP_RUN_IN_BACKGROUND,
@@ -354,6 +354,16 @@ public class HistoricalRegistry implements HistoricalRegistryInterface {
         IntArray shortIntervalOps = new IntArray();
         shortIntervalOps.addAll(SHORT_INTERVAL_OPS);
         shortIntervalOps.addAll(IMPORTANT_OPS_FOR_SECURITY);
+
+        int[] standardOps = shortIntervalOps.toArray();
+        Arrays.sort(standardOps);
+
+        for (int op : HistoricalRegistryExt.EXTRA_APP_OPS) {
+            if (Arrays.binarySearch(standardOps, op) < 0) {
+                shortIntervalOps.add(op);
+            }
+        }
+
         return shortIntervalOps.toArray();
     }
 
@@ -633,6 +643,11 @@ public class HistoricalRegistry implements HistoricalRegistryInterface {
         } finally {
             Trace.traceEnd(Trace.TRACE_TAG_SYSTEM_SERVER);
         }
+    }
+
+    @Override
+    public int[] getOpCodes() {
+        return mShortIntervalAppOpsArray;
     }
 
     @Override

--- a/services/core/java/com/android/server/appop/HistoricalRegistryExt.java
+++ b/services/core/java/com/android/server/appop/HistoricalRegistryExt.java
@@ -1,0 +1,109 @@
+package com.android.server.appop;
+
+import android.app.AppOpsManager;
+import android.content.Context;
+import android.util.Slog;
+import android.util.SparseBooleanArray;
+
+import com.android.server.ext.SystemErrorNotification;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static android.app.AppOpsManager.*;
+
+class HistoricalRegistryExt {
+    static final String TAG = "HistoricalRegistryExt";
+
+    static final int[] EXTRA_APP_OPS = {
+            // Manifest.permission_group.ACTIVITY_RECOGNITION
+            OP_ACTIVITY_RECOGNITION,
+            // Manifest.permission_group.CALENDAR
+            OP_READ_CALENDAR, OP_WRITE_CALENDAR,
+            // Manifest.permission_group.CALL_LOG
+            OP_READ_CALL_LOG, OP_WRITE_CALL_LOG, OP_PROCESS_OUTGOING_CALLS,
+            // Manifest.permission_group.CONTACTS
+            OP_READ_CONTACTS, OP_WRITE_CONTACTS, OP_GET_ACCOUNTS,
+            // Manifest.permission_group.NEARBY_DEVICES
+            OP_BLUETOOTH_ADVERTISE, OP_BLUETOOTH_CONNECT, OP_BLUETOOTH_SCAN, OP_UWB_RANGING,
+            OP_NEARBY_WIFI_DEVICES, OP_RANGING, // OP_ACCESS_LOCAL_NETWORK (not enabled yet)
+            // Manifest.permission_group.PHONE
+            OP_READ_PHONE_STATE, OP_READ_PHONE_NUMBERS, OP_CALL_PHONE, OP_ADD_VOICEMAIL, OP_USE_SIP,
+            OP_ANSWER_PHONE_CALLS, OP_ACCEPT_HANDOVER,
+            // Manifest.permission_group.READ_MEDIA_AURAL
+            OP_READ_MEDIA_AUDIO,
+            // Manifest.permission_group.READ_MEDIA_VISUAL
+            OP_READ_MEDIA_IMAGES, OP_READ_MEDIA_VIDEO, OP_READ_MEDIA_VISUAL_USER_SELECTED,
+            // Manifest.permission_group.SMS
+            OP_RECEIVE_SMS, OP_SEND_SMS, OP_READ_SMS, OP_RECEIVE_MMS, OP_RECEIVE_WAP_PUSH,
+            OP_READ_CELL_BROADCASTS,
+            // Manifest.permission_group.STORAGE,
+            OP_READ_EXTERNAL_STORAGE, OP_WRITE_EXTERNAL_STORAGE, OP_ACCESS_MEDIA_LOCATION,
+    };
+
+    // Permission to permission group mapping is stored in PermissionController, which is not
+    // available during system_server startup. PermissionController calls this method during startup
+    // to verify that permission usage history config is in sync between system_server and PermissionController
+    static void checkConfig(Context context, HistoricalRegistryInterface historicalRegistry, String[] extraPermissions) {
+        var expectedSet = new SparseBooleanArray(extraPermissions.length);
+        for (String perm : extraPermissions) {
+            int op = AppOpsManager.permissionToOpCode(perm);
+            if (op == AppOpsManager.OP_NONE) {
+                Slog.d(TAG, "no op for " + perm);
+                continue;
+            }
+            if (expectedSet.indexOfKey(op) >= 0) {
+                throw new IllegalStateException(perm);
+            }
+            expectedSet.put(op, true);
+        }
+
+        int[] actual = historicalRegistry.getOpCodes();
+        var actualOps = new SparseBooleanArray(actual.length);
+        for (int op : actual) {
+            actualOps.put(op, true);
+        }
+
+        var upstreamSet = new SparseBooleanArray();
+        for (int op : HistoricalRegistry.SHORT_INTERVAL_OPS) {
+            upstreamSet.put(op, true);
+        }
+        for (int op : HistoricalRegistry.IMPORTANT_OPS_FOR_SECURITY) {
+            upstreamSet.put(op, true);
+        }
+
+        var extraOps = new ArrayList<String>();
+        for (int i = 0, m = actualOps.size(); i < m; ++i) {
+            int op = actualOps.keyAt(i);
+            if (expectedSet.indexOfKey(op) < 0 && upstreamSet.indexOfKey(op) < 0) {
+                extraOps.add(AppOpsManager.opToPublicName(op));
+            }
+        }
+        var missingOps = new ArrayList<String>();
+        for (int i = 0, m = expectedSet.size(); i < m; ++i) {
+            int op = expectedSet.keyAt(i);
+            if (actualOps.indexOfKey(op) < 0) {
+                missingOps.add(AppOpsManager.opToPublicName(op));
+            }
+        }
+
+        if (extraOps.size() + missingOps.size() == 0) {
+            Slog.d(TAG, "config check has passed");
+            return;
+        }
+
+        var msg = new StringBuilder();
+        if (!missingOps.isEmpty()) {
+            msg.append("missing ops: ");
+            msg.append(Arrays.toString(missingOps.toArray()));
+        }
+        if (!extraOps.isEmpty()) {
+            if (!msg.isEmpty()) {
+                msg.append(", ");
+            }
+            msg.append("extra ops: ");
+            msg.append(Arrays.toString(extraOps.toArray()));
+        }
+        new SystemErrorNotification("AppOpHistoricalRegistry config check", msg.toString()).show(context);
+    }
+}

--- a/services/core/java/com/android/server/appop/HistoricalRegistryInterface.java
+++ b/services/core/java/com/android/server/appop/HistoricalRegistryInterface.java
@@ -105,6 +105,10 @@ public interface HistoricalRegistryInterface {
             @AppOpsManager.OpFlags int flags, @Nullable String[] attributionExemptPkgs,
             @NonNull RemoteCallback callback);
 
+    default int[] getOpCodes() {
+        throw new IllegalStateException();
+    }
+
     /**
      * Returns a set of recently used package names based on given op names and other filters.
      */

--- a/services/core/java/com/android/server/ext/SystemErrorNotification.java
+++ b/services/core/java/com/android/server/ext/SystemErrorNotification.java
@@ -5,6 +5,7 @@ import android.annotation.Nullable;
 import android.content.Context;
 import android.content.Intent;
 import android.ext.LogViewerApp;
+import android.os.Binder;
 import android.util.Slog;
 
 public class SystemErrorNotification {
@@ -32,6 +33,11 @@ public class SystemErrorNotification {
         i.putExtra(LogViewerApp.EXTRA_ERROR_TYPE, type);
         i.putExtra(LogViewerApp.EXTRA_SHOW_REPORT_BUTTON, showReportButton);
         Slog.e(TAG, type + ", title: " + title + ", message: " + message);
-        SystemJournalNotif.show(ctx, when, title, i);
+        final long identity = Binder.clearCallingIdentity();
+        try {
+            SystemJournalNotif.show(ctx, when, title, i);
+        } finally {
+            Binder.restoreCallingIdentity(identity);
+        }
     }
 }


### PR DESCRIPTION
The previous implementation of this change was broken by upstream changes and had an outdated list of recorded permissions.

Depends on: https://github.com/GrapheneOS/platform_packages_modules_Permission/pull/81