### PR TITLE
platform_frameworks_base: Allow Apple's servers for captive portal check

### DIFF
--- a/core/api/module-lib-current.txt
+++ b/core/api/module-lib-current.txt
@@ -172,6 +172,7 @@ package android.ext.settings {
   public class ConnChecksSetting {
     method public static int get();
     method public static boolean put(int);
+    field public static final int VAL_APPLE = 3; // 0x3
     field public static final int VAL_DEFAULT = 0; // 0x0
     field public static final int VAL_DISABLED = 2; // 0x2
     field public static final int VAL_GRAPHENEOS = 0; // 0x0

--- a/core/java/android/ext/settings/ConnChecksSetting.java
+++ b/core/java/android/ext/settings/ConnChecksSetting.java
@@ -10,6 +10,7 @@ public class ConnChecksSetting {
     public static final int VAL_GRAPHENEOS = 0;
     public static final int VAL_STANDARD = 1;
     public static final int VAL_DISABLED = 2;
+    public static final int VAL_APPLE = 3;
     public static final int VAL_DEFAULT = VAL_GRAPHENEOS;
 
     /**
@@ -20,7 +21,7 @@ public class ConnChecksSetting {
     public static final IntSysProperty SYS_PROP = new IntSysProperty(
             "persist.sys.connectivity_checks",
             ConnChecksSetting.VAL_DEFAULT,
-            ConnChecksSetting.VAL_GRAPHENEOS, ConnChecksSetting.VAL_STANDARD, ConnChecksSetting.VAL_DISABLED
+            ConnChecksSetting.VAL_GRAPHENEOS, ConnChecksSetting.VAL_STANDARD, ConnChecksSetting.VAL_DISABLED, ConnChecksSetting.VAL_APPLE
     );
 
     public static int get() {

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsParserState.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsParserState.java
@@ -92,6 +92,8 @@ class SettingsParserState {
         } else {
             if ("https://www.google.com/generate_204".equals(captivePortalHttpsUrl)) {
                 val = ConnChecksSetting.VAL_STANDARD;
+            } else if ("https://captive.apple.com".equals(captivePortalHttpsUrl)) {
+                val = ConnChecksSetting.VAL_APPLE;
             } else {
                 val = ConnChecksSetting.VAL_GRAPHENEOS;
             }


### PR DESCRIPTION
Part of GrapheneOS/os-issue-tracker#6728