### PR TITLE
Add a toggle to allow screenshots through FLAG SECURE

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -13769,6 +13769,19 @@ public final class Settings {
         public static final String DISABLE_SECURE_WINDOWS = "disable_secure_windows";
 
         /**
+
+         Whether to allow user-initiated screenshots of secure windows.
+
+         When this setting is set to a non-zero value, user-initiated screenshots
+         will capture content in windows with
+         {@link android.view.WindowManager.LayoutParams#FLAG_SECURE}.
+         Other FLAG_SECURE behaviors (recents thumbnails, casting, screen recording)
+         are preserved.
+         @hide */
+        public static final String FORCE_SCREENSHOT_SECURE_WINDOWS = "force_screenshot_secure_windows";
+
+
+        /**
          * Controls if the adaptive authentication feature should be disabled, which
          * will attempt to lock the device after a number of consecutive authentication
          * attempts fail.

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -14140,6 +14140,20 @@ public final class Settings {
                 "force_screenshot_secure_windows";
 
         /**
+         * Whether the built-in screen recorder should capture secure windows.
+         *
+         * <p>When this setting is set to a non-zero value, recordings started from the system
+         * screen recorder capture content in windows with
+         * {@link android.view.WindowManager.LayoutParams#FLAG_SECURE}. Recordings made by other
+         * apps through {@link android.media.projection.MediaProjection} are left unchanged, as is
+         * every other FLAG_SECURE behaviour.
+         *
+         * @hide
+         */
+        public static final String FORCE_SCREEN_RECORD_SECURE_WINDOWS =
+                "force_screen_record_secure_windows";
+
+        /**
          * Controls if the adaptive authentication feature should be disabled, which
          * will attempt to lock the device after a number of consecutive authentication
          * attempts fail.

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -14128,6 +14128,18 @@ public final class Settings {
         public static final String DISABLE_SECURE_WINDOWS = "disable_secure_windows";
 
         /**
+         * Whether user-initiated screenshots should capture secure windows.
+         *
+         * <p>When this setting is set to a non-zero value, screenshots capture content in windows
+         * with {@link android.view.WindowManager.LayoutParams#FLAG_SECURE}. Every other
+         * FLAG_SECURE behaviour, such as recents thumbnails and casting, is left unchanged.
+         *
+         * @hide
+         */
+        public static final String FORCE_SCREENSHOT_SECURE_WINDOWS =
+                "force_screenshot_secure_windows";
+
+        /**
          * Controls if the adaptive authentication feature should be disabled, which
          * will attempt to lock the device after a number of consecutive authentication
          * attempts fail.

--- a/packages/SettingsProvider/test/src/android/provider/SettingsBackupTest.java
+++ b/packages/SettingsProvider/test/src/android/provider/SettingsBackupTest.java
@@ -706,6 +706,7 @@ public class SettingsBackupTest {
                  Settings.Secure.ENABLED_NOTIFICATION_LISTENERS,
                  Settings.Secure.ENABLED_NOTIFICATION_POLICY_ACCESS_PACKAGES,
                  Settings.Secure.ENABLED_PRINT_SERVICES,
+                 Settings.Secure.FORCE_SCREEN_RECORD_SECURE_WINDOWS,
                  Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS,
                  Settings.Secure.GLOBAL_ACTIONS_PANEL_AVAILABLE,
                  Settings.Secure.GLOBAL_ACTIONS_PANEL_DEBUG_ENABLED,

--- a/packages/SettingsProvider/test/src/android/provider/SettingsBackupTest.java
+++ b/packages/SettingsProvider/test/src/android/provider/SettingsBackupTest.java
@@ -706,6 +706,7 @@ public class SettingsBackupTest {
                  Settings.Secure.ENABLED_NOTIFICATION_LISTENERS,
                  Settings.Secure.ENABLED_NOTIFICATION_POLICY_ACCESS_PACKAGES,
                  Settings.Secure.ENABLED_PRINT_SERVICES,
+                 Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS,
                  Settings.Secure.GLOBAL_ACTIONS_PANEL_AVAILABLE,
                  Settings.Secure.GLOBAL_ACTIONS_PANEL_DEBUG_ENABLED,
                  Settings.Secure.INCALL_BACK_BUTTON_BEHAVIOR,

--- a/packages/SystemUI/AndroidManifest.xml
+++ b/packages/SystemUI/AndroidManifest.xml
@@ -183,6 +183,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAPTURE_AUDIO_OUTPUT"/>
+    <uses-permission android:name="android.permission.CAPTURE_SECURE_VIDEO_OUTPUT"/>
     <uses-permission android:name="android.permission.USE_EXACT_ALARM"/>
     <uses-permission android:name="android.permission.RECORD_SENSITIVE_CONTENT"/>
 

--- a/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
+++ b/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
@@ -49,6 +49,7 @@ import android.os.IBinder;
 import android.os.RemoteException;
 import android.os.ServiceManager;
 import android.provider.MediaStore;
+import android.provider.Settings;
 import android.text.format.DateUtils;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -189,12 +190,16 @@ public class ScreenMediaRecorder {
         mMediaRecorder.prepare();
         // Create surface
         mInputSurface = mMediaRecorder.getSurface();
+        int displayFlags = DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR;
+        if (shouldCaptureSecureWindows()) {
+            displayFlags |= DisplayManager.VIRTUAL_DISPLAY_FLAG_SECURE;
+        }
         mVirtualDisplay = mMediaProjection.createVirtualDisplay(
                 "Recording Display",
                 videoParameters.mWidth,
                 videoParameters.mHeight,
                 metrics.densityDpi,
-                DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+                displayFlags,
                 mInputSurface,
                 new VirtualDisplay.Callback() {
                     @Override
@@ -213,6 +218,11 @@ public class ScreenMediaRecorder {
                     mMediaProjection, mAudioSource == MIC_AND_INTERNAL);
         }
 
+    }
+
+    private boolean shouldCaptureSecureWindows() {
+        return Settings.Secure.getInt(mContext.getContentResolver(),
+                Settings.Secure.FORCE_SCREEN_RECORD_SECURE_WINDOWS, 0) != 0;
     }
 
     /**

--- a/services/core/java/com/android/server/wm/WindowManagerService.java
+++ b/services/core/java/com/android/server/wm/WindowManagerService.java
@@ -113,6 +113,7 @@ import static android.window.DesktopExperienceFlags.ENABLE_PRESENTATION_FOR_CONN
 import static android.window.ScreenCapture.ScreenCaptureParams.CAPTURE_MODE_REQUIRE_OPTIMIZED;
 import static android.window.ScreenCapture.ScreenCaptureParams.PROTECTED_CONTENT_POLICY_THROW_EXCEPTION;
 import static android.window.ScreenCapture.ScreenCaptureParams.SECURE_CONTENT_POLICY_THROW_EXCEPTION;
+import static android.window.ScreenCapture.ScreenCaptureParams.SECURE_CONTENT_POLICY_CAPTURE;
 import static android.window.WindowProviderService.isWindowProviderService;
 
 import static com.android.internal.protolog.WmProtoLogGroups.WM_DEBUG_ADD_REMOVE;
@@ -835,6 +836,8 @@ public class WindowManagerService extends IWindowManager.Stub
                 Settings.Secure.getUriFor(Settings.Secure.IMMERSIVE_MODE_CONFIRMATIONS);
         private final Uri mDisableSecureWindowsUri =
                 Settings.Secure.getUriFor(Settings.Secure.DISABLE_SECURE_WINDOWS);
+        private final Uri mForceScreenshotSecureWindowsUri =
+                Settings.Secure.getUriFor(Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS);
         private final Uri mMagnifyImeEnabledUri = Settings.Secure.getUriFor(
                 Settings.Secure.ACCESSIBILITY_MAGNIFICATION_MAGNIFY_NAV_AND_IME);
         private final Uri mPolicyControlUri =
@@ -869,6 +872,9 @@ public class WindowManagerService extends IWindowManager.Stub
                     UserHandle.USER_ALL);
             resolver.registerContentObserver(mDisableSecureWindowsUri, false, this,
                     UserHandle.USER_ALL);
+            resolver.registerContentObserver(mForceScreenshotSecureWindowsUri, false, this,
+                    UserHandle.USER_ALL);
+
             if (com.android.server.accessibility.Flags.enableMagnificationMagnifyNavBarAndIme()) {
                 resolver.registerContentObserver(mMagnifyImeEnabledUri, false, this,
                         UserHandle.USER_ALL);
@@ -934,6 +940,11 @@ public class WindowManagerService extends IWindowManager.Stub
                 return;
             }
 
+            if (mForceScreenshotSecureWindowsUri.equals(uri)) {
+                updateForceScreenshotSecureWindows();
+                return;
+            }
+
             if (mMagnifyImeEnabledUri.equals(uri)) {
                 updateMagnifyIme();
             }
@@ -962,6 +973,7 @@ public class WindowManagerService extends IWindowManager.Stub
         void loadSettings() {
             updateMaximumObscuringOpacityForTouch();
             updateDisableSecureWindows();
+            updateForceScreenshotSecureWindows();
             updateMagnifyIme();
         }
 
@@ -1072,6 +1084,19 @@ public class WindowManagerService extends IWindowManager.Stub
             }
         }
 
+        void updateForceScreenshotSecureWindows() {
+
+            boolean forceScreenshotSecureWindows;
+            try {
+                forceScreenshotSecureWindows = Settings.Secure.getIntForUser(
+                        mContext.getContentResolver(),
+                        Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS, 0) != 0;
+            } catch (Settings.SettingNotFoundException e) {
+                forceScreenshotSecureWindows = false;
+            }
+            mForceScreenshotSecureWindows = forceScreenshotSecureWindows;
+        }
+        
         void updateMagnifyIme() {
             if (!com.android.server.accessibility.Flags.enableMagnificationMagnifyNavBarAndIme()) {
                 mMagnifyIme = false;
@@ -1247,6 +1272,7 @@ public class WindowManagerService extends IWindowManager.Stub
     private final ScreenRecordingCallbackController mScreenRecordingCallbackController;
 
     private volatile boolean mDisableSecureWindows = false;
+    private volatile boolean mForceScreenshotSecureWindows = false;
 
     /** Creates an instance of the WindowManagerService for the system server. */
     public static WindowManagerService main(@NonNull final Context context,
@@ -10669,10 +10695,17 @@ public class WindowManagerService extends IWindowManager.Stub
             }
         }
 
