### PR TITLE
AppsScope: Integrate Apps Scopes in framework: services.jar and frame…

### DIFF
--- a/core/java/android/app/AppsScope.java
+++ b/core/java/android/app/AppsScope.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2026 GrapheneOS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.app;
+
+import android.annotation.NonNull;
+import android.annotation.Nullable;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.util.ArrayMap;
+import android.util.Slog;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Configuration for Apps Scope, which controls the visibility of other apps.
+ * @hide
+ */
+public final class AppsScope implements Parcelable {
+    private static final String TAG = "AppsScope";
+
+    public static final int FLAG_RESTRICT_SELF = 1;
+    public static final int FLAG_RESTRICT_SHARED_CERT = 1 << 1;
+    public static final int FLAG_RESTRICT_SYSTEM = 1 << 2;
+    public static final int FLAG_RESTRICT_QUERIES = 1 << 3;
+
+    public final int flags;
+    @NonNull
+    public final Map<String, Boolean> specificRules;
+
+    public AppsScope(int flags, @NonNull Map<String, Boolean> specificRules) {
+        this.flags = flags;
+        ArrayMap<String, Boolean> map = new ArrayMap<>(specificRules.size());
+        map.putAll(specificRules);
+        this.specificRules = Collections.unmodifiableMap(map);
+    }
+
+    public boolean isDefault() {
+        return flags == 0 && specificRules.isEmpty();
+    }
+
+    private AppsScope(Parcel in) {
+        flags = in.readInt();
+        int size = in.readInt();
+        ArrayMap<String, Boolean> map = new ArrayMap<>(size);
+        for (int i = 0; i < size; i++) {
+            map.put(in.readString(), in.readBoolean());
+        }
+        specificRules = Collections.unmodifiableMap(map);
+    }
+
+    @Override
+    public void writeToParcel(@NonNull Parcel dest, int parcelFlags) {
+        dest.writeInt(this.flags);
+        dest.writeInt(specificRules.size());
+        for (Map.Entry<String, Boolean> entry : specificRules.entrySet()) {
+            dest.writeString(entry.getKey());
+            dest.writeBoolean(entry.getValue());
+        }
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final @NonNull Creator<AppsScope> CREATOR = new Creator<AppsScope>() {
+        @Override
+        public AppsScope createFromParcel(Parcel in) {
+            return new AppsScope(in);
+        }
+
+        @Override
+        public AppsScope[] newArray(int size) {
+            return new AppsScope[size];
+        }
+    };
+
+    private static final int VERSION = 1;
+
+    @NonNull
+    public static android.content.Intent createConfigActivityIntent(@NonNull String packageName) {
+        android.content.Intent intent = new android.content.Intent("android.settings.APPS_SCOPE_DETAILS");
+        intent.setData(android.net.Uri.parse("package:" + packageName));
+        return intent;
+    }
+
+    @Nullable
+    public static byte[] serialize(@Nullable AppsScope config) {
+        if (config == null) {
+            return null;
+        }
+
+        try {
+            JSONObject json = new JSONObject();
+            json.put("restrictSelf", (config.flags & FLAG_RESTRICT_SELF) != 0);
+            json.put("restrictSharedCert", (config.flags & FLAG_RESTRICT_SHARED_CERT) != 0);
+            json.put("restrictSystem", (config.flags & FLAG_RESTRICT_SYSTEM) != 0);
+            json.put("restrictQueries", (config.flags & FLAG_RESTRICT_QUERIES) != 0);
+
+            JSONObject specificRules = new JSONObject();
+            for (Map.Entry<String, Boolean> entry : config.specificRules.entrySet()) {
+                specificRules.put(entry.getKey(), entry.getValue());
+            }
+            json.put("specificRules", specificRules);
+
+            return json.toString(2).getBytes(StandardCharsets.UTF_8);
+        } catch (JSONException e) {
+            Slog.e(TAG, "serialization failed", e);
+            return null;
+        }
+    }
+
+    @Nullable
+    public static AppsScope deserialize(@Nullable byte[] data) {
+        if (data == null) {
+            return null;
+        }
+
+        try {
+            String str = new String(data, StandardCharsets.UTF_8);
+            JSONObject json = new JSONObject(str);
+
+            int flags = 0;
+            if (json.optBoolean("restrictSelf", false)) flags |= FLAG_RESTRICT_SELF;
+            if (json.optBoolean("restrictSharedCert", false)) flags |= FLAG_RESTRICT_SHARED_CERT;
+            if (json.optBoolean("restrictSystem", false)) flags |= FLAG_RESTRICT_SYSTEM;
+            if (json.optBoolean("restrictQueries", false)) flags |= FLAG_RESTRICT_QUERIES;
+
+            ArrayMap<String, Boolean> specificRules = new ArrayMap<>();
+            JSONObject rulesObj = json.optJSONObject("specificRules");
+            if (rulesObj != null) {
+                Iterator<String> keys = rulesObj.keys();
+                while (keys.hasNext()) {
+                    String pkg = keys.next();
+                    specificRules.put(pkg, rulesObj.optBoolean(pkg, true));
+                }
+            }
+
+            return new AppsScope(flags, specificRules);
+        } catch (JSONException e) {
+            Slog.e(TAG, "deserialization failed", e);
+            return null;
+        }
+    }
+
+    /** @hide */
+    public static class Builder {
+        private int flags;
+        private final ArrayMap<String, Boolean> specificRules;
+
+        public Builder() {
+            this.flags = 0;
+            this.specificRules = new ArrayMap<>();
+        }
+
+        public Builder(AppsScope config) {
+            this.flags = config.flags;
+            this.specificRules = new ArrayMap<>();
+            this.specificRules.putAll(config.specificRules);
+        }
+
+        @NonNull
+        public static Builder from(@Nullable AppsScope config) {
+            return config != null ? new Builder(config) : new Builder();
+        }
+
+        public Builder setFlags(int flags) {
+            this.flags = flags;
+            return this;
+        }
+
+        public Builder addFlag(int flag) {
+            this.flags |= flag;
+            return this;
+        }
+
+        public Builder clearFlag(int flag) {
+            this.flags &= ~flag;
+            return this;
+        }
+
+        public Builder addPackage(String pkg, boolean allowed) {
+            specificRules.put(pkg, allowed);
+            return this;
+        }
+
+        public Builder removePackage(String pkg) {
+            specificRules.remove(pkg);
+            return this;
+        }
+
+        public AppsScope build() {
+            return new AppsScope(flags, specificRules);
+        }
+    }
+}

--- a/core/java/android/content/pm/GosPackageState.java
+++ b/core/java/android/content/pm/GosPackageState.java
@@ -37,6 +37,23 @@ public final class GosPackageState implements Parcelable {
     public final byte[] storageScopes;
     @Nullable
     public final byte[] contactScopes;
+    /** @hide */
+    @Nullable
+    public final byte[] appsScopes;
+
+    @Nullable
+    private volatile android.app.AppsScope mCachedAppsScope;
+
+    /** @hide */
+    @Nullable
+    public android.app.AppsScope getAppsScope() {
+        android.app.AppsScope cached = mCachedAppsScope;
+        if (cached != null) return cached;
+        if (appsScopes == null) return null;
+        cached = android.app.AppsScope.deserialize(appsScopes);
+        mCachedAppsScope = cached;
+        return cached;
+    }
     /**
      * These flags are lazily derived from persistent state. They are intentionally skipped from
      * equals() and hashCode(). derivedFlags are stored here for performance reasons, to avoid
@@ -64,14 +81,21 @@ public final class GosPackageState implements Parcelable {
     /** @hide */
     public GosPackageState(long flagStorage1, long packageFlagStorage,
                            @Nullable byte[] storageScopes, @Nullable byte[] contactScopes) {
+        this(flagStorage1, packageFlagStorage, storageScopes, contactScopes, null);
+    }
+    /** @hide */
+    public GosPackageState(long flagStorage1, long packageFlagStorage,
+                           @Nullable byte[] storageScopes, @Nullable byte[] contactScopes,
+                           @Nullable byte[] appsScopes) {
         this.flagStorage1 = flagStorage1;
         this.packageFlagStorage = packageFlagStorage;
         this.storageScopes = storageScopes;
         this.contactScopes = contactScopes;
+        this.appsScopes = appsScopes;
     }
 
     private static GosPackageState createEmpty() {
-        return new GosPackageState(0L, 0L, null, null);
+        return new GosPackageState(0L, 0L, null, null, null);
     }
 
     private static final int TYPE_NONE = 0;
@@ -94,6 +118,7 @@ public final class GosPackageState implements Parcelable {
         dest.writeLong(this.packageFlagStorage);
         dest.writeByteArray(storageScopes);
         dest.writeByteArray(contactScopes);
+        dest.writeByteArray(appsScopes);
         dest.writeInt(derivedFlags);
     }
 
@@ -106,7 +131,7 @@ public final class GosPackageState implements Parcelable {
                 case TYPE_NONE: return NONE;
             };
             var res = new GosPackageState(in.readLong(), in.readLong(),
-                    in.createByteArray(), in.createByteArray());
+                    in.createByteArray(), in.createByteArray(), in.createByteArray());
             res.derivedFlags = in.readInt();
             return res;
         }
