### PR TITLE
SystemUI: switch to the modern smartspace infrastructure for showing the lockscreen device status info

### DIFF
--- a/core/api/system-current.txt
+++ b/core/api/system-current.txt
@@ -2775,6 +2775,7 @@ package android.app.smartspace {
     field public static final int FEATURE_COMMUTE_TIME = 3; // 0x3
     field public static final int FEATURE_CONSENT = 11; // 0xb
     field public static final int FEATURE_CROSS_DEVICE_TIMER = 32; // 0x20
+    field public static final int FEATURE_DATE_ALARM_ZEN_MEDIA = 2147483647; // 0x7fffffff
     field public static final int FEATURE_DOORBELL = 30; // 0x1e
     field public static final int FEATURE_DRIVING_MODE = 26; // 0x1a
     field public static final int FEATURE_EARTHQUAKE_ALERT = 38; // 0x26

--- a/core/java/android/app/smartspace/SmartspaceTarget.java
+++ b/core/java/android/app/smartspace/SmartspaceTarget.java
@@ -184,6 +184,10 @@ public final class SmartspaceTarget implements Parcelable {
     public static final int FEATURE_STEP_DATE = 39; // This represents a DATE. "STEP" is a typo.
     public static final int FEATURE_BLAZE_BUILD_PROGRESS = 40;
     public static final int FEATURE_EARTHQUAKE_OCCURRED = 41;
+    // Our current iteration of smartspace is intended to just be a port of the legacy
+    // KeyguardSlice, so merging it all as a single feature was the path of least resistance. It can
+    // easily be split later.
+    public static final int FEATURE_DATE_ALARM_ZEN_MEDIA = Integer.MAX_VALUE;
 
     /**
      * @hide
@@ -230,7 +234,8 @@ public final class SmartspaceTarget implements Parcelable {
             FEATURE_EARTHQUAKE_ALERT,
             FEATURE_STEP_DATE,
             FEATURE_BLAZE_BUILD_PROGRESS,
-            FEATURE_EARTHQUAKE_OCCURRED
+            FEATURE_EARTHQUAKE_OCCURRED,
+            FEATURE_DATE_ALARM_ZEN_MEDIA
     })
     @Retention(RetentionPolicy.SOURCE)
     public @interface FeatureType {

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -5291,7 +5291,7 @@
      If no service with the specified name exists on the device, smartspace will be disabled.
      Example: "com.android.intelligence/.SmartspaceService"
 -->
-    <string name="config_defaultSmartspaceService" translatable="false"></string>
+    <string name="config_defaultSmartspaceService" translatable="false">com.android.systemui/.smartspace.service.SystemUISmartspaceService</string>
 
     <!-- The package name for the system's speech recognition service.
          This service must be trusted, as it can be activated without explicit consent of the user.

--- a/packages/SystemUI/AndroidManifest.xml
+++ b/packages/SystemUI/AndroidManifest.xml
@@ -485,6 +485,10 @@
                  android:permission="com.android.systemui.permission.SELF"
                  android:exported="false" />
 
+        <service android:name=".smartspace.service.SystemUISmartspaceService"
+            android:permission="com.android.systemui.permission.MANAGE_SMARTSPACE"
+            android:exported="false" />
+
         <activity android:name=".screenshot.appclips.AppClipsTrampolineActivity"
             android:theme="@style/AppClipsTrampolineActivity"
             android:label="@string/screenshot_preview_description"

--- a/packages/SystemUI/multivalentTests/src/com/android/keyguard/KeyguardSliceViewControllerTest.java
+++ b/packages/SystemUI/multivalentTests/src/com/android/keyguard/KeyguardSliceViewControllerTest.java
@@ -71,7 +71,7 @@ public class KeyguardSliceViewControllerTest extends SysuiTestCase {
         when(mView.getContext()).thenReturn(mContext);
         mController = new KeyguardSliceViewController(mHandler, mBgHandler, mView,
                 mActivityStarter, mConfigurationController, mDumpManager,
-                mDisplayTracker, null, null);
+                mDisplayTracker);
         mController.setupUri(KeyguardSliceProvider.KEYGUARD_SLICE_URI);
     }
 

--- a/packages/SystemUI/res-keyguard/layout/keyguard_slice_view.xml
+++ b/packages/SystemUI/res-keyguard/layout/keyguard_slice_view.xml
@@ -38,7 +38,7 @@
               android:id="@+id/row"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
-              android:orientation="vertical"
+              android:orientation="horizontal"
               android:gravity="start"
     />
 </com.android.keyguard.KeyguardSliceView>

--- a/packages/SystemUI/res-keyguard/layout/keyguard_slice_view.xml
+++ b/packages/SystemUI/res-keyguard/layout/keyguard_slice_view.xml
@@ -25,7 +25,8 @@
     android:layout_height="wrap_content"
     android:layout_gravity="start"
     android:clipToPadding="false"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingStart="@dimen/below_clock_padding_start">
     <TextView
               android:id="@+id/title"
               android:layout_width="match_parent"

--- a/packages/SystemUI/res-keyguard/layout/lockscreen_smartspace_general_view.xml
+++ b/packages/SystemUI/res-keyguard/layout/lockscreen_smartspace_general_view.xml
@@ -9,10 +9,11 @@
     android:layout_gravity="start"
     android:clipToPadding="false"
     android:orientation="vertical">
-    <view class="com.android.systemui.keyguard.smartspace.LockscreenSmartspaceGeneralView$Row"
-              android:id="@+id/row"
+    <view class="com.android.systemui.keyguard.smartspace.LockscreenSmartspaceGeneralView$Rows"
+              android:id="@+id/rows"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
+              android:layout_gravity="start"
               android:orientation="vertical"
               android:gravity="start"
     />

--- a/packages/SystemUI/res-keyguard/layout/lockscreen_smartspace_general_view.xml
+++ b/packages/SystemUI/res-keyguard/layout/lockscreen_smartspace_general_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- id comes from com/android/systemui/keyguard/ui/view/layout/sections/SmartspaceSection.kt -->
+<com.android.systemui.keyguard.smartspace.LockscreenSmartspaceGeneralView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/bc_smartspace_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="start"
+    android:clipToPadding="false"
+    android:orientation="vertical">
+    <view class="com.android.systemui.keyguard.smartspace.LockscreenSmartspaceGeneralView$Row"
+              android:id="@+id/row"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical"
+              android:gravity="start"
+    />
+</com.android.systemui.keyguard.smartspace.LockscreenSmartspaceGeneralView>

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardSliceView.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardSliceView.java
@@ -445,7 +445,6 @@ public class KeyguardSliceView extends LinearLayout {
 
         private void updatePadding() {
             boolean hasText = !TextUtils.isEmpty(getText());
-            // These calculations depend on layout orientation change in keyguard_slice_view.xml
             int padding = (int) getContext().getResources()
                     .getDimension(R.dimen.widget_horizontal_padding) / 2;
             // orientation is vertical, so add padding to top & bottom

--- a/packages/SystemUI/src/com/android/keyguard/KeyguardSliceViewController.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardSliceViewController.java
@@ -18,8 +18,6 @@ package com.android.keyguard;
 
 import static android.app.slice.Slice.HINT_LIST_ITEM;
 
-import static com.android.systemui.util.kotlin.JavaAdapterKt.collectFlow;
-
 import android.app.PendingIntent;
 import android.net.Uri;
 import android.os.Handler;
@@ -45,16 +43,10 @@ import com.android.systemui.dagger.qualifiers.Background;
 import com.android.systemui.dagger.qualifiers.Main;
 import com.android.systemui.dump.DumpManager;
 import com.android.systemui.keyguard.KeyguardSliceProvider;
-import com.android.systemui.keyguard.domain.interactor.KeyguardInteractor;
 import com.android.systemui.plugins.ActivityStarter;
-import com.android.systemui.power.domain.interactor.PowerInteractor;
-import com.android.systemui.power.shared.model.ScreenPowerState;
 import com.android.systemui.settings.DisplayTracker;
 import com.android.systemui.statusbar.policy.ConfigurationController;
 import com.android.systemui.util.ViewController;
-
-import kotlin.coroutines.CoroutineContext;
-import kotlin.coroutines.EmptyCoroutineContext;
 
 import java.io.PrintWriter;
 import java.util.List;
@@ -79,8 +71,6 @@ public class KeyguardSliceViewController extends ViewController<KeyguardSliceVie
     private Uri mKeyguardSliceUri;
     private Slice mSlice;
     private Map<View, PendingIntent> mClickActions;
-    private KeyguardInteractor mKeyguardInteractor;
-    private PowerInteractor mPowerInteractor;
 
     ConfigurationController.ConfigurationListener mConfigurationListener =
             new ConfigurationController.ConfigurationListener() {
@@ -120,9 +110,7 @@ public class KeyguardSliceViewController extends ViewController<KeyguardSliceVie
             ActivityStarter activityStarter,
             ConfigurationController configurationController,
             DumpManager dumpManager,
-            DisplayTracker displayTracker,
-            KeyguardInteractor keyguardInteractor,
-            PowerInteractor powerInteractor) {
+            DisplayTracker displayTracker) {
         super(keyguardSliceView);
         mHandler = handler;
         mBgHandler = bgHandler;
@@ -130,28 +118,6 @@ public class KeyguardSliceViewController extends ViewController<KeyguardSliceVie
         mConfigurationController = configurationController;
         mDumpManager = dumpManager;
         mDisplayTracker = displayTracker;
-        mKeyguardInteractor = keyguardInteractor;
-        mPowerInteractor = powerInteractor;
-    }
-
-    @Override
-    public void onInit() {
-        setupUri(null);
-        startCoroutines(EmptyCoroutineContext.INSTANCE);
-    }
-
-    void startCoroutines(CoroutineContext context) {
-        collectFlow(mView, mKeyguardInteractor.getDozeTimeTick(),
-                (Long millis) -> {
-                    refresh();
-                }, context);
-
-        collectFlow(mView, mPowerInteractor.getScreenPowerState(),
-                (ScreenPowerState powerState) -> {
-                    if (powerState == ScreenPowerState.SCREEN_TURNING_ON) {
-                        refresh();
-                    }
-                }, context);
     }
 
     @Override

--- a/packages/SystemUI/src/com/android/systemui/dagger/SystemUIModule.java
+++ b/packages/SystemUI/src/com/android/systemui/dagger/SystemUIModule.java
@@ -128,6 +128,7 @@ import com.android.systemui.shade.transition.LargeScreenShadeInterpolator;
 import com.android.systemui.shade.transition.LargeScreenShadeInterpolatorImpl;
 import com.android.systemui.shared.condition.Monitor;
 import com.android.systemui.smartspace.dagger.SmartspaceModule;
+import com.android.systemui.smartspace.service.SystemUISmartspaceService;
 import com.android.systemui.startable.Dependencies;
 import com.android.systemui.statusbar.CommandQueue;
 import com.android.systemui.statusbar.NotificationLockscreenUserManager;
@@ -385,6 +386,11 @@ public abstract class SystemUIModule {
 
     @BindsOptionalOf
     abstract HeadsUpManager optionalHeadsUpManager();
+
+    @Binds
+    @IntoMap
+    @ClassKey(SystemUISmartspaceService.class)
+    abstract Service bindsSystemUISmartspaceService(SystemUISmartspaceService service);
 
     @BindsOptionalOf
     abstract BcSmartspaceDataPlugin optionalBcSmartspaceDataPlugin();

--- a/packages/SystemUI/src/com/android/systemui/dagger/SystemUIModule.java
+++ b/packages/SystemUI/src/com/android/systemui/dagger/SystemUIModule.java
@@ -85,6 +85,7 @@ import com.android.systemui.keyguard.shared.quickaffordance.KeyguardQuickAfforda
 import com.android.systemui.keyguard.smartspace.LockscreenSmartspaceDatePlugin;
 import com.android.systemui.keyguard.smartspace.LockscreenSmartspaceWeatherPlugin;
 import com.android.systemui.keyguard.ui.composable.LockscreenContent;
+import com.android.systemui.keyguard.smartspace.LockscreenSmartspaceGeneralPlugin;
 import com.android.systemui.log.dagger.LogModule;
 import com.android.systemui.log.dagger.MonitorLog;
 import com.android.systemui.log.table.TableLogBuffer;
@@ -396,6 +397,10 @@ public abstract class SystemUIModule {
 
     @BindsOptionalOf
     abstract BcSmartspaceDataPlugin optionalBcSmartspaceDataPlugin();
+
+    @Binds
+    abstract BcSmartspaceDataPlugin bindBcSmartspaceDataPlugin(
+            LockscreenSmartspaceGeneralPlugin impl);
 
     @BindsOptionalOf
     abstract BcSmartspaceConfigPlugin optionalBcSmartspaceConfigPlugin();

--- a/packages/SystemUI/src/com/android/systemui/dagger/SystemUIModule.java
+++ b/packages/SystemUI/src/com/android/systemui/dagger/SystemUIModule.java
@@ -82,6 +82,7 @@ import com.android.systemui.keyevent.data.repository.KeyEventRepositoryModule;
 import com.android.systemui.keyguard.data.quickaffordance.KeyguardDataQuickAffordanceModule;
 import com.android.systemui.keyguard.shared.quickaffordance.KeyguardQuickAffordancesMetricsLogger;
 import com.android.systemui.keyguard.shared.quickaffordance.KeyguardQuickAffordancesMetricsLoggerImpl;
+import com.android.systemui.keyguard.smartspace.LockscreenSmartspaceDatePlugin;
 import com.android.systemui.keyguard.ui.composable.LockscreenContent;
 import com.android.systemui.log.dagger.LogModule;
 import com.android.systemui.log.dagger.MonitorLog;
@@ -401,6 +402,10 @@ public abstract class SystemUIModule {
     @BindsOptionalOf
     @Named(SmartspaceModule.DATE_SMARTSPACE_DATA_PLUGIN)
     abstract BcSmartspaceDataPlugin optionalDateSmartspaceConfigPlugin();
+
+    @Binds
+    @Named(SmartspaceModule.DATE_SMARTSPACE_DATA_PLUGIN)
+    abstract BcSmartspaceDataPlugin bindBcSmartspaceDatePlugin(LockscreenSmartspaceDatePlugin impl);
 
     @BindsOptionalOf
     @Named(SmartspaceModule.WEATHER_SMARTSPACE_DATA_PLUGIN)

--- a/packages/SystemUI/src/com/android/systemui/dagger/SystemUIModule.java
+++ b/packages/SystemUI/src/com/android/systemui/dagger/SystemUIModule.java
@@ -83,6 +83,7 @@ import com.android.systemui.keyguard.data.quickaffordance.KeyguardDataQuickAffor
 import com.android.systemui.keyguard.shared.quickaffordance.KeyguardQuickAffordancesMetricsLogger;
 import com.android.systemui.keyguard.shared.quickaffordance.KeyguardQuickAffordancesMetricsLoggerImpl;
 import com.android.systemui.keyguard.smartspace.LockscreenSmartspaceDatePlugin;
+import com.android.systemui.keyguard.smartspace.LockscreenSmartspaceWeatherPlugin;
 import com.android.systemui.keyguard.ui.composable.LockscreenContent;
 import com.android.systemui.log.dagger.LogModule;
 import com.android.systemui.log.dagger.MonitorLog;
@@ -410,6 +411,11 @@ public abstract class SystemUIModule {
     @BindsOptionalOf
     @Named(SmartspaceModule.WEATHER_SMARTSPACE_DATA_PLUGIN)
     abstract BcSmartspaceDataPlugin optionalWeatherSmartspaceConfigPlugin();
+
+    @Binds
+    @Named(SmartspaceModule.WEATHER_SMARTSPACE_DATA_PLUGIN)
+    abstract BcSmartspaceDataPlugin bindBcSmartspaceWeatherPlugin(
+            LockscreenSmartspaceWeatherPlugin impl);
 
     @BindsOptionalOf
     abstract Recents optionalRecents();

--- a/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardSliceProvider.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/KeyguardSliceProvider.java
@@ -220,13 +220,14 @@ public class KeyguardSliceProvider extends SliceProvider implements
             synchronized (this) {
                 ListBuilder builder = new ListBuilder(getContext(), mSliceUri,
                         ListBuilder.INFINITY);
-                builder.addRow(new RowBuilder(mDateUri).setTitle(mLastText));
+                if (needsMediaLocked()) {
+                    addMediaLocked(builder);
+                } else {
+                    builder.addRow(new RowBuilder(mDateUri).setTitle(mLastText));
+                }
                 addNextAlarmLocked(builder);
                 addZenModeLocked(builder);
                 addPrimaryActionLocked(builder);
-                if (needsMediaLocked()) {
-                    addMediaLocked(builder);
-                }
                 slice = builder.build();
             }
         } catch (IllegalStateException e) {
@@ -251,11 +252,8 @@ public class KeyguardSliceProvider extends SliceProvider implements
         if (TextUtils.isEmpty(mMediaTitle)) {
             return;
         }
-        {
-            var titleBuilder = new RowBuilder(mHeaderUri);
-            titleBuilder.setTitle(mMediaTitle);
-            listBuilder.addRow(titleBuilder);
-        }
+        listBuilder.setHeader(new ListBuilder.HeaderBuilder(mHeaderUri).setTitle(mMediaTitle));
+
         if (!TextUtils.isEmpty(mMediaArtist)) {
             RowBuilder albumBuilder = new RowBuilder(mMediaUri);
             albumBuilder.setTitle(mMediaArtist);

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceDatePlugin.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceDatePlugin.java
@@ -16,17 +16,11 @@ public class LockscreenSmartspaceDatePlugin extends BaseSmartspaceDataPlugin {
 
     @Override
     public SmartspaceView getView(Context context) {
-        LockscreenSmartspacePlaceholderView v = new LockscreenSmartspacePlaceholderView(context);
-        // ID comes from com.android.systemui.keyguard.ui.view.layout.sections.SmartspaceSection.
-        v.setId(R.id.date_smartspace_view);
-        return v;
+        return new LockscreenSmartspacePlaceholderView(context, R.id.date_smartspace_view);
     }
 
     @Override
     public SmartspaceView getLargeClockView(Context context) {
-        LockscreenSmartspacePlaceholderView v = new LockscreenSmartspacePlaceholderView(context);
-        // ID comes from com.android.systemui.keyguard.ui.view.layout.sections.SmartspaceSection.
-        v.setId(R.id.date_smartspace_view_large);
-        return v;
+        return new LockscreenSmartspacePlaceholderView(context, R.id.date_smartspace_view_large);
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceDatePlugin.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceDatePlugin.java
@@ -1,0 +1,32 @@
+package com.android.systemui.keyguard.smartspace;
+
+import android.content.Context;
+
+import com.android.systemui.shared.R;
+import com.android.systemui.smartspace.plugin.BaseSmartspaceDataPlugin;
+
+import javax.inject.Inject;
+
+/**
+ * Date plugin that provides placeholder views to satisfy lockscreen smartspace constraints.
+ */
+public class LockscreenSmartspaceDatePlugin extends BaseSmartspaceDataPlugin {
+    @Inject
+    public LockscreenSmartspaceDatePlugin() {}
+
+    @Override
+    public SmartspaceView getView(Context context) {
+        LockscreenSmartspacePlaceholderView v = new LockscreenSmartspacePlaceholderView(context);
+        // ID comes from com.android.systemui.keyguard.ui.view.layout.sections.SmartspaceSection.
+        v.setId(R.id.date_smartspace_view);
+        return v;
+    }
+
+    @Override
+    public SmartspaceView getLargeClockView(Context context) {
+        LockscreenSmartspacePlaceholderView v = new LockscreenSmartspacePlaceholderView(context);
+        // ID comes from com.android.systemui.keyguard.ui.view.layout.sections.SmartspaceSection.
+        v.setId(R.id.date_smartspace_view_large);
+        return v;
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralPlugin.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralPlugin.java
@@ -21,7 +21,7 @@ public class LockscreenSmartspaceGeneralPlugin extends BaseSmartspaceDataPlugin 
 
     @Override
     public SmartspaceView getView(Context context) {
-        return (LockscreenSmartspaceGeneralView)mLayoutInflater.inflate(
+        return (LockscreenSmartspaceGeneralView) mLayoutInflater.inflate(
                 R.layout.lockscreen_smartspace_general_view, null, false);
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralPlugin.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralPlugin.java
@@ -1,0 +1,27 @@
+package com.android.systemui.keyguard.smartspace;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+
+import com.android.systemui.res.R;
+import com.android.systemui.smartspace.plugin.BaseSmartspaceDataPlugin;
+
+import javax.inject.Inject;
+
+/**
+ * Plugin that provides the lockscreen smartspace general view.
+ */
+public class LockscreenSmartspaceGeneralPlugin extends BaseSmartspaceDataPlugin {
+    private final LayoutInflater mLayoutInflater;
+
+    @Inject
+    public LockscreenSmartspaceGeneralPlugin(LayoutInflater layoutInflater) {
+        mLayoutInflater = layoutInflater;
+    }
+
+    @Override
+    public SmartspaceView getView(Context context) {
+        return (LockscreenSmartspaceGeneralView)mLayoutInflater.inflate(
+                R.layout.lockscreen_smartspace_general_view, null, false);
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralView.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralView.java
@@ -6,14 +6,12 @@ import android.app.smartspace.uitemplatedata.BaseTemplateData;
 import android.app.smartspace.uitemplatedata.CombinedCardsTemplateData;
 import android.app.smartspace.uitemplatedata.Icon;
 import android.app.smartspace.uitemplatedata.Text;
-import android.content.ComponentName;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.InsetDrawable;
 import android.text.TextUtils;
 import android.util.AttributeSet;
-import android.view.Gravity;
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -25,65 +23,74 @@ import com.android.systemui.smartspace.ui.DefaultSmartspaceView;
 
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Smartspace view for displaying date, zen mode, upcoming alarms and media. This is a
  * reimplementation of the legacy KeyguardSliceView.
  */
 public class LockscreenSmartspaceGeneralView extends LinearLayout implements DefaultSmartspaceView {
-
-    private static final int DARK_AMOUNT = 0;
-
-    private LockscreenSmartspaceGeneralView.Row mRow;
-    private int mTextColor;
-    private int mIconSize;
-
+    private Rows mRows;
+    private final int mIconSize;
 
     public LockscreenSmartspaceGeneralView(Context context, AttributeSet attrs) {
         super(context, attrs);
+
+        mIconSize = (int) mContext.getResources().getDimension(R.dimen.widget_icon_size);
     }
 
     @Override
     protected void onFinishInflate() {
         super.onFinishInflate();
-        mRow = findViewById(R.id.row);
-        mTextColor = Utils.getColorAttrDefaultColor(mContext, R.attr.wallpaperTextColor);
-        mIconSize = (int) mContext.getResources().getDimension(R.dimen.widget_icon_size);
+        mRows = findViewById(R.id.rows);
     }
 
     protected void showTarget(SmartspaceTarget target) {
-        // Remove old views.
-        // TODO: Improve efficiency by reusing existing views and only removing those which are no
-        // longer needed.
-        for (int i = 0; i < mRow.getChildCount(); i++) {
-            View child = mRow.getChildAt(i);
-            mRow.removeView(child);
-            i--;
-        }
-
-        CombinedCardsTemplateData template = (CombinedCardsTemplateData)target.getTemplateData();
+        var template = (CombinedCardsTemplateData) requireNonNull(target.getTemplateData());
         List<BaseTemplateData> subTemplates = template.getCombinedCardDataList();
 
-        mRow.setVisibility(!subTemplates.isEmpty() ? VISIBLE : GONE);
-        LinearLayout.LayoutParams layoutParams = (LayoutParams) mRow.getLayoutParams();
-        layoutParams.gravity = Gravity.START;
-        mRow.setLayoutParams(layoutParams);
+        if (subTemplates.isEmpty()) {
+            mRows.setVisibility(View.GONE);
+            return;
+        }
+
+        mRows.setVisibility(View.VISIBLE);
+
+        int viewIdx = 0;
+
+        final int textColor = ColorUtils.blendARGB(
+                Utils.getColorAttrDefaultColor(mContext, R.attr.wallpaperTextColor),
+                Color.WHITE, 0.0f);
 
         for (BaseTemplateData data : subTemplates) {
             BaseTemplateData.SubItemInfo primaryItem = data.getPrimaryItem();
-            BaseTemplateData.SubItemInfo subTitleItem = data.getSubtitleItem();
             if (primaryItem != null) {
-                drawLine(primaryItem);
+                addRow(primaryItem, textColor, viewIdx++);
+                BaseTemplateData.SubItemInfo subTitleItem = data.getSubtitleItem();
                 if (subTitleItem != null) {
-                    drawLine(subTitleItem);
+                    addRow(subTitleItem, textColor, viewIdx++);
                 }
             }
         }
+
+        int rowCount = mRows.getChildCount();
+        if (viewIdx != rowCount) {
+            if (viewIdx > rowCount) {
+                throw new IllegalStateException();
+            }
+            mRows.removeViews(viewIdx, rowCount - viewIdx);
+        }
     }
 
-    private void drawLine(BaseTemplateData.SubItemInfo subItemInfo) {
-        LockscreenSmartspaceGeneralTextView tv = new LockscreenSmartspaceGeneralTextView(mContext);
-        tv.setTextColor(getTextColor());
-        mRow.addView(tv, -1);
+    private void addRow(BaseTemplateData.SubItemInfo subItemInfo, int textColor, int viewIdx) {
+        LockscreenSmartspaceGeneralTextView tv;
+        boolean isCachedView = viewIdx < mRows.getChildCount();
+        if (isCachedView) {
+            tv = (LockscreenSmartspaceGeneralTextView) mRows.getChildAt(viewIdx);
+        } else {
+            tv = new LockscreenSmartspaceGeneralTextView(mContext);
+        }
+        tv.setTextColor(textColor);
 
         Text text = subItemInfo.getText();
         tv.setText(text == null ? null : text.getText());
@@ -93,10 +100,10 @@ public class LockscreenSmartspaceGeneralView extends LinearLayout implements Def
         if (icon != null) {
             iconDrawable = icon.getIcon().loadDrawable(mContext);
             if (iconDrawable != null) {
-                if (iconDrawable instanceof InsetDrawable) {
+                if (iconDrawable instanceof InsetDrawable insetDrawable) {
                     // System icons (DnD) use insets which are fine for centered slice content
                     // but will cause a slight indent for left/right-aligned slice views.
-                    iconDrawable = ((InsetDrawable) iconDrawable).getDrawable();
+                    iconDrawable = requireNonNull(insetDrawable.getDrawable());
                 }
                 final int width = (int) (iconDrawable.getIntrinsicWidth()
                         / (float) iconDrawable.getIntrinsicHeight() * mIconSize);
@@ -104,56 +111,51 @@ public class LockscreenSmartspaceGeneralView extends LinearLayout implements Def
             }
         }
         tv.setCompoundDrawablesRelative(iconDrawable, null, null, null);
-    }
 
-    private int getTextColor() {
-        return ColorUtils.blendARGB(mTextColor, Color.WHITE, DARK_AMOUNT);
+        if (!isCachedView) {
+            mRows.addView(tv);
+        }
     }
 
     void onDensityOrFontScaleChanged() {
-        for (int i = 0; i < mRow.getChildCount(); i++) {
-            View child = mRow.getChildAt(i);
-            if (child instanceof LockscreenSmartspaceGeneralTextView) {
-                ((LockscreenSmartspaceGeneralTextView) child).onDensityOrFontScaleChanged();
+        for (int i = 0; i < mRows.getChildCount(); i++) {
+            View child = mRows.getChildAt(i);
+            if (child instanceof LockscreenSmartspaceGeneralTextView text) {
+                text.onDensityOrFontScaleChanged();
             }
         }
     }
 
     void onOverlayChanged() {
-        for (int i = 0; i < mRow.getChildCount(); i++) {
-            View child = mRow.getChildAt(i);
-            if (child instanceof LockscreenSmartspaceGeneralTextView) {
-                ((LockscreenSmartspaceGeneralTextView) child).onOverlayChanged();
+        for (int i = 0; i < mRows.getChildCount(); i++) {
+            View child = mRows.getChildAt(i);
+            if (child instanceof LockscreenSmartspaceGeneralTextView text) {
+                text.onOverlayChanged();
             }
         }
     }
 
-    public static class Row extends LinearLayout {
+    /** based on {@link com.android.keyguard.KeyguardSliceView.Row} */
+    public static class Rows extends LinearLayout {
 
-        public Row(Context context) {
-            this(context, null);
-        }
-
-        public Row(Context context, AttributeSet attrs) {
+        public Rows(Context context, AttributeSet attrs) {
             this(context, attrs, 0);
         }
 
-        public Row(Context context, AttributeSet attrs, int defStyleAttr) {
+        public Rows(Context context, AttributeSet attrs, int defStyleAttr) {
             this(context, attrs, defStyleAttr, 0);
         }
 
-        public Row(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        public Rows(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
             super(context, attrs, defStyleAttr, defStyleRes);
         }
 
         @Override
         protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-            int childCount = getChildCount();
-
-            for (int i = 0; i < childCount; i++) {
+            for (int i = 0; i < getChildCount(); i++) {
                 View child = getChildAt(i);
-                if (child instanceof LockscreenSmartspaceGeneralTextView) {
-                    ((LockscreenSmartspaceGeneralTextView) child).setMaxWidth(Integer.MAX_VALUE);
+                if (child instanceof LockscreenSmartspaceGeneralTextView text) {
+                    text.setMaxWidth(Integer.MAX_VALUE);
                 }
             }
 
@@ -166,7 +168,8 @@ public class LockscreenSmartspaceGeneralView extends LinearLayout implements Def
         }
     }
 
-    public static class LockscreenSmartspaceGeneralTextView extends TextView {
+    /** copied from {@link com.android.keyguard.KeyguardSliceView.KeyguardSliceTextView} */
+    static class LockscreenSmartspaceGeneralTextView extends TextView {
 
         @StyleRes
         private static final int sStyleId = R.style.TextAppearance_Keyguard_Secondary;

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralView.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralView.java
@@ -30,8 +30,6 @@ import java.util.List;
  * reimplementation of the legacy KeyguardSliceView.
  */
 public class LockscreenSmartspaceGeneralView extends LinearLayout implements DefaultSmartspaceView {
-    public static final ComponentName componentName = ComponentName.createRelative(
-            "com.android.systemui", "keyguard.smartspace.LockscreenSmartspaceGeneralView");
 
     private static final int DARK_AMOUNT = 0;
 

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralView.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralView.java
@@ -1,0 +1,230 @@
+package com.android.systemui.keyguard.smartspace;
+
+import android.annotation.StyleRes;
+import android.app.smartspace.SmartspaceTarget;
+import android.app.smartspace.uitemplatedata.BaseTemplateData;
+import android.app.smartspace.uitemplatedata.CombinedCardsTemplateData;
+import android.app.smartspace.uitemplatedata.Icon;
+import android.app.smartspace.uitemplatedata.Text;
+import android.content.ComponentName;
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.InsetDrawable;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.android.internal.graphics.ColorUtils;
+import com.android.settingslib.Utils;
+import com.android.systemui.res.R;
+import com.android.systemui.smartspace.ui.DefaultSmartspaceView;
+
+import java.util.List;
+
+/**
+ * Smartspace view for displaying date, zen mode, upcoming alarms and media. This is a
+ * reimplementation of the legacy KeyguardSliceView.
+ */
+public class LockscreenSmartspaceGeneralView extends LinearLayout implements DefaultSmartspaceView {
+    public static final ComponentName componentName = ComponentName.createRelative(
+            "com.android.systemui", "keyguard.smartspace.LockscreenSmartspaceGeneralView");
+
+    private static final int DARK_AMOUNT = 0;
+
+    private LockscreenSmartspaceGeneralView.Row mRow;
+    private int mTextColor;
+    private int mIconSize;
+
+
+    public LockscreenSmartspaceGeneralView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+        mRow = findViewById(R.id.row);
+        mTextColor = Utils.getColorAttrDefaultColor(mContext, R.attr.wallpaperTextColor);
+        mIconSize = (int) mContext.getResources().getDimension(R.dimen.widget_icon_size);
+    }
+
+    protected void showTarget(SmartspaceTarget target) {
+        // Remove old views.
+        // TODO: Improve efficiency by reusing existing views and only removing those which are no
+        // longer needed.
+        for (int i = 0; i < mRow.getChildCount(); i++) {
+            View child = mRow.getChildAt(i);
+            mRow.removeView(child);
+            i--;
+        }
+
+        CombinedCardsTemplateData template = (CombinedCardsTemplateData)target.getTemplateData();
+        List<BaseTemplateData> subTemplates = template.getCombinedCardDataList();
+
+        mRow.setVisibility(!subTemplates.isEmpty() ? VISIBLE : GONE);
+        LinearLayout.LayoutParams layoutParams = (LayoutParams) mRow.getLayoutParams();
+        layoutParams.gravity = Gravity.START;
+        mRow.setLayoutParams(layoutParams);
+
+        for (BaseTemplateData data : subTemplates) {
+            BaseTemplateData.SubItemInfo primaryItem = data.getPrimaryItem();
+            BaseTemplateData.SubItemInfo subTitleItem = data.getSubtitleItem();
+            if (primaryItem != null) {
+                drawLine(primaryItem);
+                if (subTitleItem != null) {
+                    drawLine(subTitleItem);
+                }
+            }
+        }
+    }
+
+    private void drawLine(BaseTemplateData.SubItemInfo subItemInfo) {
+        LockscreenSmartspaceGeneralTextView tv = new LockscreenSmartspaceGeneralTextView(mContext);
+        tv.setTextColor(getTextColor());
+        mRow.addView(tv, -1);
+
+        Text text = subItemInfo.getText();
+        tv.setText(text == null ? null : text.getText());
+
+        Drawable iconDrawable = null;
+        Icon icon = subItemInfo.getIcon();
+        if (icon != null) {
+            iconDrawable = icon.getIcon().loadDrawable(mContext);
+            if (iconDrawable != null) {
+                if (iconDrawable instanceof InsetDrawable) {
+                    // System icons (DnD) use insets which are fine for centered slice content
+                    // but will cause a slight indent for left/right-aligned slice views.
+                    iconDrawable = ((InsetDrawable) iconDrawable).getDrawable();
+                }
+                final int width = (int) (iconDrawable.getIntrinsicWidth()
+                        / (float) iconDrawable.getIntrinsicHeight() * mIconSize);
+                iconDrawable.setBounds(0, 0, Math.max(width, 1), mIconSize);
+            }
+        }
+        tv.setCompoundDrawablesRelative(iconDrawable, null, null, null);
+    }
+
+    private int getTextColor() {
+        return ColorUtils.blendARGB(mTextColor, Color.WHITE, DARK_AMOUNT);
+    }
+
+    void onDensityOrFontScaleChanged() {
+        for (int i = 0; i < mRow.getChildCount(); i++) {
+            View child = mRow.getChildAt(i);
+            if (child instanceof LockscreenSmartspaceGeneralTextView) {
+                ((LockscreenSmartspaceGeneralTextView) child).onDensityOrFontScaleChanged();
+            }
+        }
+    }
+
+    void onOverlayChanged() {
+        for (int i = 0; i < mRow.getChildCount(); i++) {
+            View child = mRow.getChildAt(i);
+            if (child instanceof LockscreenSmartspaceGeneralTextView) {
+                ((LockscreenSmartspaceGeneralTextView) child).onOverlayChanged();
+            }
+        }
+    }
+
+    public static class Row extends LinearLayout {
+
+        public Row(Context context) {
+            this(context, null);
+        }
+
+        public Row(Context context, AttributeSet attrs) {
+            this(context, attrs, 0);
+        }
+
+        public Row(Context context, AttributeSet attrs, int defStyleAttr) {
+            this(context, attrs, defStyleAttr, 0);
+        }
+
+        public Row(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+            super(context, attrs, defStyleAttr, defStyleRes);
+        }
+
+        @Override
+        protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+            int childCount = getChildCount();
+
+            for (int i = 0; i < childCount; i++) {
+                View child = getChildAt(i);
+                if (child instanceof LockscreenSmartspaceGeneralTextView) {
+                    ((LockscreenSmartspaceGeneralTextView) child).setMaxWidth(Integer.MAX_VALUE);
+                }
+            }
+
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        }
+
+        @Override
+        public boolean hasOverlappingRendering() {
+            return false;
+        }
+    }
+
+    public static class LockscreenSmartspaceGeneralTextView extends TextView {
+
+        @StyleRes
+        private static final int sStyleId = R.style.TextAppearance_Keyguard_Secondary;
+
+        LockscreenSmartspaceGeneralTextView(Context context) {
+            super(context, null /* attrs */, 0 /* styleAttr */, sStyleId);
+            onDensityOrFontScaleChanged();
+            setEllipsize(TextUtils.TruncateAt.END);
+        }
+
+        public void onDensityOrFontScaleChanged() {
+            updatePadding();
+        }
+
+        public void onOverlayChanged() {
+            setTextAppearance(sStyleId);
+        }
+
+        @Override
+        public void setText(CharSequence text, BufferType type) {
+            super.setText(text, type);
+            updatePadding();
+        }
+
+        private void updatePadding() {
+            boolean hasText = !TextUtils.isEmpty(getText());
+            int padding = (int) getContext().getResources()
+                    .getDimension(R.dimen.widget_horizontal_padding) / 2;
+            // Orientation is vertical, so add padding to top and bottom.
+            setPadding(0, padding, 0, hasText ? padding : 0);
+
+            setCompoundDrawablePadding((int) mContext.getResources()
+                    .getDimension(R.dimen.widget_icon_padding));
+        }
+
+        @Override
+        public void setTextColor(int color) {
+            super.setTextColor(color);
+            updateDrawableColors();
+        }
+
+        @Override
+        public void setCompoundDrawablesRelative(Drawable start, Drawable top, Drawable end,
+                Drawable bottom) {
+            super.setCompoundDrawablesRelative(start, top, end, bottom);
+            updateDrawableColors();
+            updatePadding();
+        }
+
+        private void updateDrawableColors() {
+            final int color = getCurrentTextColor();
+            for (Drawable drawable : getCompoundDrawables()) {
+                if (drawable != null) {
+                    drawable.setTint(color);
+                }
+            }
+        }
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralViewController.java
@@ -1,6 +1,7 @@
 package com.android.systemui.keyguard.smartspace;
 
 import android.app.smartspace.SmartspaceTarget;
+import android.content.ComponentName;
 import android.os.Parcelable;
 
 import com.android.systemui.plugins.BcSmartspaceDataPlugin;
@@ -56,12 +57,10 @@ public class LockscreenSmartspaceGeneralViewController extends
 
     @Override
     public void onSmartspaceTargetsUpdated(List<? extends Parcelable> targets) {
-        SmartspaceTarget target;
+        var lsgv = new ComponentName(getContext(), LockscreenSmartspaceGeneralView.class);
         for (Parcelable parcelable : targets) {
-            if (parcelable instanceof SmartspaceTarget) {
-                target = (SmartspaceTarget) parcelable;
-                if (target.getComponentName().equals(
-                        LockscreenSmartspaceGeneralView.componentName)) {
+            if (parcelable instanceof SmartspaceTarget target) {
+                if (lsgv.equals(target.getComponentName())) {
                     mView.showTarget(target);
                 }
             }

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralViewController.java
@@ -10,8 +10,6 @@ import com.android.systemui.util.ViewController;
 
 import java.util.List;
 
-// TODO: Burn in.
-
 /**
  * Controller for LockscreenSmartspaceGeneralView. This is a reimplementation of the legacy
  * KeyguardSliceViewController.

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralViewController.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceGeneralViewController.java
@@ -1,0 +1,72 @@
+package com.android.systemui.keyguard.smartspace;
+
+import android.app.smartspace.SmartspaceTarget;
+import android.os.Parcelable;
+
+import com.android.systemui.plugins.BcSmartspaceDataPlugin;
+import com.android.systemui.statusbar.lockscreen.LockscreenSmartspaceController;
+import com.android.systemui.statusbar.policy.ConfigurationController;
+import com.android.systemui.util.ViewController;
+
+import java.util.List;
+
+// TODO: Burn in.
+
+/**
+ * Controller for LockscreenSmartspaceGeneralView. This is a reimplementation of the legacy
+ * KeyguardSliceViewController.
+ */
+public class LockscreenSmartspaceGeneralViewController extends
+        ViewController<LockscreenSmartspaceGeneralView> implements
+        BcSmartspaceDataPlugin.SmartspaceTargetListener {
+
+    private final LockscreenSmartspaceController mLockscreenSmartspaceController;
+    private final ConfigurationController mConfigurationController;
+
+    ConfigurationController.ConfigurationListener mConfigurationListener =
+            new ConfigurationController.ConfigurationListener() {
+                @Override
+                public void onDensityOrFontScaleChanged() {
+                    mView.onDensityOrFontScaleChanged();
+                }
+                @Override
+                public void onThemeChanged() {
+                    mView.onOverlayChanged();
+                }
+            };
+
+
+    public LockscreenSmartspaceGeneralViewController(LockscreenSmartspaceGeneralView view,
+            LockscreenSmartspaceController lockscreenSmartspaceController,
+            ConfigurationController configurationController) {
+        super(view);
+        mLockscreenSmartspaceController = lockscreenSmartspaceController;
+        mConfigurationController = configurationController;
+    }
+
+    @Override
+    protected void onViewAttached() {
+        mLockscreenSmartspaceController.addListener(this);
+        mConfigurationController.addCallback(mConfigurationListener);
+    }
+
+    @Override
+    protected void onViewDetached() {
+        mLockscreenSmartspaceController.removeListener(this);
+        mConfigurationController.removeCallback(mConfigurationListener);
+    }
+
+    @Override
+    public void onSmartspaceTargetsUpdated(List<? extends Parcelable> targets) {
+        SmartspaceTarget target;
+        for (Parcelable parcelable : targets) {
+            if (parcelable instanceof SmartspaceTarget) {
+                target = (SmartspaceTarget) parcelable;
+                if (target.getComponentName().equals(
+                        LockscreenSmartspaceGeneralView.componentName)) {
+                    mView.showTarget(target);
+                }
+            }
+        }
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspacePlaceholderView.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspacePlaceholderView.java
@@ -1,5 +1,6 @@
 package com.android.systemui.keyguard.smartspace;
 
+import android.annotation.IdRes;
 import android.content.Context;
 import android.widget.LinearLayout;
 
@@ -7,7 +8,11 @@ import com.android.systemui.smartspace.ui.DefaultSmartspaceView;
 
 public class LockscreenSmartspacePlaceholderView extends LinearLayout
         implements DefaultSmartspaceView {
-    public LockscreenSmartspacePlaceholderView(Context context) {
+
+    /** ID must match the relevant ID from
+     * @see com.android.systemui.keyguard.ui.view.layout.sections.SmartspaceSection */
+    public LockscreenSmartspacePlaceholderView(Context context, @IdRes int id) {
         super(context);
+        setId(id);
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspacePlaceholderView.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspacePlaceholderView.java
@@ -1,0 +1,13 @@
+package com.android.systemui.keyguard.smartspace;
+
+import android.content.Context;
+import android.widget.LinearLayout;
+
+import com.android.systemui.smartspace.ui.DefaultSmartspaceView;
+
+public class LockscreenSmartspacePlaceholderView extends LinearLayout
+        implements DefaultSmartspaceView {
+    public LockscreenSmartspacePlaceholderView(Context context) {
+        super(context);
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceWeatherPlugin.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceWeatherPlugin.java
@@ -16,17 +16,11 @@ public class LockscreenSmartspaceWeatherPlugin extends BaseSmartspaceDataPlugin 
 
     @Override
     public SmartspaceView getView(Context context) {
-        LockscreenSmartspacePlaceholderView v = new LockscreenSmartspacePlaceholderView(context);
-        // ID comes from com.android.systemui.keyguard.ui.view.layout.sections.SmartspaceSection.
-        v.setId(R.id.weather_smartspace_view);
-        return v;
+        return new LockscreenSmartspacePlaceholderView(context, R.id.weather_smartspace_view);
     }
 
     @Override
     public SmartspaceView getLargeClockView(Context context) {
-        LockscreenSmartspacePlaceholderView v = new LockscreenSmartspacePlaceholderView(context);
-        // ID comes from com.android.systemui.keyguard.ui.view.layout.sections.SmartspaceSection.
-        v.setId(R.id.weather_smartspace_view_large);
-        return v;
+        return new LockscreenSmartspacePlaceholderView(context, R.id.weather_smartspace_view_large);
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceWeatherPlugin.java
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/smartspace/LockscreenSmartspaceWeatherPlugin.java
@@ -1,0 +1,32 @@
+package com.android.systemui.keyguard.smartspace;
+
+import android.content.Context;
+
+import com.android.systemui.shared.R;
+import com.android.systemui.smartspace.plugin.BaseSmartspaceDataPlugin;
+
+import javax.inject.Inject;
+
+/**
+ * Weather plugin that provides placeholder views to satisfy lockscreen smartspace constraints.
+ */
+public class LockscreenSmartspaceWeatherPlugin extends BaseSmartspaceDataPlugin {
+    @Inject
+    public LockscreenSmartspaceWeatherPlugin() {}
+
+    @Override
+    public SmartspaceView getView(Context context) {
+        LockscreenSmartspacePlaceholderView v = new LockscreenSmartspacePlaceholderView(context);
+        // ID comes from com.android.systemui.keyguard.ui.view.layout.sections.SmartspaceSection.
+        v.setId(R.id.weather_smartspace_view);
+        return v;
+    }
+
+    @Override
+    public SmartspaceView getLargeClockView(Context context) {
+        LockscreenSmartspacePlaceholderView v = new LockscreenSmartspacePlaceholderView(context);
+        // ID comes from com.android.systemui.keyguard.ui.view.layout.sections.SmartspaceSection.
+        v.setId(R.id.weather_smartspace_view_large);
+        return v;
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/binder/KeyguardRootViewBinder.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/binder/KeyguardRootViewBinder.kt
@@ -200,7 +200,6 @@ object KeyguardRootViewBinder {
                         viewModel.alpha(viewState).collect { alpha ->
                             view.alpha = alpha
                             childViews[burnInLayerId]?.alpha = alpha
-                            childViews[sliceViewId]?.alpha = alpha
                         }
                     }
 
@@ -229,7 +228,6 @@ object KeyguardRootViewBinder {
                         // need to add translation to it here same as translationX
                         viewModel.translationY.collect { y ->
                             childViews[burnInLayerId]?.translationY = y
-                            childViews[sliceViewId]?.translationY = y
                             childViews[largeClockId]?.translationY = y
                             if (com.android.systemui.shared.Flags.clockReactiveSmartspaceLayout()) {
                                 childViews[largeClockDateId]?.translationY = y
@@ -246,7 +244,6 @@ object KeyguardRootViewBinder {
                                 state.isToOrFrom(KeyguardState.AOD) -> {
                                     // Large Clock is not translated in the x direction
                                     childViews[burnInLayerId]?.translationX = px
-                                    childViews[sliceViewId]?.translationX = px
                                     childViews[aodPromotedNotificationId]?.translationX = px
                                     childViews[aodNotificationIconContainerId]?.translationX = px
                                 }
@@ -295,7 +292,6 @@ object KeyguardRootViewBinder {
                     launch {
                         viewModel.burnInLayerVisibility.collect { visibility ->
                             childViews[burnInLayerId]?.visibility = visibility
-                            childViews[sliceViewId]?.visibility = visibility
                         }
                     }
 
@@ -582,7 +578,6 @@ object KeyguardRootViewBinder {
     }
 
     private val burnInLayerId = R.id.burn_in_layer
-    private val sliceViewId = R.id.keyguard_slice_view
     private val aodPromotedNotificationId = AodPromotedNotificationSection.viewId
     private val aodNotificationIconContainerId = R.id.aod_notification_icon_container
     private val largeClockId = ClockViewIds.LOCKSCREEN_CLOCK_VIEW_LARGE

--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/blueprints/SplitShadeKeyguardBlueprint.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/blueprints/SplitShadeKeyguardBlueprint.kt
@@ -31,7 +31,6 @@ import com.android.systemui.keyguard.ui.view.layout.sections.DefaultSettingsPopu
 import com.android.systemui.keyguard.ui.view.layout.sections.DefaultShortcutsSection
 import com.android.systemui.keyguard.ui.view.layout.sections.DefaultStatusBarSection
 import com.android.systemui.keyguard.ui.view.layout.sections.KeyguardSectionsModule
-import com.android.systemui.keyguard.ui.view.layout.sections.KeyguardSliceViewSection
 import com.android.systemui.keyguard.ui.view.layout.sections.SmartspaceSection
 import com.android.systemui.keyguard.ui.view.layout.sections.SplitShadeGuidelines
 import com.android.systemui.keyguard.ui.view.layout.sections.SplitShadeMediaSection
@@ -67,7 +66,6 @@ constructor(
     clockSection: ClockSection,
     smartspaceSection: SmartspaceSection,
     mediaSection: SplitShadeMediaSection,
-    keyguardSliceViewSection: KeyguardSliceViewSection,
 ) : KeyguardBlueprint {
     override val id: String = ID
 
@@ -87,7 +85,6 @@ constructor(
             smartspaceSection,
             aodBurnInSection,
             clockSection,
-            keyguardSliceViewSection,
             mediaSection,
             defaultDeviceEntrySection, // Add LAST: Intentionally has z-order above other views.
         )

--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/KeyguardSliceViewSection.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/KeyguardSliceViewSection.kt
@@ -129,5 +129,8 @@ constructor(
         }
     }
 
-    override fun removeViews(constraintLayout: ConstraintLayout) {}
+    override fun removeViews(constraintLayout: ConstraintLayout) {
+        if (smartspaceController.isEnabled) return
+        constraintLayout.removeView(R.id.keyguard_slice_view)
+    }
 }

--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/KeyguardSliceViewSection.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/KeyguardSliceViewSection.kt
@@ -36,7 +36,6 @@ import com.android.systemui.keyguard.ui.binder.KeyguardSliceViewBinder
 import com.android.systemui.keyguard.ui.viewmodel.AodBurnInViewModel
 import com.android.systemui.plugins.ActivityStarter
 import com.android.systemui.plugins.keyguard.ui.clocks.ClockViewIds
-import com.android.systemui.power.domain.interactor.PowerInteractor
 import com.android.systemui.res.R
 import com.android.systemui.settings.DisplayTracker
 import com.android.systemui.statusbar.lockscreen.LockscreenSmartspaceController
@@ -57,7 +56,6 @@ constructor(
     val dumpManager: DumpManager,
     val displayTracker: DisplayTracker,
     val keyguardInteractor: KeyguardInteractor,
-    val powerInteractor: PowerInteractor,
     val aodBurnInViewModel: AodBurnInViewModel,
 ) : KeyguardSection() {
     private lateinit var sliceView: KeyguardSliceView
@@ -81,8 +79,6 @@ constructor(
                 configurationController,
                 dumpManager,
                 displayTracker,
-                keyguardInteractor,
-                powerInteractor,
             )
         controller.setupUri(null)
         controller.init()

--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/KeyguardSliceViewSection.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/KeyguardSliceViewSection.kt
@@ -17,16 +17,13 @@
 
 package com.android.systemui.keyguard.ui.view.layout.sections
 
-import android.content.Context
 import android.os.Handler
-import android.util.TypedValue
 import android.view.LayoutInflater
 import androidx.constraintlayout.widget.Barrier
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import com.android.keyguard.KeyguardSliceView
 import com.android.keyguard.KeyguardSliceViewController
-import com.android.systemui.customization.clocks.R as clocksR
 import com.android.systemui.dagger.qualifiers.Background
 import com.android.systemui.dagger.qualifiers.Main
 import com.android.systemui.dump.DumpManager
@@ -46,7 +43,6 @@ import kotlinx.coroutines.DisposableHandle
 class KeyguardSliceViewSection
 @Inject
 constructor(
-    private val context: Context,
     val smartspaceController: LockscreenSmartspaceController,
     val layoutInflater: LayoutInflater,
     @Main val handler: Handler,
@@ -101,9 +97,6 @@ constructor(
                 ConstraintSet.START,
                 ConstraintSet.PARENT_ID,
                 ConstraintSet.START,
-                context.resources.getDimensionPixelSize(clocksR.dimen.clock_padding_start) +
-                    context.resources.getDimensionPixelSize(clocksR.dimen.status_view_margin_horizontal) +
-                    TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 4f, context.resources.displayMetrics).toInt(),
             )
             connect(
                 R.id.keyguard_slice_view,

--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/SmartspaceSection.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/SmartspaceSection.kt
@@ -31,6 +31,8 @@ import com.android.systemui.keyguard.KeyguardUnlockAnimationController
 import com.android.systemui.keyguard.domain.interactor.KeyguardBlueprintInteractor
 import com.android.systemui.keyguard.domain.interactor.KeyguardSmartspaceInteractor
 import com.android.systemui.keyguard.shared.model.KeyguardSection
+import com.android.systemui.keyguard.smartspace.LockscreenSmartspaceGeneralView
+import com.android.systemui.keyguard.smartspace.LockscreenSmartspaceGeneralViewController
 import com.android.systemui.keyguard.ui.binder.KeyguardSmartspaceViewBinder
 import com.android.systemui.keyguard.ui.viewmodel.KeyguardClockViewModel
 import com.android.systemui.keyguard.ui.viewmodel.KeyguardRootViewModel
@@ -41,6 +43,7 @@ import com.android.systemui.shade.ShadeDisplayAware
 import com.android.systemui.shared.Flags.clockReactiveSmartspaceLayout
 import com.android.systemui.shared.R as sharedR
 import com.android.systemui.statusbar.lockscreen.LockscreenSmartspaceController
+import com.android.systemui.statusbar.policy.ConfigurationController
 import dagger.Lazy
 import javax.inject.Inject
 import kotlinx.coroutines.DisposableHandle
@@ -57,6 +60,7 @@ constructor(
     val keyguardUnlockAnimationController: KeyguardUnlockAnimationController,
     private val blueprintInteractor: Lazy<KeyguardBlueprintInteractor>,
     private val keyguardRootViewModel: KeyguardRootViewModel,
+    val configurationController: ConfigurationController
 ) : KeyguardSection() {
     private var smartspaceView: View? = null
     private var dateView: LinearLayout? = null
@@ -117,6 +121,15 @@ constructor(
 
     override fun bindData(constraintLayout: ConstraintLayout) {
         if (!keyguardSmartspaceViewModel.isSmartspaceEnabled) return
+
+        val controller =
+            LockscreenSmartspaceGeneralViewController(
+                smartspaceView as LockscreenSmartspaceGeneralView,
+                smartspaceController,
+                configurationController
+            )
+        controller.init()
+
         disposableHandle?.dispose()
         disposableHandle =
             KeyguardSmartspaceViewBinder.bind(

--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/SplitShadeMediaSection.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/view/layout/sections/SplitShadeMediaSection.kt
@@ -68,7 +68,7 @@ constructor(
         constraintSet.apply {
             constrainWidth(mediaContainerId, MATCH_CONSTRAINT)
             constrainHeight(mediaContainerId, WRAP_CONTENT)
-            connect(mediaContainerId, TOP, R.id.keyguard_slice_view, BOTTOM)
+            connect(mediaContainerId, TOP, R.id.smart_space_barrier_bottom, BOTTOM)
             connect(mediaContainerId, START, PARENT_ID, START)
             connect(mediaContainerId, END, R.id.split_shade_guideline, END)
         }

--- a/packages/SystemUI/src/com/android/systemui/keyguard/ui/viewmodel/KeyguardSmartspaceViewModel.kt
+++ b/packages/SystemUI/src/com/android/systemui/keyguard/ui/viewmodel/KeyguardSmartspaceViewModel.kt
@@ -32,6 +32,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 
+import android.util.TypedValue
+
 @SysUISingleton
 class KeyguardSmartspaceViewModel
 @Inject
@@ -120,8 +122,13 @@ constructor(
         }
 
         fun getSmartspaceHorizontalMargin(context: Context): Int {
-            return context.resources.getDimensionPixelSize(R.dimen.smartspace_padding_horizontal) +
-                context.resources.getDimensionPixelSize(clocksR.dimen.status_view_margin_horizontal)
+            // This value comes from KeyguardSliceViewSection and results in the smartspace
+            // lockscreen general view being positioned in the same way as the KeyguardViewSlice
+            // was.
+            return context.resources.getDimensionPixelSize(clocksR.dimen.clock_padding_start) +
+                context.resources.getDimensionPixelSize(clocksR.dimen.status_view_margin_horizontal) +
+                TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 4f, context.resources.displayMetrics).toInt()
+
         }
     }
 }

--- a/packages/SystemUI/src/com/android/systemui/smartspace/plugin/BaseSmartspaceDataPlugin.java
+++ b/packages/SystemUI/src/com/android/systemui/smartspace/plugin/BaseSmartspaceDataPlugin.java
@@ -1,0 +1,56 @@
+package com.android.systemui.smartspace.plugin;
+
+import android.app.smartspace.SmartspaceTarget;
+
+import com.android.systemui.plugins.BcSmartspaceDataPlugin;
+import com.android.systemui.util.Assert;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+/**
+ * Simple plugin that handles listener registration/deregistration and dispatching of target
+ * updates.
+ */
+public class BaseSmartspaceDataPlugin implements BcSmartspaceDataPlugin  {
+    private final Set<SmartspaceTargetListener> mTargetListeners;
+
+    @Inject
+    public BaseSmartspaceDataPlugin() {
+        mTargetListeners = new HashSet<>();
+    }
+
+    @Override
+    public void registerListener(SmartspaceTargetListener listener) {
+        Assert.isMainThread();
+        mTargetListeners.add(listener);
+    }
+
+    @Override
+    public void unregisterListener(SmartspaceTargetListener listener) {
+        Assert.isMainThread();
+        mTargetListeners.remove(listener);
+    }
+
+    @Override
+    public void setEventDispatcher(SmartspaceEventDispatcher eventDispatcher) {}
+
+    @Override
+    public void setIntentStarter(IntentStarter intentStarter) {}
+
+    @Override
+    public SmartspaceEventNotifier getEventNotifier() {
+        return null;
+    }
+
+    @Override
+    public void onTargetsAvailable(List<SmartspaceTarget> targets) {
+        Assert.isMainThread();
+        for (SmartspaceTargetListener listener : mTargetListeners) {
+            listener.onSmartspaceTargetsUpdated(targets);
+        }
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/smartspace/service/SystemUISmartspaceService.java
+++ b/packages/SystemUI/src/com/android/systemui/smartspace/service/SystemUISmartspaceService.java
@@ -1,0 +1,482 @@
+package com.android.systemui.smartspace.service;
+
+import static android.app.smartspace.SmartspaceTarget.FEATURE_DATE_ALARM_ZEN_MEDIA;
+import static android.app.smartspace.SmartspaceTarget.UI_TEMPLATE_DEFAULT;
+
+import android.app.AlarmManager;
+import android.app.smartspace.SmartspaceConfig;
+import android.app.smartspace.SmartspaceSessionId;
+import android.app.smartspace.SmartspaceTarget;
+import android.app.smartspace.SmartspaceTargetEvent;
+import android.app.smartspace.uitemplatedata.BaseTemplateData;
+import android.app.smartspace.uitemplatedata.CombinedCardsTemplateData;
+import android.app.smartspace.uitemplatedata.Icon;
+import android.app.smartspace.uitemplatedata.Text;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.icu.text.DateFormat;
+import android.icu.text.DisplayContext;
+import android.media.MediaMetadata;
+import android.media.session.PlaybackState;
+import android.os.UserHandle;
+import android.provider.Settings;
+import android.service.notification.ZenModeConfig;
+import android.service.smartspace.SmartspaceService;
+import android.text.TextUtils;
+import android.util.ArrayMap;
+
+import androidx.annotation.NonNull;
+
+import com.android.keyguard.KeyguardUpdateMonitor;
+import com.android.keyguard.KeyguardUpdateMonitorCallback;
+import com.android.systemui.keyguard.smartspace.LockscreenSmartspaceGeneralView;
+import com.android.systemui.media.NotificationMediaManager;
+import com.android.systemui.plugins.BcSmartspaceDataPlugin;
+import com.android.systemui.plugins.statusbar.StatusBarStateController;
+import com.android.systemui.res.R;
+import com.android.systemui.settings.UserTracker;
+import com.android.systemui.statusbar.policy.NextAlarmController;
+import com.android.systemui.statusbar.policy.ZenModeController;
+import com.android.systemui.util.Assert;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+/**
+ * SmartspaceService implementation that currently only powers the lockscreen's general smartspace
+ * view. Some of the underlying business logic is based on the legacy KeyguardSliceProvider.
+ */
+public class SystemUISmartspaceService extends SmartspaceService implements
+        NextAlarmController.NextAlarmChangeCallback, ZenModeController.Callback,
+        StatusBarStateController.StateListener, NotificationMediaManager.MediaListener {
+
+    // Only display alarms that are triggering within this number of hours.
+    private static final int ALARM_VISIBILITY_HOURS = 12;
+
+    // State needed for the Service to remain informed of device state.
+    private final KeyguardUpdateMonitor mKeyguardUpdateMonitor;
+    private final NextAlarmController mNextAlarmController;
+    private final ZenModeController mZenModeController;
+    private final StatusBarStateController mStatusBarStateController;
+    private final NotificationMediaManager mNotificationMediaManager;
+    private final UserTracker mUserTracker;
+
+    // Stores the sessions that are associated with a surface.
+    private Map<String, Set<SmartspaceSessionId>> mSurfaceSessions;
+    // Stores the surface that is associated with a session.
+    private Map<SmartspaceSessionId, String> mSessionSurface;
+
+    // State needed for date display.
+    private  String mDatePattern;
+    private DateFormat mDateFormat;
+    private String mFormattedDate;
+
+    // State needed for alarm display.
+    private AlarmManager.AlarmClockInfo mNextAlarm;
+    private String mFormattedNextAlarmDate;
+
+    // State needed for media display.
+    private boolean mDozing;
+    private boolean mMediaIsVisible;
+    private CharSequence mMediaTitle;
+    private CharSequence mMediaArtist;
+
+    private final BroadcastReceiver mDateUpdateReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            final String action = intent.getAction();
+            if (Intent.ACTION_DATE_CHANGED.equals(action)) {
+                updateFormattedDate();
+            } else if (Intent.ACTION_LOCALE_CHANGED.equals(action)) {
+                // mDateFormat is dependent on locale, so clear it.
+                mDateFormat = null;
+                updateFormattedDate();
+            }
+        }
+    };
+
+    private final KeyguardUpdateMonitorCallback mKeyguardUpdateMonitorCallback =
+            new KeyguardUpdateMonitorCallback() {
+                @Override
+                public void onTimeChanged() {
+                    updateFormattedDate();
+                }
+
+                @Override
+                public void onTimeZoneChanged(TimeZone timeZone) {
+                    updateFormattedDate();
+                }
+            };
+
+    @Inject
+    public SystemUISmartspaceService(
+            KeyguardUpdateMonitor keyguardUpdateMonitor,
+            NextAlarmController nextAlarmController,
+            ZenModeController zenModeController,
+            StatusBarStateController statusBarStateController,
+            NotificationMediaManager notificationMediaManager,
+            UserTracker userTracker) {
+        mKeyguardUpdateMonitor = keyguardUpdateMonitor;
+        mNextAlarmController = nextAlarmController;
+        mZenModeController = zenModeController;
+        mStatusBarStateController = statusBarStateController;
+        mNotificationMediaManager = notificationMediaManager;
+        mUserTracker = userTracker;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        mSurfaceSessions = new ArrayMap<>();
+        mSessionSurface = new ArrayMap<>();
+
+        // KeyguardSliceProvider uses the aod pattern regardless of aod setting, we follow suit.
+        mDatePattern = getString(R.string.system_ui_aod_date_pattern);
+
+        registerStateUpdates();
+    }
+
+    private void registerStateUpdates() {
+        mKeyguardUpdateMonitor.registerCallback(mKeyguardUpdateMonitorCallback);
+        // Fires immediately, so must be called after dependent state is initialized.
+        mNextAlarmController.addCallback(this);
+        mZenModeController.addCallback(this);
+        mStatusBarStateController.addCallback(this);
+        mNotificationMediaManager.addCallback(this);
+
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(Intent.ACTION_DATE_CHANGED);
+        filter.addAction(Intent.ACTION_LOCALE_CHANGED);
+        registerReceiver(mDateUpdateReceiver, filter, null /* permission*/, null /* scheduler */);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+
+        unregisterStateUpdates();
+    }
+
+    private void unregisterStateUpdates() {
+        mKeyguardUpdateMonitor.removeCallback(mKeyguardUpdateMonitorCallback);
+        mNextAlarmController.removeCallback(this);
+        mZenModeController.removeCallback(this);
+        mStatusBarStateController.removeCallback(this);
+        mNotificationMediaManager.removeCallback(this);
+
+        unregisterReceiver(mDateUpdateReceiver);
+    }
+
+    @Override
+    public void onNextAlarmChanged(AlarmManager.AlarmClockInfo nextAlarm) {
+        mNextAlarm = nextAlarm;
+        mFormattedNextAlarmDate = getFormattedAlarmDate(nextAlarm);
+        updateLockscreenClients();
+    }
+
+    @Override
+    public void onZenChanged(int zen) {
+        updateLockscreenClients();
+    }
+
+    @Override
+    public void onConfigChanged(ZenModeConfig config) {
+        updateLockscreenClients();
+    }
+
+    @Override
+    public void onPrimaryMetadataOrStateChanged(MediaMetadata metadata,
+            @PlaybackState.State int state) {
+        boolean nextVisible = NotificationMediaManager.isPlayingState(state);
+
+        CharSequence title = null;
+        if (metadata != null) {
+            title = metadata.getText(MediaMetadata.METADATA_KEY_TITLE);
+            if (TextUtils.isEmpty(title)) {
+                title = getResources().getString(R.string.music_controls_no_title);
+            }
+        }
+        CharSequence artist = metadata == null ? null : metadata.getText(
+                MediaMetadata.METADATA_KEY_ARTIST);
+
+        if (nextVisible == mMediaIsVisible && TextUtils.equals(title, mMediaTitle)
+                && TextUtils.equals(artist, mMediaArtist)) {
+            return;
+        }
+
+        mMediaTitle = title;
+        mMediaArtist = artist;
+        mMediaIsVisible = nextVisible;
+        updateLockscreenClients();
+    }
+
+    @Override
+    public void onDozingChanged(boolean isDozing) {
+        boolean shouldDisplayMediaPrevious = shouldDisplayMedia();
+        mDozing = isDozing;
+        if(shouldDisplayMedia() != shouldDisplayMediaPrevious) {
+            updateLockscreenClients();
+        }
+    }
+
+    private void updateFormattedDate() {
+        if (mDateFormat == null) {
+            final Locale l = Locale.getDefault();
+            DateFormat format = DateFormat.getInstanceForSkeleton(mDatePattern, l);
+            // See KeyguardSliceProvider for explanation of why CAPITALIZATION_FOR_STANDALONE is not
+            // used.
+            format.setContext(DisplayContext.CAPITALIZATION_FOR_BEGINNING_OF_SENTENCE);
+            mDateFormat = format;
+        }
+        Date currentTime = new Date();
+        currentTime.setTime(System.currentTimeMillis());
+        mFormattedDate = mDateFormat.format(currentTime);
+
+        updateLockscreenClients();
+    }
+
+    private void updateLockscreenClients() {
+        Assert.isMainThread();
+        Set<SmartspaceSessionId> sessions = mSurfaceSessions.get(
+                BcSmartspaceDataPlugin.UI_SURFACE_LOCK_SCREEN_AOD);
+
+        if (sessions != null) {
+            List<SmartspaceTarget> targets = createLockscreenTargets();
+            for (SmartspaceSessionId sessionId : sessions) {
+                updateSmartspaceTargets(sessionId, targets);
+            }
+        }
+    }
+
+    private List<SmartspaceTarget> createLockscreenTargets() {
+        return List.of(createLockscreenGeneralTarget());
+    }
+
+    private SmartspaceTarget createLockscreenGeneralTarget() {
+        List<BaseTemplateData> templates = new ArrayList<>();
+
+        BaseTemplateData dateTemplate = createDateTemplate();
+        if (dateTemplate != null) {
+            templates.add(dateTemplate);
+        }
+        BaseTemplateData alarmTemplate = createAlarmTemplate();
+        if (alarmTemplate != null) {
+            templates.add(alarmTemplate);
+        }
+        BaseTemplateData zenModeTemplate = createZenModeTemplate();
+        if (zenModeTemplate != null) {
+            templates.add(zenModeTemplate);
+        }
+        BaseTemplateData mediaTemplate = createMediaTemplate();
+        if (mediaTemplate != null) {
+            templates.add(mediaTemplate);
+        }
+
+        // Treat the lockscreen general surface as being the combination of multiple logical
+        // smartspace cards. This might be slightly bending the definition of card, but the public
+        // smartspace code and surrounding comments imply Google are also bending definitions within
+        // their proprietary rendering code in order to make things fit. Another reasonable approach
+        // would be to create a new DynamicRowsTemplateData template type and add our four rows to
+        // that. In any case, squashing all the data into a BaseTemplateType with its oddly-named
+        // member variables would be confusing.
+        CombinedCardsTemplateData.Builder templateBuilder = new CombinedCardsTemplateData.Builder(
+                templates);
+
+        SmartspaceTarget.Builder targetBuilder = createLockscreenGeneralTargetBuilder();
+        targetBuilder.setTemplateData(templateBuilder.build());
+        // This isn't used anywhere currently.
+        targetBuilder.setFeatureType(FEATURE_DATE_ALARM_ZEN_MEDIA);
+
+        return targetBuilder.build();
+    }
+
+    private SmartspaceTarget.Builder createLockscreenGeneralTargetBuilder() {
+        String identifier = UUID.randomUUID().toString();
+        ComponentName componentName = LockscreenSmartspaceGeneralView.componentName;
+        UserHandle user = mUserTracker.getUserHandle();
+        return new SmartspaceTarget.Builder(identifier, componentName, user);
+    }
+
+    private BaseTemplateData createDateTemplate() {
+        if (mFormattedDate == null) {
+            return null;
+        }
+
+        Text.Builder textBuilder = new Text.Builder(mFormattedDate);
+
+        BaseTemplateData.SubItemInfo.Builder primaryItemBuilder =
+                new BaseTemplateData.SubItemInfo.Builder();
+        primaryItemBuilder.setText(textBuilder.build());
+
+        BaseTemplateData.Builder templateBuilder = new BaseTemplateData.Builder(
+                UI_TEMPLATE_DEFAULT);
+        templateBuilder.setPrimaryItem(primaryItemBuilder.build());
+
+        return templateBuilder.build();
+    }
+
+    private BaseTemplateData createAlarmTemplate() {
+        if (!shouldDisplayAlarm(mNextAlarm)) {
+            return null;
+        }
+
+        Text.Builder textBuilder = new Text.Builder(mFormattedNextAlarmDate);
+
+        android.graphics.drawable.Icon alarmIcon =
+                android.graphics.drawable.Icon.createWithResource(this,
+                        R.drawable.ic_access_alarms_big);
+        Icon.Builder iconBuilder = new Icon.Builder(alarmIcon);
+
+        BaseTemplateData.SubItemInfo.Builder primaryItemBuilder =
+                new BaseTemplateData.SubItemInfo.Builder();
+        primaryItemBuilder.setText(textBuilder.build());
+        primaryItemBuilder.setIcon(iconBuilder.build());
+
+        BaseTemplateData.Builder templateBuilder = new BaseTemplateData.Builder(
+                UI_TEMPLATE_DEFAULT);
+        templateBuilder.setPrimaryItem(primaryItemBuilder.build());
+
+        return templateBuilder.build();
+    }
+
+    private boolean shouldDisplayAlarm(AlarmManager.AlarmClockInfo alarm) {
+        if (alarm == null) {
+            return false;
+        }
+
+        long currentTime = System.currentTimeMillis();
+        long delta = alarm.getTriggerTime() - currentTime;
+        return delta > 0 && delta <= TimeUnit.HOURS.toMillis(ALARM_VISIBILITY_HOURS);
+    }
+
+    private String getFormattedAlarmDate(AlarmManager.AlarmClockInfo alarm) {
+        if (alarm == null) {
+            return null;
+        }
+
+        String pattern = android.text.format.DateFormat.is24HourFormat(this,
+                mUserTracker.getUserId()) ? "HH:mm" : "h:mm";
+        return android.text.format.DateFormat.format(pattern, alarm.getTriggerTime())
+                .toString();
+    }
+
+    private BaseTemplateData createZenModeTemplate() {
+        if (!isZenModeEnabled()) {
+            return null;
+        }
+
+        android.graphics.drawable.Icon zenModeIcon =
+                android.graphics.drawable.Icon.createWithResource(this,
+                        R.drawable.stat_sys_dnd);
+        Icon.Builder iconBuilder = new Icon.Builder(zenModeIcon);
+
+        BaseTemplateData.SubItemInfo.Builder primaryItemBuilder =
+                new BaseTemplateData.SubItemInfo.Builder();
+        primaryItemBuilder.setIcon(iconBuilder.build());
+
+        BaseTemplateData.Builder templateBuilder = new BaseTemplateData.Builder(
+                UI_TEMPLATE_DEFAULT);
+        templateBuilder.setPrimaryItem(primaryItemBuilder.build());
+
+        return templateBuilder.build();
+    }
+
+    private boolean isZenModeEnabled() {
+        return mZenModeController.getZen() != Settings.Global.ZEN_MODE_OFF;
+    }
+
+    private BaseTemplateData createMediaTemplate() {
+        if (!shouldDisplayMedia()) {
+            return null;
+        }
+
+        BaseTemplateData.Builder templateBuilder = new BaseTemplateData.Builder(
+                UI_TEMPLATE_DEFAULT);
+
+        Text.Builder textBuilder = new Text.Builder(mMediaTitle);
+        BaseTemplateData.SubItemInfo.Builder primaryItemBuilder =
+                new BaseTemplateData.SubItemInfo.Builder();
+        primaryItemBuilder.setText(textBuilder.build());
+        templateBuilder.setPrimaryItem(primaryItemBuilder.build());
+
+        if (!TextUtils.isEmpty(mMediaArtist)) {
+            android.graphics.drawable.Icon mediaIcon = mNotificationMediaManager == null ?
+                    null : mNotificationMediaManager.getMediaIcon();
+            if (mediaIcon != null) {
+                BaseTemplateData.SubItemInfo.Builder subtitleItemBuilder =
+                        new BaseTemplateData.SubItemInfo.Builder();
+                Text.Builder subtitleTextBuilder = new Text.Builder(mMediaArtist);
+                subtitleItemBuilder.setText(subtitleTextBuilder.build());
+                Icon.Builder iconBuilder = new Icon.Builder(mediaIcon);
+                subtitleItemBuilder.setIcon(iconBuilder.build());
+                templateBuilder.setSubtitleItem(subtitleItemBuilder.build());
+            }
+        }
+        return templateBuilder.build();
+    }
+
+    protected boolean shouldDisplayMedia() {
+        return !TextUtils.isEmpty(mMediaTitle) && mMediaIsVisible && mDozing;
+    }
+
+    @Override
+    public void onCreateSmartspaceSession(@NonNull SmartspaceConfig config,
+            @NonNull SmartspaceSessionId sessionId) {
+        String surface = config.getUiSurface();
+
+        Set<SmartspaceSessionId> sessions = mSurfaceSessions.get(surface);
+        if (sessions == null) {
+            sessions = new HashSet<>();
+            mSurfaceSessions.put(surface, sessions);
+        }
+        sessions.add(sessionId);
+
+        mSessionSurface.put(sessionId, surface);
+    }
+
+    // We don't need bidirectional communication for our simple smartspace implementation.
+    @Override
+    public void notifySmartspaceEvent(@NonNull SmartspaceSessionId sessionId,
+            @NonNull SmartspaceTargetEvent event) {}
+
+    @Override
+    public void onRequestSmartspaceUpdate(@NonNull SmartspaceSessionId sessionId) {
+        String surface = mSessionSurface.get(sessionId);
+        if (surface == null) {
+            return;
+        }
+        if (surface.equals(BcSmartspaceDataPlugin.UI_SURFACE_LOCK_SCREEN_AOD)) {
+            List<SmartspaceTarget> targets = createLockscreenTargets();
+            updateSmartspaceTargets(sessionId, targets);
+        }
+    }
+
+    @Override
+    public void onDestroySmartspaceSession(@NonNull SmartspaceSessionId sessionId) {
+        String surface = mSessionSurface.get(sessionId);
+        mSessionSurface.remove(sessionId);
+        Set<SmartspaceSessionId> sessionsForSurface = mSurfaceSessions.get(surface);
+        if (sessionsForSurface != null) {
+            sessionsForSurface.remove(sessionId);
+        }
+    }
+
+    @Override
+    public void onDestroy(@NonNull SmartspaceSessionId sessionId) {
+        throw new UnsupportedOperationException("This method should not be called");
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/smartspace/service/SystemUISmartspaceService.java
+++ b/packages/SystemUI/src/com/android/systemui/smartspace/service/SystemUISmartspaceService.java
@@ -306,7 +306,7 @@ public class SystemUISmartspaceService extends SmartspaceService implements
 
     private SmartspaceTarget.Builder createLockscreenGeneralTargetBuilder() {
         String identifier = UUID.randomUUID().toString();
-        ComponentName componentName = LockscreenSmartspaceGeneralView.componentName;
+        var componentName = new ComponentName(this, LockscreenSmartspaceGeneralView.class);
         UserHandle user = mUserTracker.getUserHandle();
         return new SmartspaceTarget.Builder(identifier, componentName, user);
     }

--- a/packages/SystemUI/src/com/android/systemui/smartspace/service/SystemUISmartspaceService.java
+++ b/packages/SystemUI/src/com/android/systemui/smartspace/service/SystemUISmartspaceService.java
@@ -9,6 +9,7 @@ import android.app.smartspace.SmartspaceSessionId;
 import android.app.smartspace.SmartspaceTarget;
 import android.app.smartspace.SmartspaceTargetEvent;
 import android.app.smartspace.uitemplatedata.BaseTemplateData;
+import android.app.smartspace.uitemplatedata.BaseTemplateData.SubItemInfo;
 import android.app.smartspace.uitemplatedata.CombinedCardsTemplateData;
 import android.app.smartspace.uitemplatedata.Icon;
 import android.app.smartspace.uitemplatedata.Text;
@@ -207,7 +208,7 @@ public class SystemUISmartspaceService extends SmartspaceService implements
         if (metadata != null) {
             title = metadata.getText(MediaMetadata.METADATA_KEY_TITLE);
             if (TextUtils.isEmpty(title)) {
-                title = getResources().getString(R.string.music_controls_no_title);
+                title = getString(R.string.music_controls_no_title);
             }
         }
         CharSequence artist = metadata == null ? null : metadata.getText(
@@ -228,7 +229,7 @@ public class SystemUISmartspaceService extends SmartspaceService implements
     public void onDozingChanged(boolean isDozing) {
         boolean shouldDisplayMediaPrevious = shouldDisplayMedia();
         mDozing = isDozing;
-        if(shouldDisplayMedia() != shouldDisplayMediaPrevious) {
+        if (shouldDisplayMedia() != shouldDisplayMediaPrevious) {
             updateLockscreenClients();
         }
     }
@@ -316,17 +317,11 @@ public class SystemUISmartspaceService extends SmartspaceService implements
             return null;
         }
 
-        Text.Builder textBuilder = new Text.Builder(mFormattedDate);
-
-        BaseTemplateData.SubItemInfo.Builder primaryItemBuilder =
-                new BaseTemplateData.SubItemInfo.Builder();
-        primaryItemBuilder.setText(textBuilder.build());
-
-        BaseTemplateData.Builder templateBuilder = new BaseTemplateData.Builder(
-                UI_TEMPLATE_DEFAULT);
-        templateBuilder.setPrimaryItem(primaryItemBuilder.build());
-
-        return templateBuilder.build();
+        return new BaseTemplateData.Builder(UI_TEMPLATE_DEFAULT)
+                .setPrimaryItem(new SubItemInfo.Builder()
+                        .setText(new Text.Builder(mFormattedDate).build())
+                        .build())
+                .build();
     }
 
     private BaseTemplateData createAlarmTemplate() {
@@ -334,26 +329,18 @@ public class SystemUISmartspaceService extends SmartspaceService implements
             return null;
         }
 
-        Text.Builder textBuilder = new Text.Builder(mFormattedNextAlarmDate);
-
-        android.graphics.drawable.Icon alarmIcon =
-                android.graphics.drawable.Icon.createWithResource(this,
+        var alarmIcon = android.graphics.drawable.Icon.createWithResource(this,
                         R.drawable.ic_access_alarms_big);
-        Icon.Builder iconBuilder = new Icon.Builder(alarmIcon);
 
-        BaseTemplateData.SubItemInfo.Builder primaryItemBuilder =
-                new BaseTemplateData.SubItemInfo.Builder();
-        primaryItemBuilder.setText(textBuilder.build());
-        primaryItemBuilder.setIcon(iconBuilder.build());
-
-        BaseTemplateData.Builder templateBuilder = new BaseTemplateData.Builder(
-                UI_TEMPLATE_DEFAULT);
-        templateBuilder.setPrimaryItem(primaryItemBuilder.build());
-
-        return templateBuilder.build();
+        return new BaseTemplateData.Builder(UI_TEMPLATE_DEFAULT)
+                .setPrimaryItem(new SubItemInfo.Builder()
+                        .setText(new Text.Builder(mFormattedNextAlarmDate).build())
+                        .setIcon(new Icon.Builder(alarmIcon).build())
+                        .build())
+                .build();
     }
 
-    private boolean shouldDisplayAlarm(AlarmManager.AlarmClockInfo alarm) {
+    private static boolean shouldDisplayAlarm(AlarmManager.AlarmClockInfo alarm) {
         if (alarm == null) {
             return false;
         }
@@ -379,20 +366,13 @@ public class SystemUISmartspaceService extends SmartspaceService implements
             return null;
         }
 
-        android.graphics.drawable.Icon zenModeIcon =
-                android.graphics.drawable.Icon.createWithResource(this,
-                        R.drawable.stat_sys_dnd);
-        Icon.Builder iconBuilder = new Icon.Builder(zenModeIcon);
+        var icon = android.graphics.drawable.Icon.createWithResource(this, R.drawable.stat_sys_dnd);
 
-        BaseTemplateData.SubItemInfo.Builder primaryItemBuilder =
-                new BaseTemplateData.SubItemInfo.Builder();
-        primaryItemBuilder.setIcon(iconBuilder.build());
-
-        BaseTemplateData.Builder templateBuilder = new BaseTemplateData.Builder(
-                UI_TEMPLATE_DEFAULT);
-        templateBuilder.setPrimaryItem(primaryItemBuilder.build());
-
-        return templateBuilder.build();
+        return new BaseTemplateData.Builder(UI_TEMPLATE_DEFAULT)
+                .setPrimaryItem(new SubItemInfo.Builder()
+                        .setIcon(new Icon.Builder(icon).build())
+                        .build())
+                .build();
     }
 
     private boolean isZenModeEnabled() {
@@ -404,32 +384,26 @@ public class SystemUISmartspaceService extends SmartspaceService implements
             return null;
         }
 
-        BaseTemplateData.Builder templateBuilder = new BaseTemplateData.Builder(
-                UI_TEMPLATE_DEFAULT);
+        var templateBuilder = new BaseTemplateData.Builder(UI_TEMPLATE_DEFAULT);
 
-        Text.Builder textBuilder = new Text.Builder(mMediaTitle);
-        BaseTemplateData.SubItemInfo.Builder primaryItemBuilder =
-                new BaseTemplateData.SubItemInfo.Builder();
-        primaryItemBuilder.setText(textBuilder.build());
-        templateBuilder.setPrimaryItem(primaryItemBuilder.build());
+        templateBuilder.setPrimaryItem(new SubItemInfo.Builder()
+                .setText(new Text.Builder(mMediaTitle).build())
+                .build());
 
         if (!TextUtils.isEmpty(mMediaArtist)) {
             android.graphics.drawable.Icon mediaIcon = mNotificationMediaManager == null ?
                     null : mNotificationMediaManager.getMediaIcon();
             if (mediaIcon != null) {
-                BaseTemplateData.SubItemInfo.Builder subtitleItemBuilder =
-                        new BaseTemplateData.SubItemInfo.Builder();
-                Text.Builder subtitleTextBuilder = new Text.Builder(mMediaArtist);
-                subtitleItemBuilder.setText(subtitleTextBuilder.build());
-                Icon.Builder iconBuilder = new Icon.Builder(mediaIcon);
-                subtitleItemBuilder.setIcon(iconBuilder.build());
-                templateBuilder.setSubtitleItem(subtitleItemBuilder.build());
+                templateBuilder.setSubtitleItem(new SubItemInfo.Builder()
+                        .setText(new Text.Builder(mMediaArtist).build())
+                        .setIcon(new Icon.Builder(mediaIcon).build())
+                        .build());
             }
         }
         return templateBuilder.build();
     }
 
-    protected boolean shouldDisplayMedia() {
+    private boolean shouldDisplayMedia() {
         return !TextUtils.isEmpty(mMediaTitle) && mMediaIsVisible && mDozing;
     }
 

--- a/packages/SystemUI/src/com/android/systemui/smartspace/ui/DefaultSmartspaceView.java
+++ b/packages/SystemUI/src/com/android/systemui/smartspace/ui/DefaultSmartspaceView.java
@@ -1,0 +1,33 @@
+package com.android.systemui.smartspace.ui;
+
+import android.os.Handler;
+
+import com.android.systemui.plugins.BcSmartspaceConfigPlugin;
+import com.android.systemui.plugins.BcSmartspaceDataPlugin;
+import com.android.systemui.plugins.FalsingManager;
+
+/**
+ * An extension of SmartspaceView that provides default empty methods to satisfy the interface.
+ */
+public interface DefaultSmartspaceView extends BcSmartspaceDataPlugin.SmartspaceView {
+    @Override
+    default void registerDataProvider(BcSmartspaceDataPlugin plugin) {}
+
+    @Override
+    default void registerConfigProvider(BcSmartspaceConfigPlugin configProvider) {}
+
+    @Override
+    default void setPrimaryTextColor(int color) {}
+
+    @Override
+    default void setUiSurface(String uiSurface) {}
+
+    @Override
+    default void setBgHandler(Handler bgHandler) {}
+
+    @Override
+    default void setDozeAmount(float amount) {}
+
+    @Override
+    default void setFalsingManager(FalsingManager falsingManager) {}
+}

--- a/packages/SystemUI/tests/utils/src/com/android/systemui/keyguard/data/repository/KeyguardBlueprintRepositoryKosmos.kt
+++ b/packages/SystemUI/tests/utils/src/com/android/systemui/keyguard/data/repository/KeyguardBlueprintRepositoryKosmos.kt
@@ -105,7 +105,6 @@ val Kosmos.splitShadeBlueprint by
             smartspaceSection = keyguardSmartspaceSection,
             mediaSection = mock(),
             accessibilityActionsSection = mock(),
-            keyguardSliceViewSection = mock(),
         )
     }
 


### PR DESCRIPTION
AOSP uses the legacy keyguard slice infrastructure for showing the following info on the lockscreen and in always-on-display mode:
- current date
- next alarm
- Do Not Disturb status
- current media info (title and artist)

The proprietary SystemUIGoogle on stock Pixel OS uses the modern smartspace infrastructure for displaying this info.

The legacy keyguard slice infrastructure isn't being properly maintained upstream. It has numerous layout and animation issues.

This pull request adds a smartspace implementation to avoid these issues by reusing the same infrastructure that is used by SystemUIGoogle. Fixes for the legacy keyguard slice infrastructure are reverted.