-        return new ScreenCaptureInternal.LayerCaptureArgs.Builder(
+        ScreenCaptureInternal.LayerCaptureArgs.Builder builder =
+                new ScreenCaptureInternal.LayerCaptureArgs.Builder(
                         displaySurfaceControl, captureArgs)
-                .setSourceCrop(mTmpRect)
-                .build();
+                        .setSourceCrop(mTmpRect);
+
+        if (mForceScreenshotSecureWindows) {
+            builder = builder.setSecureContentPolicy(
+                    SECURE_CONTENT_POLICY_CAPTURE);
+        }
+
+        return builder.build();
     }
 
     @Override
@@ -10868,6 +10901,10 @@ public class WindowManagerService extends IWindowManager.Stub
 
     boolean getDisableSecureWindows() {
         return mDisableSecureWindows;
+    }
+
+    boolean getForceScreenshotSecureWindows() {
+        return mForceScreenshotSecureWindows;
     }
 
     /**

--- a/services/core/java/com/android/server/wm/WindowManagerService.java
+++ b/services/core/java/com/android/server/wm/WindowManagerService.java
@@ -114,6 +114,7 @@ import static android.view.displayhash.DisplayHashResultCallback.DISPLAY_HASH_ER
 import static android.view.flags.Flags.sensitiveContentAppProtection;
 import static android.window.ScreenCapture.ScreenCaptureParams.CAPTURE_MODE_REQUIRE_OPTIMIZED;
 import static android.window.ScreenCapture.ScreenCaptureParams.PROTECTED_CONTENT_POLICY_THROW_EXCEPTION;
+import static android.window.ScreenCapture.ScreenCaptureParams.SECURE_CONTENT_POLICY_CAPTURE;
 import static android.window.ScreenCapture.ScreenCaptureParams.SECURE_CONTENT_POLICY_THROW_EXCEPTION;
 import static android.window.WindowProviderService.isWindowProviderService;
 
@@ -844,6 +845,8 @@ public class WindowManagerService extends IWindowManager.Stub
                 Settings.Secure.getUriFor(Settings.Secure.IMMERSIVE_MODE_CONFIRMATIONS);
         private final Uri mDisableSecureWindowsUri =
                 Settings.Secure.getUriFor(Settings.Secure.DISABLE_SECURE_WINDOWS);
+        private final Uri mForceScreenshotSecureWindowsUri =
+                Settings.Secure.getUriFor(Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS);
         private final Uri mMagnifyImeEnabledUri = Settings.Secure.getUriFor(
                 Settings.Secure.ACCESSIBILITY_MAGNIFICATION_MAGNIFY_NAV_AND_IME);
         private final Uri mPolicyControlUri =
@@ -877,6 +880,8 @@ public class WindowManagerService extends IWindowManager.Stub
             resolver.registerContentObserver(mImmersiveModeConfirmationsUri, false, this,
                     UserHandle.USER_ALL);
             resolver.registerContentObserver(mDisableSecureWindowsUri, false, this,
+                    UserHandle.USER_ALL);
+            resolver.registerContentObserver(mForceScreenshotSecureWindowsUri, false, this,
                     UserHandle.USER_ALL);
             resolver.registerContentObserver(mMagnifyImeEnabledUri, false, this,
                     UserHandle.USER_ALL);
@@ -941,6 +946,11 @@ public class WindowManagerService extends IWindowManager.Stub
                 return;
             }
 
+            if (mForceScreenshotSecureWindowsUri.equals(uri)) {
+                updateForceScreenshotSecureWindows();
+                return;
+            }
+
             if (mMagnifyImeEnabledUri.equals(uri)) {
                 updateMagnifyIme();
             }
@@ -969,6 +979,7 @@ public class WindowManagerService extends IWindowManager.Stub
         void loadSettings() {
             updateMaximumObscuringOpacityForTouch();
             updateDisableSecureWindows();
+            updateForceScreenshotSecureWindows();
             updateMagnifyIme();
         }
 
@@ -1077,6 +1088,15 @@ public class WindowManagerService extends IWindowManager.Stub
                 mDisableSecureWindows = disableSecureWindows;
                 mRoot.refreshSecureSurfaceState();
             }
+        }
+
+        void updateForceScreenshotSecureWindows() {
+            // Get the value of the current user. The Settings toggle writes the value to the
+            // user that changed it.
+            mForceScreenshotSecureWindows = Settings.Secure.getIntForUser(
+                    mContext.getContentResolver(),
+                    Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS, /* def= */ 0,
+                    UserHandle.USER_CURRENT) != 0;
         }
 
         void updateMagnifyIme() {
@@ -1284,6 +1304,7 @@ public class WindowManagerService extends IWindowManager.Stub
     private final ScreenRecordingCallbackController mScreenRecordingCallbackController;
 
     private volatile boolean mDisableSecureWindows = false;
+    private volatile boolean mForceScreenshotSecureWindows = false;
 
     /** Creates an instance of the WindowManagerService for the system server. */
     public static WindowManagerService main(@NonNull final Context context,
@@ -11095,10 +11116,14 @@ public class WindowManagerService extends IWindowManager.Stub
             }
         }
 