@@ -119,7 +144,8 @@ public final class GosPackageState implements Parcelable {
 
     @Override
     public int hashCode() {
-        return Long.hashCode(flagStorage1) + Arrays.hashCode(storageScopes) + Arrays.hashCode(contactScopes) + Long.hashCode(packageFlagStorage);
+        return Long.hashCode(flagStorage1) + Arrays.hashCode(storageScopes) + Arrays.hashCode(contactScopes) +
+                Arrays.hashCode(appsScopes) + Long.hashCode(packageFlagStorage);
     }
 
     @Override
@@ -137,6 +163,9 @@ public final class GosPackageState implements Parcelable {
             return false;
         }
         if (!Arrays.equals(contactScopes, o.contactScopes)) {
+            return false;
+        }
+        if (!Arrays.equals(appsScopes, o.appsScopes)) {
             return false;
         }
         if (packageFlagStorage != o.packageFlagStorage) {
@@ -236,6 +265,7 @@ public final class GosPackageState implements Parcelable {
         private long packageFlagStorage;
         private byte[] storageScopes;
         private byte[] contactScopes;
+        private byte[] appsScopes;
         private int editorFlags;
 
         /** @hide */
@@ -246,6 +276,7 @@ public final class GosPackageState implements Parcelable {
             this.packageFlagStorage = s.packageFlagStorage;
             this.storageScopes = s.storageScopes;
             this.contactScopes = s.contactScopes;
+            this.appsScopes = s.appsScopes;
         }
 
         @NonNull
@@ -305,6 +336,27 @@ public final class GosPackageState implements Parcelable {
         }
 
         @NonNull
+        public Editor setAppsScopeConfig(@Nullable byte[] appsScopes) {
+            this.appsScopes = appsScopes;
+            return this;
+        }
+
+        /** @hide */
+        public long getFlags() {
+            return flagStorage1;
+        }
+
+        /** @hide */
+        public long getPackageFlags() {
+            return packageFlagStorage;
+        }
+
+        @Nullable
+        public byte[] getAppsScopeConfig() {
+            return appsScopes;
+        }
+
+        @NonNull
         public Editor killUidAfterApply() {
             return setKillUidAfterApply(true);
         }
@@ -334,7 +386,7 @@ public final class GosPackageState implements Parcelable {
         public boolean apply() {
             try {
                 return ActivityThread.getPackageManager().setGosPackageState(packageName, userId,
-                        new GosPackageState(flagStorage1, packageFlagStorage, storageScopes, contactScopes),
+                        new GosPackageState(flagStorage1, packageFlagStorage, storageScopes, contactScopes, appsScopes),
                         editorFlags);
             } catch (RemoteException e) {
                 throw e.rethrowFromSystemServer();

--- a/core/java/android/content/pm/GosPackageStateFlag.java
+++ b/core/java/android/content/pm/GosPackageStateFlag.java
@@ -36,6 +36,7 @@ public interface GosPackageStateFlag {
     /** @hide */ int PLAY_INTEGRITY_API_USED_AT_LEAST_ONCE = 26;
     /** @hide */ int SUPPRESS_PLAY_INTEGRITY_API_NOTIF = 27;
     /** @hide */ int BLOCK_PLAY_INTEGRITY_API = 28;
+    /** @hide */ int APPS_SCOPES_ENABLED = 29;
 
     /** @hide */
     @IntDef(value = {
@@ -64,6 +65,7 @@ public interface GosPackageStateFlag {
             PLAY_INTEGRITY_API_USED_AT_LEAST_ONCE,
             SUPPRESS_PLAY_INTEGRITY_API_NOTIF,
             BLOCK_PLAY_INTEGRITY_API,
+            APPS_SCOPES_ENABLED,
     })
     @Retention(RetentionPolicy.SOURCE)
     @interface Enum {}

--- a/services/core/java/com/android/server/pm/AppsScopeManager.java
+++ b/services/core/java/com/android/server/pm/AppsScopeManager.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) 2026 GrapheneOS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.server.pm;
+
+import static com.android.server.pm.PackageManagerServiceUtils.compareSignatures;
+
+import android.app.AppsScope;
+import android.content.pm.GosPackageState;
+import android.content.pm.PackageManager;
+import android.content.pm.SigningDetails;
+import android.os.UserHandle;
+import android.util.ArraySet;
+import android.util.Log;
+
+import com.android.server.pm.pkg.PackageStateInternal;
+
+import java.util.Map;
+import java.util.function.IntFunction;
+
+/**
+ * Manages visibility rules defined by Apps Scope (GrapheneOS).
+ *
+ * Reads configuration from in-memory {@link GosPackageState} (loaded at boot),
+ * avoiding disk I/O on the hot path.
+ *
+ * Returns a tri-state action:
+ *   ACTION_ALLOW (0) = Force visible, return false in shouldFilterApplication.
+ *   ACTION_DENY  (1) = Force hidden, return true in shouldFilterApplication.
+ *   ACTION_PASS  (2) = No decision, continue with default Android logic.
+ */
+public class AppsScopeManager {
+    private static final String TAG = "AppsScopeManager";
+
+    /** Force visible: the app must be shown. */
+    public static final int ACTION_ALLOW = 0;
+    /** Force hidden: the app must be hidden. */
+    public static final int ACTION_DENY  = 1;
+    /** No decision: let the normal Android filtering logic decide. */
+    public static final int ACTION_PASS  = 2;
+
+    // =========================================================================
+    // Main entry point
+    // =========================================================================
+
+    /**
+     * Main entry point called from ComputerEngine.shouldFilterApplication.
+     * Resolves calling UID to package states, determines relationship flags,
+     * and evaluates Apps Scope visibility rules using two specialized passes.
+     *
+     * @param ps               Target package state.
+     * @param callingUid       The raw calling UID.
+     * @param settingsResolver Callback to resolve an appId to its SettingBase.
+     * @return ACTION_ALLOW, ACTION_DENY, or ACTION_PASS.
+     */
+    public static int checkVisibility(PackageStateInternal ps, int callingUid,
+                                      IntFunction<SettingBase> settingsResolver) {
+        if (ps == null) return ACTION_PASS;
+
+        // --- Step 1: Resolve callingUid to PackageStateInternal(s) ---
+        final int callingAppId = UserHandle.getAppId(callingUid);
+        final SettingBase callingSetting = settingsResolver.apply(callingAppId);
+        if (callingSetting == null) return ACTION_PASS;
+
+        PackageStateInternal[] callingPkgStates = null;
+        SigningDetails callingSigning = null;
+
+        if (callingSetting instanceof SharedUserSetting) {
+            ArraySet<? extends PackageStateInternal> pkgs =
+                    ((SharedUserSetting) callingSetting).getPackageStates();
+            callingPkgStates = new PackageStateInternal[pkgs.size()];
+            for (int i = 0; i < pkgs.size(); i++) {
+                callingPkgStates[i] = pkgs.valueAt(i);
+            }
+            callingSigning = ((SharedUserSetting) callingSetting).getSigningDetails();
+        } else if (callingSetting instanceof PackageSetting) {
+            callingPkgStates = new PackageStateInternal[] { (PackageSetting) callingSetting };
+            callingSigning = ((PackageSetting) callingSetting).getSigningDetails();
+        }
+
+        if (callingPkgStates == null) return ACTION_PASS;
+
+        // --- Determine relationship flags ---
+        final String targetPackageName = ps.getPackageName();
+        final int N = callingPkgStates.length;
+        final int userId = UserHandle.getUserId(callingUid);
+        AppsScope[] loadedConfigs = new AppsScope[N];
+
+        // --- Pass 1: Self-Check (restrictSelf only) ---
+        // If the target is within the calling UID group, its own restrictSelf
+        // takes absolute priority over any peer rules.
+        for (int i = 0; i < N; i++) {
+            AppsScope config = getAppsScope(callingPkgStates[i], userId);
+            loadedConfigs[i] = config;
+
+            if (config == null) continue;
+
+            if (callingPkgStates[i].getPackageName().equals(targetPackageName)) {
+                int action = checkSelfRestriction(config);
+                if (action == ACTION_ALLOW || action == ACTION_DENY) {
+                    return action;
+                }
+            }
+        }
+
+        // --- Pass 2: Peer Rules (Specific Rules + Category Restrictions) ---
+        final boolean isSystem = ps.isSystem();
+        // TODO: isCore implementation to isolate core system apps
+        // final boolean isCore = (ps.getAppId() < Process.FIRST_APPLICATION_UID);
+        boolean isSharedCert = false;
+        if (callingSigning != null && ps.getSigningDetails() != null) {
+            isSharedCert = (compareSignatures(callingSigning, ps.getSigningDetails())
+                    == PackageManager.SIGNATURE_MATCH);
+        }
+
+        for (int i = 0; i < N; i++) {
+            AppsScope config = loadedConfigs[i];
+            if (config == null) continue;
+
+            int action = checkPeerRestriction(config, targetPackageName,
+                    isSystem, isSharedCert);
+            if (action == ACTION_DENY) {
+                return ACTION_DENY;
+            }
+        }
+
+        return ACTION_PASS;
+    }
+
+    // =========================================================================
+    // Helper: In-memory config reader
+    // =========================================================================
+
+    /**
+     * Extracts the Apps Scope config from in-memory {@link GosPackageState}.
+     * No disk I/O - data was loaded at boot by {@link GosPackageStatePersistence}.
+     * Uses cached AppsScope object to avoid redundant deserialization.
+     *
+     * @return Parsed AppsScope, or null if no config exists.
+     */
+    private static AppsScope getAppsScope(PackageStateInternal pkgState, int userId) {
+        try {
+            GosPackageState gosState = pkgState.getUserStateOrDefault(userId).getGosPackageState();
+            if (gosState == null) return null;
+            return gosState.getAppsScope();
+        } catch (Exception e) {
+            Log.e(TAG, "Error reading AppsScope for " + pkgState.getPackageName()
+                    + " user " + userId, e);
+            return null;
+        }
+    }
+
+    // =========================================================================
+    // Pass 1: Self-Restriction (restrictSelf only)
+    // =========================================================================
+
+    /**
+     * Checks ONLY the restrictSelf flag for a package viewing itself.
+     * Called exclusively when callingPkg == targetPkg.
+     */
+    private static int checkSelfRestriction(AppsScope config) {
+        boolean restrictSelf = (config.flags & AppsScope.FLAG_RESTRICT_SELF) != 0;
+        if (!restrictSelf) {
+            return ACTION_ALLOW;
+        }
+        return ACTION_DENY;
+    }
+
+    // =========================================================================
+    // Pass 2: Peer Restrictions (Specific Rules + Category Wildcards)
+    // =========================================================================
+
+    /**
+     * Checks specific rules and category restrictions for a peer package.
+     * Does NOT check restrictSelf (already handled in Pass 1).
+     *
+     * Priority: Specific Rules > SharedCert > System > Queries
+     */
+    private static int checkPeerRestriction(AppsScope config, String targetPkg,
+                                            boolean isSystem, boolean isSharedCert) {
+        // --- Specific Rules ---
+        Map<String, Boolean> specificRules = config.specificRules;
+        if (specificRules != null && specificRules.containsKey(targetPkg)) {
+            Boolean allowed = specificRules.get(targetPkg);
+            if (allowed == null || !allowed) {
+                return ACTION_DENY;
+            }
+            return ACTION_PASS;
+        }
+
+        // --- Category Restrictions: SharedCert > System > Queries ---
+        boolean restricted;
+        if (isSharedCert) {
+            restricted = (config.flags & AppsScope.FLAG_RESTRICT_SHARED_CERT) != 0;
+        } else if (isSystem) {
+            restricted = (config.flags & AppsScope.FLAG_RESTRICT_SYSTEM) != 0;
+        } else {
+            restricted = (config.flags & AppsScope.FLAG_RESTRICT_QUERIES) != 0;
+        }
+
+        if (restricted) {
+            return ACTION_DENY;
+        }
+
+        return ACTION_PASS;
+    }
+
+}
+

--- a/services/core/java/com/android/server/pm/AppsScopeStorage.java
+++ b/services/core/java/com/android/server/pm/AppsScopeStorage.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2026 GrapheneOS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.server.pm;
+
+import android.annotation.Nullable;
+import android.annotation.UserIdInt;
+import android.app.AppsScope;
+import android.os.Environment;
+import android.os.FileUtils;
+import android.util.AtomicFile;
+import android.util.Slog;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+
+/**
+ * Manages storage for Apps Scope configuration in separate JSON files.
+ * Location: /data/system/users/<user_id>/apps-scope/<package_name>.json
+ */
+class AppsScopeStorage {
+    private static final String TAG = "AppsScopeStorage";
+    private static final String DIR_NAME = "apps-scope";
+
+    @Nullable
+    static byte[] read(@UserIdInt int userId, String packageName) {
+        File file = getFile(userId, packageName);
+        try {
+            return new AtomicFile(file).readFully();
+        } catch (FileNotFoundException e) {
+            return null;
+        } catch (IOException e) {
+            Slog.e(TAG, "Failed to read apps scope config for " + packageName + " user " + userId, e);
+        }
+        return null;
+    }
+
+    static void write(@UserIdInt int userId, String packageName, @Nullable byte[] data, boolean enabled) {
+        File file = getFile(userId, packageName);
+        File disabledFile = getDisabledFile(userId, packageName);
+        if (data == null) {
+            Slog.d(TAG, "write: Apps Scope config cleared for " + packageName + ", deleting storage files");
+            if (file.exists()) {
+                file.delete();
+            }
+            if (disabledFile.exists()) {
+                disabledFile.delete();
+            }
+            return;
+        }
+
+        // Check if data is identical to avoid redundant writes
+        if (enabled && file.exists()) {
+            byte[] existing = read(userId, packageName);
+            if (Arrays.equals(existing, data)) {
+                return;
+            }
+        } else if (!enabled && disabledFile.exists()) {
+            try {
+                byte[] existing = Files.readAllBytes(disabledFile.toPath());
+                if (Arrays.equals(existing, data)) {
+                    return;
+                }
+            } catch (IOException ignored) {}
+        }
+
+        Slog.d(TAG, "write: userId=" + userId + " pkg=" + packageName + " enabled=" + enabled + " hasData=true");
+
+        if (!enabled) {
+            AppsScope config = AppsScope.deserialize(data);
+            if (config == null || config.isDefault()) {
+                Slog.d(TAG, "write: Apps Scope disabled with default config for " + packageName + ", deleting files");
+                if (file.exists()) {
+                    file.delete();
+                }
+                if (disabledFile.exists()) {
+                    disabledFile.delete();
+                }
+                return;
+            }
+
+            if (file.exists()) {
+                Slog.d(TAG, "write: Apps Scope disabled for " + packageName + ", renaming " + file + " to " + disabledFile);
+                if (disabledFile.exists()) {
+                    disabledFile.delete();
+                }
+                if (!file.renameTo(disabledFile)) {
+                    Slog.w(TAG, "Failed to rename " + file + " to " + disabledFile);
+                }
+            }
+            return;
+        }
+
+        File dir = file.getParentFile();
+        if (!dir.exists()) {
+            Slog.d(TAG, "write: directory does not exist, creating: " + dir);
+            if (dir.mkdirs()) {
+                Slog.d(TAG, "write: successfully created directory " + dir);
+                // Set permissions: rwxrwx--x (771) and owner: system (1000)
+                FileUtils.setPermissions(dir.getPath(),
+                        FileUtils.S_IRWXU | FileUtils.S_IRWXG | FileUtils.S_IXOTH,
+                        1000, 1000);
+            } else {
+                Slog.e(TAG, "write: FAILED to create directory " + dir);
+                return;
+            }
+        }
+
+        // If a disabled file exists, rename it back before writing the new data
+        if (disabledFile.exists() && !file.exists()) {
+            Slog.d(TAG, "write: Apps Scope re-enabled for " + packageName + ", restoring " + disabledFile + " to " + file);
+            if (!disabledFile.renameTo(file)) {
+                Slog.w(TAG, "Failed to restore " + disabledFile + " to " + file);
+            }
+        }
+
+        AtomicFile atomicFile = new AtomicFile(file);
+        FileOutputStream fos = null;
+        try {
+            fos = atomicFile.startWrite();
+            fos.write(data);
+            atomicFile.finishWrite(fos);
+            // Set file permissions: rw-rw---- (660) and owner: system (1000)
+            FileUtils.setPermissions(file.getPath(),
+                    FileUtils.S_IRUSR | FileUtils.S_IWUSR | FileUtils.S_IRGRP | FileUtils.S_IWGRP,
+                    1000, 1000);
+        } catch (IOException e) {
+            if (fos != null) {
+                atomicFile.failWrite(fos);
+            }
+            Slog.e(TAG, "Failed to write apps scope config for " + packageName + " user " + userId, e);
+        }
+    }
+
+    private static File getFile(int userId, String packageName) {
+        File userSystemDir = Environment.getUserSystemDirectory(userId);
+        return new File(new File(userSystemDir, DIR_NAME), packageName + ".json");
+    }
+
+    private static File getDisabledFile(int userId, String packageName) {
+        File userSystemDir = Environment.getUserSystemDirectory(userId);
+        return new File(new File(userSystemDir, DIR_NAME), packageName + ".DISABLE.json");
+    }
+}

--- a/services/core/java/com/android/server/pm/ComputerEngine.java
+++ b/services/core/java/com/android/server/pm/ComputerEngine.java
@@ -145,6 +145,8 @@ import com.android.server.pm.parsing.pkg.AndroidPackageUtils;
 import com.android.server.pm.permission.PermissionManagerServiceInternal;
 import com.android.server.pm.permission.PermissionManagerServiceInternal.HotwordDetectionServiceProvider;
 import com.android.server.pm.pkg.AndroidPackage;
+import com.android.server.pm.PackageSetting;
+import com.android.server.pm.SharedUserSetting;
 import com.android.server.pm.pkg.PackageState;
 import com.android.server.pm.pkg.PackageStateInternal;
 import com.android.server.pm.pkg.PackageStateUtils;
@@ -2519,6 +2521,34 @@ public class ComputerEngine implements Computer {
             int callingUid, @Nullable ComponentName component,
             @PackageManager.ComponentType int componentType, int userId, boolean filterUninstall,
             boolean filterArchived) {
+        return shouldFilterApplication(ps, callingUid, component, componentType, userId,
+                filterUninstall, filterArchived, false /* bypassAppsScope */);
+    }
+
+    public final boolean shouldFilterApplication(@Nullable PackageStateInternal ps,
+            int callingUid, @Nullable ComponentName component,
+            @PackageManager.ComponentType int componentType, int userId, boolean filterUninstall,
+            boolean filterArchived, boolean bypassAppsScope) {
+
+        if (!bypassAppsScope) {
+            // --- Apps Scope Hook ---
+            if (ps != null) {
+                try {
+                    int action = AppsScopeManager.checkVisibility(
+                            ps, callingUid, mSettings::getSettingBase);
+                    if (action == AppsScopeManager.ACTION_ALLOW) {
+                        return false; // Force visible
+                    } else if (action == AppsScopeManager.ACTION_DENY) {
+                        return true;  // Force hidden
+                    }
+                    // ACTION_PASS: continue with default code
+                } catch (SecurityException | IllegalArgumentException e) {
+                    Slog.e(TAG, "Apps Scope Hook Error", e);
+                }
+            }
+            // --- End Apps Scope Hook ---
+        }
+
         if (Process.isSdkSandboxUid(callingUid)) {
             int clientAppUid = Process.getAppUidForSdkSandboxUid(callingUid);
             // SDK sandbox should be able to see it's client app
@@ -5547,7 +5577,20 @@ public class ComputerEngine implements Computer {
         enforceCrossUserPermission(callingUid, userId, false /*requireFullPermission*/,
                 false /*checkShell*/, "can package query");
 
-        final PackageStateInternal sourceSetting = getPackageStateInternal(sourcePackageName);
+        // --- HMAC Apps Scope Hook ---
+        String effectiveSourcePackageName = sourcePackageName;
+        boolean bypassAppsScope = false;
+        if (sourcePackageName.endsWith(".unfiltered")) {
+            // Check if a package with this exact name exists.
+            // If it DOES NOT exist, it's a bypass request.
+            if (getPackageStateInternal(sourcePackageName) == null) {
+                effectiveSourcePackageName = sourcePackageName.substring(0, sourcePackageName.length() - ".unfiltered".length());
+                bypassAppsScope = true;
+            }
+        }
+
+        final PackageStateInternal sourceSetting = getPackageStateInternal(effectiveSourcePackageName);
+        // --- End HMAC Apps Scope Hook ---
         final PackageStateInternal[] targetSettings = new PackageStateInternal[targetSize];
         // Throw exception if the caller without the visibility of source package
         boolean throwException =
@@ -5562,13 +5605,15 @@ public class ComputerEngine implements Computer {
         }
         if (throwException) {
             throw new ParcelableException(new PackageManager.NameNotFoundException("Package(s) "
-                    + sourcePackageName + " and/or " + Arrays.toString(targetPackageNames)
+                    + effectiveSourcePackageName + " and/or " + Arrays.toString(targetPackageNames)
                     + " not found."));
         }
 
         final int sourcePackageUid = UserHandle.getUid(userId, sourceSetting.getAppId());
         for (int i = 0; i < targetSize; i++) {
-            results[i] = !shouldFilterApplication(targetSettings[i], sourcePackageUid, userId);
+            results[i] = !shouldFilterApplication(targetSettings[i], sourcePackageUid, /* component */ null,
+                    TYPE_UNKNOWN, userId, /* filterUninstall */ false,
+                    /* filterArchived */ true, bypassAppsScope);
         }
         return results;
     }

--- a/services/core/java/com/android/server/pm/GosPackageStatePermission.java
+++ b/services/core/java/com/android/server/pm/GosPackageStatePermission.java
@@ -25,9 +25,10 @@ class GosPackageStatePermission {
     static final int FIELD_STORAGE_SCOPES = 0;
     static final int FIELD_CONTACT_SCOPES = 1;
     static final int FIELD_PACKAGE_FLAGS = 2;
+    static final int FIELD_APPS_SCOPES = 3;
 
     @IntDef(prefix = "FIELD_", value = {
-            FIELD_STORAGE_SCOPES, FIELD_CONTACT_SCOPES, FIELD_PACKAGE_FLAGS
+            FIELD_STORAGE_SCOPES, FIELD_CONTACT_SCOPES, FIELD_PACKAGE_FLAGS, FIELD_APPS_SCOPES
     })
     @Retention(RetentionPolicy.SOURCE)
     @interface Field {}
@@ -214,6 +215,7 @@ class GosPackageStatePermission {
                 , canReadField(FIELD_PACKAGE_FLAGS) ? ps.packageFlagStorage : default_.packageFlagStorage
                 , canReadField(FIELD_STORAGE_SCOPES) ? ps.storageScopes : default_.storageScopes
                 , canReadField(FIELD_CONTACT_SCOPES) ? ps.contactScopes : default_.contactScopes
+                , canReadField(FIELD_APPS_SCOPES) ? ps.appsScopes : default_.appsScopes
         );
         if (default_.equals(res)) {
             return default_;
@@ -235,6 +237,7 @@ class GosPackageStatePermission {
                 , canWriteField(FIELD_PACKAGE_FLAGS) ? update.packageFlagStorage : current.packageFlagStorage
                 , canWriteField(FIELD_STORAGE_SCOPES) ? update.storageScopes : current.storageScopes
                 , canWriteField(FIELD_CONTACT_SCOPES) ? update.contactScopes : current.contactScopes
+                , canWriteField(FIELD_APPS_SCOPES) ? update.appsScopes : current.appsScopes
         );
         var default_ = GosPackageState.DEFAULT;
         if (default_.equals(res)) {

--- a/services/core/java/com/android/server/pm/GosPackageStatePermissions.java
+++ b/services/core/java/com/android/server/pm/GosPackageStatePermissions.java
@@ -22,6 +22,7 @@ import com.android.server.LocalServices;
 import java.util.Objects;
 
 import static android.content.pm.GosPackageStateFlag.ALLOW_ACCESS_TO_OBB_DIRECTORY;
+import static android.content.pm.GosPackageStateFlag.APPS_SCOPES_ENABLED;
 import static android.content.pm.GosPackageStateFlag.BLOCK_NATIVE_DEBUGGING;
 import static android.content.pm.GosPackageStateFlag.BLOCK_NATIVE_DEBUGGING_NON_DEFAULT;
 import static android.content.pm.GosPackageStateFlag.BLOCK_NATIVE_DEBUGGING_SUPPRESS_NOTIF;
@@ -48,6 +49,7 @@ import static android.content.pm.GosPackageStateFlag.USE_HARDENED_MALLOC;
 import static android.content.pm.GosPackageStateFlag.USE_HARDENED_MALLOC_NON_DEFAULT;
 import static com.android.server.pm.GosPackageStatePermission.ALLOW_CROSS_USER_PROFILE_READS;
 import static com.android.server.pm.GosPackageStatePermission.ALLOW_CROSS_USER_PROFILE_WRITES;
+import static com.android.server.pm.GosPackageStatePermission.FIELD_APPS_SCOPES;
 import static com.android.server.pm.GosPackageStatePermission.FIELD_CONTACT_SCOPES;
 import static com.android.server.pm.GosPackageStatePermission.FIELD_PACKAGE_FLAGS;
 import static com.android.server.pm.GosPackageStatePermission.FIELD_STORAGE_SCOPES;
@@ -74,11 +76,13 @@ class GosPackageStatePermissions {
                 SUPPRESS_PLAY_INTEGRITY_API_NOTIF,
         };
 
+        // Self-access: allow compatible scopes and flags, AND apps scope config
         selfAccessPermission = builder()
                 .readFlags(STORAGE_SCOPES_ENABLED, ALLOW_ACCESS_TO_OBB_DIRECTORY,
-                        CONTACT_SCOPES_ENABLED)
+                        CONTACT_SCOPES_ENABLED, APPS_SCOPES_ENABLED)
                 .readFlags(playIntegrityFlags)
                 .readWriteFlag(PLAY_INTEGRITY_API_USED_AT_LEAST_ONCE)
+                .readField(FIELD_APPS_SCOPES)
                 .create();
 
         grantedPermissions = new SparseArray<>();
@@ -103,7 +107,7 @@ class GosPackageStatePermissions {
                 .readField(FIELD_CONTACT_SCOPES)
                 .apply(ksp.contactsProvider, computer);
         builder()
-                .readFlags(STORAGE_SCOPES_ENABLED, CONTACT_SCOPES_ENABLED)
+                .readFlags(STORAGE_SCOPES_ENABLED, CONTACT_SCOPES_ENABLED, APPS_SCOPES_ENABLED)
                 // user profiles are handled by the launcher instance in profile parent user
                 .crossUserPermission(ALLOW_CROSS_USER_PROFILE_READS)
                 .apply(ksp.launcher, computer);
@@ -140,12 +144,14 @@ class GosPackageStatePermissions {
                 FORCE_MEMTAG,
                 FORCE_MEMTAG_SUPPRESS_NOTIF,
                 ENABLE_EXPLOIT_PROTECTION_COMPAT_MODE,
+                APPS_SCOPES_ENABLED
         };
         builder()
                 .readWriteFlags(settingsReadWriteFlags)
                 .readWriteFlags(playIntegrityFlags)
                 .readFlags(STORAGE_SCOPES_ENABLED, CONTACT_SCOPES_ENABLED)
                 .readFields(FIELD_PACKAGE_FLAGS)
+                .readWriteFields(FIELD_APPS_SCOPES)
                 .crossUserPermission(ALLOW_CROSS_USER_PROFILE_READS)
                 .crossUserPermission(ALLOW_CROSS_USER_PROFILE_WRITES)
                 // note that this applies to all packages that run in the android.uid.system sharedUserId,

--- a/services/core/java/com/android/server/pm/GosPackageStatePersistence.java
+++ b/services/core/java/com/android/server/pm/GosPackageStatePersistence.java
@@ -23,11 +23,19 @@ class GosPackageStatePersistence {
     private static final String ATTR_CONTACT_SCOPES = "contact-scopes";
 
     /** @see Settings#writePackageRestrictions */
-    static void serialize(PackageUserStateInternal packageUserState, TypedXmlSerializer serializer) throws IOException {
+    static void serialize(PackageUserStateInternal packageUserState, String packageName, int userId, TypedXmlSerializer serializer) throws IOException {
         GosPackageState ps = packageUserState.getGosPackageState();
+        boolean enabled = ps.hasFlag(GosPackageStateFlag.APPS_SCOPES_ENABLED);
+
         if (GosPackageState.DEFAULT.equals(ps)) {
+            // Even if default, we call write to ensure any existing files are deleted
+            AppsScopeStorage.write(userId, packageName, null, false);
             return;
         }
+
+        // Write side-car data
+        AppsScopeStorage.write(userId, packageName, ps.appsScopes, enabled);
+
         serializer.startTag(null, TAG_GOS_PACKAGE_STATE);
         serializeInner(ps, serializer);
         serializer.endTag(null, TAG_GOS_PACKAGE_STATE);
@@ -56,7 +64,7 @@ class GosPackageStatePersistence {
         }
     }
 
-    static GosPackageState deserialize(TypedXmlPullParser parser) throws XmlPullParserException {
+    static GosPackageState deserialize(TypedXmlPullParser parser, String packageName, int userId) throws XmlPullParserException {
         long flagStorage1 = 0L;
         long packageFlagStorage = 0L;
         byte[] storageScopes = null;
@@ -77,7 +85,11 @@ class GosPackageStatePersistence {
                     Slog.e(TAG, "deserialize: unknown attribute " + attr);
             }
         }
-        return new GosPackageState(flagStorage1, packageFlagStorage, storageScopes, contactScopes);
+
+        // Apps scope config is exclusively read from JSON sidecar files
+        byte[] appsScopes = AppsScopeStorage.read(userId, packageName);
+
+        return new GosPackageState(flagStorage1, packageFlagStorage, storageScopes, contactScopes, appsScopes);
     }
 
     // Compatibility with legacy serialized GosPackageState.
@@ -91,7 +103,7 @@ class GosPackageStatePersistence {
         long packageFlagStorage = parser.getAttributeLong(null, "GrapheneOS-package-flags", 0L);
         byte[] storageScopes = parser.getAttributeBytesHex(null, "GrapheneOS-storage-scopes", null);
         byte[] contactScopes = parser.getAttributeBytesHex(null, "GrapheneOS-contact-scopes", null);
-        return new GosPackageState(flagStorage1, packageFlagStorage, storageScopes, contactScopes);
+        return new GosPackageState(flagStorage1, packageFlagStorage, storageScopes, contactScopes, null);
     }
 
     private static long migrateLegacyFlags(int flags) {

--- a/services/core/java/com/android/server/pm/GosPackageStatePmHooks.java
+++ b/services/core/java/com/android/server/pm/GosPackageStatePmHooks.java
@@ -16,6 +16,7 @@ import android.os.ShellCommand;
 import android.os.UserHandle;
 import android.util.Slog;
 
+import android.app.AppsScope;
 import com.android.internal.pm.parsing.pkg.AndroidPackageInternal;
 import com.android.internal.pm.pkg.component.ParsedUsesPermission;
 import com.android.server.LocalServices;
@@ -25,7 +26,10 @@ import com.android.server.pm.pkg.PackageUserStateInternal;
 import com.android.server.pm.pkg.SharedUserApi;
 import com.android.server.utils.Slogf;
 
+import java.io.PrintWriter;
+import java.lang.reflect.Field;
 import java.util.List;
+import java.util.StringJoiner;
 
 import static android.content.pm.GosPackageState.*;
 import static com.android.server.pm.GosPackageStateUtils.parseFlag;
@@ -123,13 +127,57 @@ public class GosPackageStatePmHooks {
             SharedUserSetting sharedUser = pm.mSettings.getSharedUserSettingLPr(packageSetting);
 
             if (sharedUser != null) {
-                List<AndroidPackage> sharedPkgs = sharedUser.getPackages();
+                byte[] targetConfigBytes = updatedGosPs.appsScopes;
+                AppsScope targetConfig = null;
+                if (targetConfigBytes != null) {
+                    targetConfig = AppsScope.deserialize(targetConfigBytes);
+                }
 
-                // see GosPackageState doc
+                // Precompute the byte array for a peer WITH restrictSelf enabled
+                AppsScope.Builder builderWithRestrictSelf = (targetConfig != null) ?
+                        new AppsScope.Builder(targetConfig) :
+                        new AppsScope.Builder();
+                builderWithRestrictSelf.addFlag(AppsScope.FLAG_RESTRICT_SELF);
+                byte[] newPeerConfigBytesWithRestrictSelf = AppsScope.serialize(builderWithRestrictSelf.build());
+
+                // Precompute the byte array for a peer WITHOUT restrictSelf enabled
+                byte[] newPeerConfigBytesWithoutRestrictSelf;
+                if (targetConfig == null) {
+                    newPeerConfigBytesWithoutRestrictSelf = null;
+                } else {
+                    AppsScope.Builder builderWithoutRestrictSelf = new AppsScope.Builder(targetConfig);
+                    builderWithoutRestrictSelf.clearFlag(AppsScope.FLAG_RESTRICT_SELF);
+                    newPeerConfigBytesWithoutRestrictSelf = AppsScope.serialize(builderWithoutRestrictSelf.build());
+                }
+
+                List<AndroidPackage> sharedPkgs = sharedUser.getPackages();
                 for (AndroidPackage sharedPkg : sharedPkgs) {
                     PackageSetting sharedPkgSetting = pm.mSettings.getPackageLPr(sharedPkg.getPackageName());
                     if (sharedPkgSetting != null) {
-                        sharedPkgSetting.setGosPackageState(userId, updatedGosPs);
+                        GosPackageState psToSet;
+
+                        if (sharedPkg.getPackageName().equals(packageName)) {
+                            psToSet = updatedGosPs;
+                        } else {
+                            GosPackageState peerCurrentPs = sharedPkgSetting.getUserStateOrDefault(userId).getGosPackageState();
+
+                            // Use cached AppsScope so we avoid JSON deserialization overhead inside the pm.mLock loop
+                            AppsScope peerConfig = peerCurrentPs.getAppsScope();
+                            boolean peerRestrictSelf = (peerConfig != null) &&
+                                    ((peerConfig.flags & AppsScope.FLAG_RESTRICT_SELF) != 0);
+
+                            byte[] newPeerConfigBytes = peerRestrictSelf ?
+                                    newPeerConfigBytesWithRestrictSelf : newPeerConfigBytesWithoutRestrictSelf;
+
+                            psToSet = new GosPackageState(
+                                    updatedGosPs.flagStorage1,
+                                    updatedGosPs.packageFlagStorage,
+                                    updatedGosPs.storageScopes,
+                                    updatedGosPs.contactScopes,
+                                    newPeerConfigBytes
+                            );
+                        }
+                        sharedPkgSetting.setGosPackageState(userId, psToSet);
                     }
                 }
             } else {
@@ -138,6 +186,7 @@ public class GosPackageStatePmHooks {
 
             // will invalidate app-side caches (GosPackageState.sCache)
             pm.scheduleWritePackageRestrictions(userId);
+            android.content.pm.PackageManager.invalidatePackageInfoCache();
         }
 
         if ((editorFlags & EDITOR_FLAG_KILL_UID_AFTER_APPLY) != 0) {
@@ -355,6 +404,30 @@ public class GosPackageStatePmHooks {
                     ed.setStorageScopes(getByteArrArg(cmd));
                 case "set-contact-scopes" ->
                     ed.setContactScopes(getByteArrArg(cmd));
+                case "set-apps-scopes-config" ->
+                    ed.setAppsScopeConfig(getByteArrArg(cmd));
+                case "add-apps-scopes-flag", "clear-apps-scopes-flag", "add-apps-scopes-package-allow", "add-apps-scopes-package-deny", "clear-apps-scopes-package", "dump-apps-scopes" -> {
+                    byte[] data = ed.getAppsScopeConfig();
+                    AppsScope config = AppsScope.deserialize(data);
+                    AppsScope.Builder b = config != null ?
+                            new AppsScope.Builder(config) :
+                            new AppsScope.Builder();
+
+                    String val = "dump-apps-scopes".equals(arg) ? null : cmd.getNextArgRequired();
+
+                    switch (arg) {
+                        case "add-apps-scopes-flag" -> b.addFlag(parseAppsScopeFlag(val));
+                        case "clear-apps-scopes-flag" -> b.clearFlag(parseAppsScopeFlag(val));
+                        case "add-apps-scopes-package-allow" -> b.addPackage(val, true);
+                        case "add-apps-scopes-package-deny" -> b.addPackage(val, false);
+                        case "clear-apps-scopes-package" -> b.removePackage(val);
+                        case "dump-apps-scopes" -> {
+                            dumpAppsScope(cmd.getOutPrintWriter(), packageName, userId, ed.getFlags(), ed.getPackageFlags(), b.build());
+                            continue;
+                        }
+                    }
+                    ed.setAppsScopeConfig(AppsScope.serialize(b.build()));
+                }
                 case "set-kill-uid-after-apply" ->
                     ed.setKillUidAfterApply(Boolean.parseBoolean(cmd.getNextArgRequired()));
                 case "set-notify-uid-after-apply" ->
@@ -365,6 +438,65 @@ public class GosPackageStatePmHooks {
                     throw new IllegalArgumentException(arg);
             }
         }
+    }
+
+    private static void dumpAppsScope(PrintWriter pw, String packageName, int userId, long flags, long packageFlags, AppsScope config) {
+        pw.println("Package: " + packageName + ", User: " + userId);
+        pw.println("Flags: " + flagStorageToString(flags));
+        pw.println("Package Flags: " + packageFlags);
+        if (config != null) {
+            pw.println("Apps Scope Config:");
+            pw.println("  Flags: " + appsScopeFlagsToString(config.flags));
+            if (!config.specificRules.isEmpty()) {
+                pw.println("  Specific Rules:");
+                for (var entry : config.specificRules.entrySet()) {
+                    pw.println("    " + entry.getKey() + ": " + (entry.getValue() ? "ALLOW" : "DENY"));
+                }
+            }
+        } else {
+            pw.println("Apps Scope Config: null");
+        }
+    }
+
+    private static int parseAppsScopeFlag(String s) {
+        if (Character.isDigit(s.charAt(0))) {
+            return Integer.parseInt(s);
+        }
+        try {
+            return AppsScope.class.getDeclaredField(s).getInt(null);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private static String flagStorageToString(long flags) {
+        StringJoiner sj = new StringJoiner(", ");
+        for (Field field : GosPackageStateFlag.class.getDeclaredFields()) {
+            if (field.getType() == int.class) {
+                try {
+                    int bit = field.getInt(null);
+                    if ((flags & (1L << bit)) != 0) {
+                        sj.add(field.getName());
+                    }
+                } catch (IllegalAccessException ignored) {}
+            }
+        }
+        return sj.length() > 0 ? sj.toString() : "0";
+    }
+
+    private static String appsScopeFlagsToString(int flags) {
+        StringJoiner sj = new StringJoiner(", ");
+        for (Field field : AppsScope.class.getDeclaredFields()) {
+            if (field.getName().startsWith("FLAG_") && field.getType() == int.class) {
+                try {
+                    int bitValue = field.getInt(null);
+                    if ((flags & bitValue) != 0) {
+                        sj.add(field.getName());
+                    }
+                } catch (IllegalAccessException ignored) {}
+            }
+        }
+        return sj.length() > 0 ? sj.toString() : "0";
     }
 
     @Nullable

--- a/services/core/java/com/android/server/pm/Settings.java
+++ b/services/core/java/com/android/server/pm/Settings.java
@@ -2047,7 +2047,7 @@ public final class Settings implements Watchable, Snappable, ResilientAtomicFile
                                     archiveState = parseArchiveState(parser);
                                     break;
                                 case GosPackageStatePersistence.TAG_GOS_PACKAGE_STATE:
-                                    gosPackageState = GosPackageStatePersistence.deserialize(parser);
+                                    gosPackageState = GosPackageStatePersistence.deserialize(parser, name, userId);
                                     break;
                                 default:
                                     Slog.wtf(TAG, "Unknown tag " + parser.getName() + " under tag "
@@ -2501,7 +2501,8 @@ public final class Settings implements Watchable, Snappable, ResilientAtomicFile
                                     ustate.getMinAspectRatio());
                         }
 
-                        GosPackageStatePersistence.serialize(ustate, serializer);
+                        Slog.d("AppsScope", "serialize: pkg=" + pkg.getPackageName() + " user=" + userId);
+                        GosPackageStatePersistence.serialize(ustate, pkg.getPackageName(), userId, serializer);
 
                         if (ustate.isSuspended()) {
                             for (int i = 0; i < ustate.getSuspendParams().size(); i++) {


### PR DESCRIPTION
At the moment, the implementation impact the following files:
/system/framework/framework.jar
/system/framework/services.jar
/system_ext/priv-app/Settings/Settings.apk
/system_ext/priv-app/Launcher3QuickStep/Launcher3QuickStep.apk

It is a 3 repository PR:
https://github.com/GrapheneOS/platform_frameworks_base
https://github.com/GrapheneOS/platform_packages_apps_Launcher3
https://github.com/GrapheneOS/platform_packages_apps_Settings

Main points of what it is implemented for now:
Individual configuration to each application to enable/disable apps scopes.
A browser of all apps that the targeted app is able to see naturally, including system apps.
Any application can be hided to one particular target, using 2 methods:
*Blacklist: hide specific applications, while the default rule is not hide.
*Whitelist: hide everything unless you specifically allow an app to be seen.
The method of whitelist/blacklist can be setup individually for user apps, and system apps.
A quick option to wipe out the apps scopes configuration of the app
A quick option to restrict everything on the app.
It is integrated in the launcher so when you hold onto an app with the apps scopes enabled, you can see a shortcut to the apps scopes configuration of that app.
