### PR TITLE
SystemUI: Open Tethering settings from QS Hotspot tile

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/HotspotTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/HotspotTile.java
@@ -103,7 +103,7 @@ public class HotspotTile extends QSTileImpl<BooleanState> {
 
     @Override
     public Intent getLongClickIntent() {
-        return new Intent(Settings.ACTION_WIFI_TETHER_SETTING);
+        return new Intent(Settings.ACTION_TETHER_SETTINGS);
     }
 
     @Override


### PR DESCRIPTION
Replace Wi-Fi Hotspot settings intent with Tethering settings to provide access to all tethering options.

Resolves https://github.com/GrapheneOS/os-issue-tracker/issues/7336