### PR TITLE
FusedLocationProvider: restore pre-16-QPR1 GNSS usage policy; add workaround for system_server startUserInBackgroundTemporarily crash

### DIFF
--- a/packages/FusedLocation/src/com/android/location/fused/FusedLocationProvider.java
+++ b/packages/FusedLocation/src/com/android/location/fused/FusedLocationProvider.java
@@ -62,9 +62,6 @@ public class FusedLocationProvider extends LocationProviderBase {
                 .build();
 
     private static final long MAX_LOCATION_COMPARISON_NS = 11 * 1000000000L; // 11 seconds
-    // Maximum request interval at which we will activate GPS (because GPS sometimes consumes
-    // excessive power with large intervals).
-    private static final long MAX_GPS_INTERVAL_MS = 5 * 1000; // 5 seconds
 
     private final Object mLock = new Object();
 
@@ -171,8 +168,7 @@ public class FusedLocationProvider extends LocationProviderBase {
             mNlpPresent = mLocationManager.hasProvider(NETWORK_PROVIDER);
         }
 
-        boolean requestAllowsGps = mRequest.getQuality() == QUALITY_HIGH_ACCURACY
-                && mRequest.getIntervalMillis() <= MAX_GPS_INTERVAL_MS;
+        boolean requestAllowsGps = !mNlpPresent || mRequest.getQuality() < LocationRequest.QUALITY_LOW_POWER;
         long gpsInterval =
                 mGpsPresent && requestAllowsGps
                         ? mRequest.getIntervalMillis() : INTERVAL_DISABLED;

--- a/services/core/java/com/android/server/am/UserController.java
+++ b/services/core/java/com/android/server/am/UserController.java
@@ -2008,6 +2008,11 @@ class UserController implements Handler.Callback {
     }
 
     boolean startUserInBackgroundTemporarily(@UserIdInt int userId, int durationSecs) {
+        synchronized (mLock) {
+            if (!mReady) {
+                return false;
+            }
+        }
         return startUserNoChecks(userId, Display.DEFAULT_DISPLAY, USER_START_MODE_BACKGROUND,
                 durationSecs, /* unlockListener= */ null);
     }

--- a/services/core/java/com/android/server/ext/TombstoneHandler.java
+++ b/services/core/java/com/android/server/ext/TombstoneHandler.java
@@ -421,7 +421,8 @@ public class TombstoneHandler {
             );
         }
 
-        if ("/apex/com.google.android.hardware.biometrics.fingerprint/bin/hw/android.hardware.biometrics.fingerprint-service.goodix".equals(cmdline[0])) {
+        if ("/apex/com.google.android.hardware.biometrics.fingerprint/bin/hw/android.hardware.biometrics.fingerprint-service.goodix".equals(cmdline[0])
+                || "/vendor/bin/hw/android.hardware.biometrics.fingerprint-service.goodix".equals(cmdline[0])) {
             // rare harmless crash, fingerprint service restarts and continues to work
             String[] functionNames = {
                     "android::VectorImpl::editArrayImpl()",

--- a/services/core/java/com/android/server/pm/KeySetManagerService.java
+++ b/services/core/java/com/android/server/pm/KeySetManagerService.java
@@ -853,14 +853,7 @@ public class KeySetManagerService {
             ArraySet<Long> pubKeys = mKeySetMapping.valueAt(i);
             final int pkSize = pubKeys.size();
             for (int j = 0; j < pkSize; j++) {
-                long pubKeyId = pubKeys.valueAt(j);
-                PublicKeyHandle key = mPublicKeys.get(pubKeyId);
-                if (key == null) {
-                    // match the logic of decrementPublicKeyLPw() above
-                    Slog.wtf(TAG, "addRefCountsFromSavedPackagesLPw: no public key with identifier " + pubKeyId);
-                } else {
-                    key.incrRefCountLPw();
-                }
+                mPublicKeys.get(pubKeys.valueAt(j)).incrRefCountLPw();
             }
         }
         final int numOrphans = orphanedKeySets.size();


### PR DESCRIPTION
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/6790
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/7103