-        return new ScreenCaptureInternal.LayerCaptureArgs.Builder(
+        final ScreenCaptureInternal.LayerCaptureArgs.Builder builder =
+                new ScreenCaptureInternal.LayerCaptureArgs.Builder(
                         displaySurfaceControl, captureArgs)
-                .setSourceCrop(mTmpRect)
-                .build();
+                        .setSourceCrop(mTmpRect);
+        if (mForceScreenshotSecureWindows) {
+            builder.setSecureContentPolicy(SECURE_CONTENT_POLICY_CAPTURE);
+        }
+        return builder.build();
     }
 
     @Override

--- a/services/tests/wmtests/src/com/android/server/wm/WindowManagerServiceTests.java
+++ b/services/tests/wmtests/src/com/android/server/wm/WindowManagerServiceTests.java
@@ -84,6 +84,7 @@ import android.app.ActivityThread;
 import android.app.IApplicationThread;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
+import android.content.ContentResolver;
 import android.graphics.Rect;
 import android.os.Binder;
 import android.os.IBinder;
@@ -121,6 +122,7 @@ import android.window.ActivityWindowInfo;
 import android.window.ClientWindowFrames;
 import android.window.ConfigurationChangeSetting;
 import android.window.InputTransferToken;
+import android.window.ScreenCapture;
 import android.window.ScreenCaptureInternal;
 import android.window.WindowContainerToken;
 
