### PR TITLE
match the initial call stack between exec and zygote spawning

### DIFF
--- a/cmds/app_process/app_main.cpp
+++ b/cmds/app_process/app_main.cpp
@@ -337,7 +337,12 @@ int main(int argc, char* const argv[])
     if (zygote) {
         runtime.start("com.android.internal.os.ZygoteInit", args, zygote);
     } else if (!className.empty()) {
-        runtime.start("com.android.internal.os.RuntimeInit", args, zygote);
+        const char* isExecSpawning = getenv("IS_EXEC_SPAWNED_APP_PROCESS");
+        if (isExecSpawning != nullptr && strcmp(isExecSpawning, "1") == 0) {
+            runtime.start("com.android.internal.os.ZygoteInit", args, false);
+        } else {
+            runtime.start("com.android.internal.os.RuntimeInit", args, zygote);
+        }
     } else {
         fprintf(stderr, "Error: no class name or --zygote supplied.\n");
         app_usage();

--- a/core/java/com/android/internal/os/ExecInit.java
+++ b/core/java/com/android/internal/os/ExecInit.java
@@ -20,6 +20,8 @@ public class ExecInit {
     private ExecInit() {
     }
 
+    public static final String IS_EXEC_SPAWNED_APP_PROCESS = "IS_EXEC_SPAWNED_APP_PROCESS";
+
     /**
      * The main function called when starting a runtime application.
      *
@@ -47,7 +49,18 @@ public class ExecInit {
 
         Zygote.nativeHandleRuntimeFlags(runtimeFlags);
 
-        r.run();
+        pendingExecInit = r;
+    }
+
+    private static Runnable pendingExecInit;
+
+    static Runnable getPendingExecInit() {
+        Runnable res = pendingExecInit;
+        if (res == null) {
+            throw new IllegalStateException("pendingExecInit is null");
+        }
+        pendingExecInit = null;
+        return res;
     }
 
     /**
@@ -84,6 +97,8 @@ public class ExecInit {
                 // checked by bionic during early init
                 Os.setenv("DISABLE_HARDENED_MALLOC", "1", true);
             }
+
+            Os.setenv(IS_EXEC_SPAWNED_APP_PROCESS, "1", true);
 
             if ((runtimeFlags & Zygote.ENABLE_COMPAT_VA_39_BIT) != 0) {
                 final int FLAG_COMPAT_VA_39_BIT = 1 << 30;

--- a/core/java/com/android/internal/os/ZygoteInit.java
+++ b/core/java/com/android/internal/os/ZygoteInit.java
@@ -828,6 +828,16 @@ public class ZygoteInit {
      */
     @UnsupportedAppUsage
     public static void main(String[] argv) {
+        if ("1".equals(Os.getenv(ExecInit.IS_EXEC_SPAWNED_APP_PROCESS))) {
+            Log.d(TAG, "IS_EXEC_SPAWNED_APP_PROCESS is 1");
+            RuntimeInit.main(argv);
+            // Some apps perform a weak security check by looking at the main thread stack trace.
+            // Executing the ExecInit.execInit() runnable from here makes the exec spawning call
+            // stack match the zygote spawning call stack
+            ExecInit.getPendingExecInit().run();
+            return;
+        }
+
         ZygoteServer zygoteServer = null;
 
         // Mark zygote start. This ensures that thread creation will throw


### PR DESCRIPTION
Some apps perform a weak security check by looking at the main thread stack trace.