### PR TITLE
fixup! add second factor to fingerprint unlock

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/BiometricUnlockController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/BiometricUnlockController.java
@@ -438,6 +438,10 @@ public class BiometricUnlockController extends KeyguardUpdateMonitorCallback imp
         Trace.beginSection("BiometricUnlockController#onBiometricAuthenticated");
         try {
             if (mUpdateMonitor.isGoingToSleep()) {
+                if (secondFactorStatus == SecondFactorStatus.Enabled) {
+                    mUpdateMonitor.clearFingerprintRecognized();
+                    return;
+                }
                 mLogger.deferringAuthenticationDueToSleep(userId,
                         biometricSourceType,
                         mPendingAuthenticated != null);
@@ -903,13 +907,6 @@ public class BiometricUnlockController extends KeyguardUpdateMonitorCallback imp
                         PendingAuthenticated pendingAuthenticated = mPendingAuthenticated;
                         // Post this to make sure it's executed after the device is fully locked.
                         mHandler.post(() -> {
-                            // Needed for SecurityMode.BiometricSecondFactorPin.
-                            if (pendingAuthenticated.biometricSourceType ==
-                                    BiometricSourceType.FINGERPRINT) {
-                                mUpdateMonitor.setUserAuthenticatedWithFingerprint(
-                                        pendingAuthenticated.userId,
-                                        pendingAuthenticated.isStrongBiometric);
-                            }
                             onBiometricAuthenticated(pendingAuthenticated.userId,
                                 pendingAuthenticated.biometricSourceType,
                                 pendingAuthenticated.isStrongBiometric,


### PR DESCRIPTION
The 2FA implementation was catching its own minor bug and as a result the second factor lockscreen was unable to be dismissed when a fingerprint was authenticated after KeyguardUpdateMonitor started going to sleep.

Now, when 2FA is enabled, fingerprint authentication after the device has started going to sleep will be ignored. It is rare that a fingerprint gets authenticated during this tiny window, so this will not be noticeable or reduce user experience.

Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/6089