@@ -1364,6 +1366,30 @@ public class WindowManagerServiceTests extends WindowTestsBase {
         assertEquals(validRect, resultingArgs.mSourceCrop);
     }
 
+    @Test
+    public void testCaptureArgs_forceScreenshotSecureWindows() {
+        Rect displayBounds = new Rect(0, 0, 100, 200);
+        spyOn(mDisplayContent);
+        when(mDisplayContent.getBounds()).thenReturn(displayBounds);
+        ContentResolver cr = useFakeSettingsProvider();
+
+        // secureContentPolicy should be REDACT (default) when setting is disabled
+        Settings.Secure.putInt(cr, Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS, 0);
+        mWm.mSettingsObserver.onChange(false,
+                Settings.Secure.getUriFor(Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS));
+        ScreenCaptureInternal.LayerCaptureArgs resultingArgs =
+                mWm.getCaptureArgs(DEFAULT_DISPLAY, null);
+        assertEquals(ScreenCapture.ScreenCaptureParams.SECURE_CONTENT_POLICY_REDACT,
+                resultingArgs.mSecureContentPolicy);
+
+        // secureContentPolicy should be CAPTURE when setting is enabled
+        Settings.Secure.putInt(cr, Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS, 1);
+        mWm.mSettingsObserver.onChange(false,
+                Settings.Secure.getUriFor(Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS));
+        resultingArgs = mWm.getCaptureArgs(DEFAULT_DISPLAY, null);
+        assertEquals(ScreenCapture.ScreenCaptureParams.SECURE_CONTENT_POLICY_CAPTURE,
+                resultingArgs.mSecureContentPolicy);
+    }
     @Test
     public void testGrantInputChannel_sanitizeSpyWindowForApplications() {
         final Session session = mock(Session.class);

--- a/services/tests/wmtests/src/com/android/server/wm/WindowManagerServiceTests.java
+++ b/services/tests/wmtests/src/com/android/server/wm/WindowManagerServiceTests.java
@@ -92,6 +92,7 @@ import android.app.IApplicationThread;
 import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
+import android.content.ContentResolver;
 import android.graphics.Rect;
 import android.os.Binder;
 import android.os.IBinder;
@@ -132,6 +133,7 @@ import android.window.ClientWindowFrames;
 import android.window.ConfigurationChangeSetting;
 import android.window.IDisplayEngagementModeCallback;
 import android.window.InputTransferToken;
+import android.window.ScreenCapture;
 import android.window.ScreenCaptureInternal;
 import android.window.WindowContainerToken;
 
@@ -1564,6 +1566,31 @@ public class WindowManagerServiceTests extends WindowTestsBase {
                 new ScreenCaptureInternal.CaptureArgs.Builder<>().setSourceCrop(validRect).build();
         resultingArgs = mWm.getCaptureArgs(DEFAULT_DISPLAY, captureArgs);
         assertEquals(validRect, resultingArgs.mSourceCrop);
+    }
+
+    @Test
+    public void testCaptureDisplay_forceScreenshotSecureWindows() {
+        Rect displayBounds = new Rect(0, 0, 100, 200);
+        spyOn(mDisplayContent);
+        when(mDisplayContent.getBounds()).thenReturn(displayBounds);
+        ContentResolver cr = useFakeSettingsProvider();
+
+        // secureContentPolicy should be REDACT (default) when setting is disabled
+        Settings.Secure.putInt(cr, Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS, 0);
+        mWm.mSettingsObserver.onChange(false,
+                Settings.Secure.getUriFor(Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS));
+        ScreenCaptureInternal.LayerCaptureArgs resultingArgs =
+                mWm.getCaptureArgs(DEFAULT_DISPLAY, null);
+        assertEquals(ScreenCapture.ScreenCaptureParams.SECURE_CONTENT_POLICY_REDACT,
+                resultingArgs.mSecureContentPolicy);
+
+        // secureContentPolicy should be CAPTURE when setting is enabled
+        Settings.Secure.putInt(cr, Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS, 1);
+        mWm.mSettingsObserver.onChange(false,
+                Settings.Secure.getUriFor(Settings.Secure.FORCE_SCREENSHOT_SECURE_WINDOWS));
+        resultingArgs = mWm.getCaptureArgs(DEFAULT_DISPLAY, null);
+        assertEquals(ScreenCapture.ScreenCaptureParams.SECURE_CONTENT_POLICY_CAPTURE,
+                resultingArgs.mSecureContentPolicy);
     }
 
     @Test


### PR DESCRIPTION
issue: https://github.com/GrapheneOS/os-issue-tracker/issues/664

Adds a setting to developer options to disable flag secure globally. Actual setting is implemented in https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/411

<img width="395" height="712" alt="image" src="https://github.com/user-attachments/assets/b04db2cc-bbe8-4d06-a877-665547f29df1" />

<img width="1080" height="1920" alt="image" src="https://github.com/user-attachments/assets/54383bb1-955e-45e7-bb6a-0a7d36f7d82c" />
