### PR TITLE
gmscompat: notify for RCS permissions if Bugle tries to verifies number & change API for updating package states

### DIFF
--- a/core/api/system-current.txt
+++ b/core/api/system-current.txt
@@ -12845,7 +12845,6 @@ package android.permission {
     method @RequiresPermission(android.Manifest.permission.MANAGE_ONE_TIME_PERMISSION_SESSIONS) public void startOneTimePermissionSession(@NonNull String, long, long, int, int);
     method @RequiresPermission(android.Manifest.permission.MANAGE_ONE_TIME_PERMISSION_SESSIONS) public void stopOneTimePermissionSession(@NonNull String);
     method @FlaggedApi("android.permission.flags.device_aware_permission_apis_enabled") @RequiresPermission(anyOf={android.Manifest.permission.GRANT_RUNTIME_PERMISSIONS, android.Manifest.permission.REVOKE_RUNTIME_PERMISSIONS}) public void updatePermissionFlags(@NonNull String, @NonNull String, @NonNull String, int, int);
-    method public void updatePermissionState(@NonNull String, int);
     field @RequiresPermission(android.Manifest.permission.START_REVIEW_PERMISSION_DECISIONS) public static final String ACTION_REVIEW_PERMISSION_DECISIONS = "android.permission.action.REVIEW_PERMISSION_DECISIONS";
     field public static final String EXTRA_PERMISSION_USAGES = "android.permission.extra.PERMISSION_USAGES";
     field public static final int PERMISSION_GRANTED = 0; // 0x0

--- a/core/java/android/app/ContextImpl.java
+++ b/core/java/android/app/ContextImpl.java
@@ -2610,6 +2610,11 @@ class ContextImpl extends Context {
             throw new IllegalArgumentException("permission is null");
         }
 
+        // TODO: In Android 17, READ_PRIVILEGED_PHONE_STATE will no longer be accepted for
+        //  TelephonyManager#getIccAuthentication. However, Manifest.permission.USE_ICC_AUTH was
+        //  introduced. getIccAuthentication can accept this new permission along with preexisting
+        //  Manifest.permission.USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER. Need to pay attention to how
+        //  GmsCore uses USE_ICC_AUTH or USE_ICC_AUTH_WITH_DEVICE_IDENTIFIER.
         if (GmsCompat.isGmsCore() &&
                 android.Manifest.permission.READ_PRIVILEGED_PHONE_STATE.equals(permission)) {
             if (Log.isLoggable(TAG_SPOOF, Log.VERBOSE)) {

--- a/core/java/android/os/Binder.java
+++ b/core/java/android/os/Binder.java
@@ -769,11 +769,13 @@ public class Binder implements IBinder {
 
         if (GmsCompat.isGmsCore()) {
             mIsGmsServiceBroker = GmsHooks.GMS_SERVICE_BROKER_INTERFACE_DESCRIPTOR.equals(descriptor);
+            mIsGmsConstellationService = GmsHooks.GMS_CONSTELLATION_SERVICE_INTERFACE_DESCRIPTOR.equals(descriptor);
         }
     }
 
     private boolean mIsIGmsCallbacks;
     private boolean mIsGmsServiceBroker;
+    private boolean mIsGmsConstellationService;
 
     /**
      * Default implementation returns an empty interface name.
@@ -1496,6 +1498,8 @@ public class Binder implements IBinder {
         try {
             if (mIsGmsServiceBroker) {
                 onBeginGmsServiceBrokerCallRet = GmsHooks.onBeginGmsServiceBrokerCall(code, data);
+            } else if (mIsGmsConstellationService) {
+                GmsHooks.onBeginGmsConstellationServiceCall(code, data);
             }
             // TODO(b/299356201) - this logic should not be in Java - it should be in native
             // code in libbinder so that it works for all binder users.

--- a/core/java/android/permission/IPermissionManager.aidl
+++ b/core/java/android/permission/IPermissionManager.aidl
@@ -110,8 +110,6 @@ interface IPermissionManager {
     Map<String, PermissionState> getAllPermissionStates(String packageName, String persistentDeviceId, int userId);
 
     int getPermissionRequestState(String packageName, String permissionName, int deviceId);
-
-    void updatePermissionState(String packageName, int userId);
 }
 
 /**

--- a/core/java/android/permission/IPermissionManager.aidl
+++ b/core/java/android/permission/IPermissionManager.aidl
@@ -110,6 +110,8 @@ interface IPermissionManager {
     Map<String, PermissionState> getAllPermissionStates(String packageName, String persistentDeviceId, int userId);
 
     int getPermissionRequestState(String packageName, String permissionName, int deviceId);
+
+    void updatePermissionStateAndInvalidateCache(String packageName, int userId);
 }
 
 /**

--- a/core/java/android/permission/PermissionManager.java
+++ b/core/java/android/permission/PermissionManager.java
@@ -2282,12 +2282,4 @@ public final class PermissionManager {
                     + '}';
         }
     }
-
-    public void updatePermissionState(@NonNull String packageName, int userId) {
-        try {
-            mPermissionManager.updatePermissionState(packageName, userId);
-        } catch (RemoteException e) {
-            e.rethrowFromSystemServer();
-        }
-    }
 }

--- a/core/java/android/permission/PermissionManager.java
+++ b/core/java/android/permission/PermissionManager.java
@@ -2282,4 +2282,13 @@ public final class PermissionManager {
                     + '}';
         }
     }
+
+    /** @hide */
+    public void updatePermissionStateAndInvalidateCache(@NonNull String packageName, int userId) {
+        try {
+            mPermissionManager.updatePermissionStateAndInvalidateCache(packageName, userId);
+        } catch (RemoteException e) {
+            e.rethrowFromSystemServer();
+        }
+    }
 }

--- a/core/java/com/android/internal/gmscompat/GmsHooks.java
+++ b/core/java/com/android/internal/gmscompat/GmsHooks.java
@@ -37,7 +37,9 @@ import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.ext.PackageId;
 import android.net.Uri;
+import android.os.Binder;
 import android.os.Bundle;
 import android.os.DeadSystemRuntimeException;
 import android.os.IBinder;
@@ -670,6 +672,56 @@ public final class GmsHooks {
         tlPermissionsToSpoof.set(null);
         // invalidate the cache of permission state inside GmsCore
         GmcPackageManager.notifyPermissionsChangeListeners();
+    }
+
+    public static final String GMS_CONSTELLATION_SERVICE_INTERFACE_DESCRIPTOR =
+            "com.google.android.gms.constellation.internal.IConstellationApiService";
+
+    public static void onBeginGmsConstellationServiceCall(int transactionCode, Parcel data) {
+        if (transactionCode != 3) { // verifyPhoneNumber V2 method
+            return;
+        }
+
+        try {
+            final var ctx = GmsCompat.appContext();
+            if (ctx == null) return;
+            final var callingPkg = ctx.getPackageManager().getNameForUid(Binder.getCallingUid());
+            // Ensure we're only sending RCS permission notifications for Bugle phone number
+            // verification attempts.
+            //
+            // GmsServiceBroker also does validation of allowed packages, but it doesn't seem it's
+            // restricted to only Bugle. For the Constellation service (155), the
+            // VerifyPhoneNumberApi__packages_allowed_to_call flag (proto list) also includes other
+            // apps like com.google.android.dialer, etc. in its default value.
+            if (!PackageId.BUGLE_NAME.equals(callingPkg)) {
+                Log.d(TAG, "onBeginGmsConstellationServiceCall code " + transactionCode + ", unexpected callingPkg " + callingPkg);
+                return;
+            }
+
+            data.enforceInterface(GMS_CONSTELLATION_SERVICE_INTERFACE_DESCRIPTOR);
+            // IConstellationCallbacks binder
+            data.readStrongBinder();
+
+            if (data.readInt() == 1) { // VerifyPhoneNumberRequest is present
+                IGmsCompatLib lib = GmsCompatLib.get();
+                final String policyId = lib.parseVerifyPhoneNumberRequestForPolicy(data);
+                final boolean isTs43Verification = policyId != null &&
+                        policyId.startsWith("upi-") &&
+                        policyId.contains("ts43");
+                Log.d(TAG, "onBeginGmsConstellationServiceCall: policyId " + policyId);
+                // We could also decode the Bundle field in VerifyPhoneNumberRequest which
+                // stores the key-value "required_consumer_consent" -> "RCS", and check
+                // for this. However, this is set as an "API param", so it's not as backwards
+                // compatible or guaranteed as the String property in the VerifyPhoneNumberRequest
+                // class
+                GmsCompatApp.iGms2Gca()
+                        .maybeShowRcsRequirementsNotification(isTs43Verification);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "onBeginGmsConstellationServiceCall: failed", e);
+        } finally {
+            data.setDataPosition(0);
+        }
     }
 
     public static IBinder maybeOverrideBinder(IBinder binder) {

--- a/core/java/com/android/internal/gmscompat/IGms2Gca.aidl
+++ b/core/java/com/android/internal/gmscompat/IGms2Gca.aidl
@@ -47,4 +47,6 @@ interface IGms2Gca {
     Notification getMediaProjectionNotification();
 
     void raisePackageToForeground(String targetPkg, long durationMs, @nullable String reason, int reasonCode);
+
+    oneway void maybeShowRcsRequirementsNotification(boolean isTs43Verification);
 }

--- a/core/java/com/android/internal/gmscompat/IGmsCompatLib.java
+++ b/core/java/com/android/internal/gmscompat/IGmsCompatLib.java
@@ -7,9 +7,11 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.BinderProxy;
 import android.os.IInterface;
+import android.os.Parcel;
 import android.os.UserHandle;
 
 import java.io.FileDescriptor;
+import java.text.ParseException;
 import java.util.concurrent.Executor;
 
 public interface IGmsCompatLib {
@@ -26,4 +28,22 @@ public interface IGmsCompatLib {
     /** @see BinderProxy#dump(FileDescriptor, String[])
      *  @see BinderProxy#dumpAsync(FileDescriptor, String[]) */
     boolean maybeInterceptBinderProxyDump(BinderProxy binderProxy, FileDescriptor fd, String[] args, boolean async);
+
+    /**
+     * Parses a {@code com.google.android.gms.constellation.VerifyPhoneNumberRequest} and returns
+     * its policy id.
+     * <p>
+     * This is not a replacement for {@link Parcel#readTypedObject}, so a
+     * {@link Parcel#readInt} == 1 check should be done beforehand if {@code data} is from a
+     * transaction. This is more of a replacement for direct {@code
+     * VerifyPhoneNumberRequest.CREATOR} usage.
+     * <p>
+     * If any exceptions are thrown (exceptions from {@link Parcel} reading), the data position will
+     * be in an undefined position.
+     *
+     * @param data The data where the {@code VerifyPhoneNumberRequest} is in. Initial data position
+     *             should be at the header of the {@code VerifyPhoneNumberRequest}.
+     */
+    @Nullable
+    String parseVerifyPhoneNumberRequestForPolicy(Parcel data) throws ParseException;
 }

--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -6620,6 +6620,10 @@
     <permission android:name="android.permission.INSTALL_GRANT_RUNTIME_PERMISSIONS"
         android:protectionLevel="signature|installer|verifier" />
 
+    <!--- @hide -->
+    <permission android:name="android.permission.UPDATE_AND_INVALIDATE_PERMISSION_STATE"
+        android:protectionLevel="internal|preinstalled" />
+
     <!-- @SystemApi Allows an application to revoke specific permissions.
         @hide -->
     <permission android:name="android.permission.REVOKE_RUNTIME_PERMISSIONS"

--- a/packages/Shell/AndroidManifest.xml
+++ b/packages/Shell/AndroidManifest.xml
@@ -1052,6 +1052,8 @@
     <!-- Permission required for CTS test - CtsMediaProjectionTestCases -->
     <uses-permission android:name="android.permission.MANAGE_MEDIA_PROJECTION" />
 
+    <!--  Permission required for GrapheneOS package state updates -->
+    <uses-permission android:name="android.permission.UPDATE_AND_INVALIDATE_PERMISSION_STATE" />
 
     <application
         android:label="@string/app_label"

--- a/services/core/java/com/android/server/pm/GosPackageStatePermissions.java
+++ b/services/core/java/com/android/server/pm/GosPackageStatePermissions.java
@@ -117,6 +117,7 @@ class GosPackageStatePermissions {
         builder()
                 .readFlags(playIntegrityFlags)
                 .readWriteFlag(SUPPRESS_PLAY_INTEGRITY_API_NOTIF)
+                .readWriteFields(FIELD_PACKAGE_FLAGS)
                 .apply(GmsCompatApp.PKG_NAME, computer);
 
         @GosPackageStateFlag.Enum int[] settingsReadWriteFlags = {

--- a/services/core/java/com/android/server/pm/GosPackageStatePmHooks.java
+++ b/services/core/java/com/android/server/pm/GosPackageStatePmHooks.java
@@ -341,7 +341,8 @@ public class GosPackageStatePmHooks {
                     return 1;
                 }
                 if (updatePermissionState) {
-                    cmd.mPermissionManager.updatePermissionState(packageName, userId);
+                    cmd.mPermissionManager.updatePermissionStateAndInvalidateCache(
+                            packageName, userId);
                 }
                 return 0;
             }

--- a/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
+++ b/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
@@ -495,21 +495,6 @@ public class PermissionManagerService extends IPermissionManager.Stub {
         return result;
     }
 
-    @Override
-    public void updatePermissionState(String packageName, int userId) {
-        mContext.enforceCallingPermission(
-                android.Manifest.permission.GRANT_RUNTIME_PERMISSIONS,
-                "updatePermissionState");
-
-        PackageState packageState = mPackageManagerInt.getPackageStateInternal(packageName);
-        if (packageState == null) {
-            Slog.w(LOG_TAG, "updatePermissionState: no PackageState for " + packageName);
-            return;
-        }
-
-        mPermissionManagerServiceImpl.updatePermissions(packageState, userId);
-    }
-
     /* Start of delegate methods to PermissionManagerServiceInterface */
 
     @Override

--- a/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
+++ b/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
@@ -39,6 +39,7 @@ import android.annotation.Nullable;
 import android.annotation.SpecialUsers.CanBeALL;
 import android.annotation.UserIdInt;
 import android.app.ActivityManager;
+import android.app.AppGlobals;
 import android.app.AppOpsManager;
 import android.app.AppOpsManager.AttributionFlags;
 import android.app.IActivityManager;
@@ -493,6 +494,70 @@ public class PermissionManagerService extends IPermissionManager.Stub {
             }
         }, userId);
         return result;
+    }
+
+    @Override
+    public void updatePermissionStateAndInvalidateCache(String packageName, int userId) {
+        mContext.enforceCallingPermission(
+                android.Manifest.permission.UPDATE_AND_INVALIDATE_PERMISSION_STATE,
+                "updatePermissionStateAndInvalidateCache");
+
+        final int callingUid = Binder.getCallingUid();
+        if (UserHandle.getUserId(callingUid) != userId) {
+            final boolean isCallerAllowed = mContext.checkCallingPermission(
+                    Manifest.permission.INTERACT_ACROSS_USERS_FULL)
+                    == PackageManager.PERMISSION_GRANTED;
+            if (!isCallerAllowed) {
+                throw new SecurityException(
+                        "uid " + callingUid + " can't update state for " + userId);
+            }
+            Slog.w(LOG_TAG, "updatePermissionStateAndInvalidateCache: cross user granted for " + callingUid);
+        }
+
+        final String callingPackage;
+        {
+            final AndroidPackage callingAndroidPackage = mPackageManagerInt.getPackage(callingUid);
+            if (callingAndroidPackage == null) {
+                Slog.w(LOG_TAG, "updatePermissionStateAndInvalidateCache: no callingPackage "
+                        + "for uid " + callingUid);
+                return;
+            }
+            callingPackage = callingAndroidPackage.getPackageName();
+        }
+
+        PackageState packageState = mPackageManagerInt.getPackageStateInternal(packageName);
+        if (packageState == null) {
+            Slog.w(LOG_TAG, "updatePermissionStateAndInvalidateCache: no PackageState "
+                    + "for " + packageName);
+            return;
+        }
+        mPermissionManagerServiceImpl.updatePermissions(packageState, userId);
+
+        final var pm = AppGlobals.getPackageManager();
+
+        final long identity = Binder.clearCallingIdentity();
+        try {
+            final var appInfo = pm.getApplicationInfo(packageName, 0, userId);
+            if (appInfo == null) {
+                Slog.w(LOG_TAG, "updatePermissionStateAndInvalidateCache: no "
+                        + "appInfo for " + packageName);
+                return;
+            }
+
+            if (appInfo.enabled) {
+                // Invalidate cached system_server state; clearing identity, since this requires
+                // Manifest.permission.CHANGE_COMPONENT_ENABLED_STATE
+                pm.setApplicationEnabledSetting(packageName,
+                        PackageManager.COMPONENT_ENABLED_STATE_DISABLED, 0, userId, callingPackage);
+                pm.setApplicationEnabledSetting(packageName,
+                        PackageManager.COMPONENT_ENABLED_STATE_ENABLED, 0, userId, callingPackage);
+            }
+        } catch (RemoteException e) {
+            Slog.e(LOG_TAG, "updatePermissionStateAndInvalidateCache: failed "
+                    + "for " + packageName, e);
+        } finally {
+            Binder.restoreCallingIdentity(identity);
+        }
     }
 
     /* Start of delegate methods to PermissionManagerServiceInterface */


### PR DESCRIPTION
Changeset: 
- https://github.com/GrapheneOS/platform_packages_apps_GmsCompat/pull/270
- https://github.com/GrapheneOS/platform_packages_modules_Permission/pull/86

As the toggle for RCS activation from version [2026021200](https://grapheneos.org/releases#2026021200) is working for a lot of users, we should make it more accessible and generally inform the user about what permissions are needed for RCS activation. We want to avoid telling users to activate the ICC toggle unconditionally, as some carriers don't need it.

Adds a potential notification for missing RCS permissions when Bugle calls `IConstellationApiService#verifyPhoneNumber` for RCS configuration and activation. We detect if their policy is a TS.43 policy; this would be a case where the user would need the ICC auth toggle enabled.

To accommodate GmsCompat config screens being moved to the GmsCompat app, a new API + permission is also added