### PR TITLE
fix StrictMode BackgroundActivityLaunchCallback leak

### DIFF
--- a/core/java/android/os/StrictMode.java
+++ b/core/java/android/os/StrictMode.java
@@ -2226,12 +2226,18 @@ public final class StrictMode {
         }
     }
 
+    private static volatile BackgroundActivityLaunchCallback sBackgroundActivityLaunchCallback;
+
     private static void registerBackgroundActivityLaunchCallback() {
+        if (sBackgroundActivityLaunchCallback != null) {
+            return;
+        }
+        sBackgroundActivityLaunchCallback = new BackgroundActivityLaunchCallback();
         try {
             IActivityTaskManager service = ActivityTaskManager.getService();
             if (service != null) {
                 service.registerBackgroundActivityStartCallback(
-                    new BackgroundActivityLaunchCallback());
+                    sBackgroundActivityLaunchCallback);
             }
         } catch (DeadObjectException e) {
             // ignore


### PR DESCRIPTION
A leak can occur for any app that uses StrictMode#enableDefaults or sets StrictMode.VmPolicy.Builder's detectBlockedBackgroundActivityLaunch or detectAll. If any of those are called or set, every call to StrictMode#setVmPolicy (this is used in core framework code like LoadedApk) will trigger StrictMode#registerBackgroundActivityLaunchCallback. This registers a brand new callback every time.

In system_server, these new callbacks are just stored in an ArrayMap in BackgroundActivityStartController's addStrictModeCallback which uses the IBinder as the map key. Since every new BackgroundActivityLaunchCallback is a distinct IBinder, containsKey(callback) never returns true for a new callback instance from StrictMode.

For userdebug/eng builds, this leak can also occur in any bundled system app due to the logic in StrictMode#initVmDefaults. In particular, SystemUI can crash because of this leak. When such a crash occurs, the following is printed out (UID 10126 is SystemUI):

```
V Binder  : BinderProxy descriptor histogram (top 10):
V Binder  :  # 1: android.app.IBackgroundActivityLaunchCallback x5698
V Binder  :  # 2: android.content.IIntentReceiver x471
V Binder  :  # 3: android.content.IContentProvider x304
V Binder  :  # 4: android.database.IContentObserver x237
V Binder  :  # 5: android.app.IApplicationThread x140
V Binder  :  # 6: com.android.internal.os.IResultReceiver x135
V Binder  :  # 7: android.app.IUnsafeIntentStrictModeCallback x92
V Binder  :  # 8:  x86
V Binder  :  # 9: <cleared weak-ref> x83
V Binder  :  # 10: <proxy to dead node> x54
D Binder  : Per Uid Binder Proxy Counts:
...
D Binder  : UID : 10126  count = 6006
...
E BpBinder: Too many binder proxy objects sent to uid 1000 from uid 10126 (... proxies held)
E ActivityManager: Uid 10126 sent too many Binders to uid 1000
...
I ActivityManager: Killing 2145:com.android.systemui/u0a126 (adj -800): Too many Binders sent to SYSTEM
I am_kill : [User=0,PID=2145,Process Name=com.android.systemui,OomAdj=-800,Reason=Too many Binders sent to SYSTEM,Rss=477156B]
```

StrictMode#initVmDefaults calls builder.detectAll() for all bundled system apps on userdebug and eng builds. detectAll() includes DETECT_VM_BACKGROUND_ACTIVITY_LAUNCH_ABORTED. SystemUI is a bundled system app, so it gets this flag at startup. With this flag, every call to StrictMode#setVmPolicy will trigger StrictMode#registerBackgroundActivityLaunchCallback.

A hot path is in LoadedApk which SystemUI calls very often when managing notification UI. In LoadedApk#canAccessDataDir, the following pattern is used which should demonstrate how this leak can happen:

```java
StrictMode.VmPolicy old = StrictMode.allowVmViolations(); try {
    // StrictMode violation code
} finally {
    StrictMode.setVmPolicy(old); // re-registers a new BAL callback every time
}
```

It's not unexpected for other apps to be following this pattern as well.

The following is a stacktrace of how SystemUI adds new BAL callbacks. This runs on every notification that gets posted:

```
W StrictMode: java.lang.Throwable
W StrictMode:     at android.os.StrictMode.registerBackgroundActivityLaunchCallback(StrictMode.java:2230)
W StrictMode:     at android.os.StrictMode.setVmPolicy(StrictMode.java:2222)
W StrictMode:     at android.app.LoadedApk.setVmPolicy(LoadedApk.java:875)
W StrictMode:     at android.app.LoadedApk.canAccessDataDir(LoadedApk.java:1170)
W StrictMode:     at android.app.LoadedApk.createOrUpdateClassLoaderLocked(LoadedApk.java:962)
W StrictMode:     at android.app.LoadedApk.getClassLoader(LoadedApk.java:1183)
W StrictMode:     at android.app.ActivityThread.getTopLevelResources(ActivityThread.java:3169)
W StrictMode:     at android.app.ApplicationPackageManager.getResourcesForApplication(ApplicationPackageManager.java:2199)
W StrictMode:     at android.app.ApplicationPackageManager.getResourcesForApplication(ApplicationPackageManager.java:2182)
W StrictMode:     at android.app.ApplicationPackageManager.getResourcesForApplication(ApplicationPackageManager.java:2218)
W StrictMode:     at android.graphics.drawable.Icon.loadDrawableAsUser(Icon.java:616)
W StrictMode:     at com.android.systemui.statusbar.StatusBarIconView.getIcon(StatusBarIconView.java)
W StrictMode:     at com.android.systemui.statusbar.StatusBarIconView.updateDrawable(StatusBarIconView.java)
W StrictMode:     at com.android.systemui.statusbar.StatusBarIconView.set(StatusBarIconView.java)
W StrictMode:     at com.android.systemui.statusbar.notification.icon.IconManager.setIcon(IconManager.java)
W StrictMode:     at com.android.systemui.statusbar.notification.icon.IconManager.createIcons(IconManager.java)
W StrictMode:     at com.android.systemui.statusbar.notification.collection.inflation.NotificationRowBinderImpl.inflateViews(NotificationRowBinderImpl.java)
W StrictMode:     at com.android.systemui.statusbar.notification.collection.NotifInflaterImpl.inflateViewsImpl(NotifInflaterImpl.java)
W StrictMode:     at com.android.systemui.statusbar.notification.collection.coordinator.PreparationCoordinator.inflateEntry(PreparationCoordinator.java)
W StrictMode:     at com.android.systemui.statusbar.notification.collection.coordinator.PreparationCoordinator.inflateRequiredNotifViews(PreparationCoordinator.java)
W StrictMode:     at com.android.systemui.statusbar.notification.collection.coordinator.PreparationCoordinator.inflateRequiredGroupViews(PreparationCoordinator.java)
W StrictMode:     at com.android.systemui.statusbar.notification.collection.coordinator.PreparationCoordinator$$ExternalSyntheticLambda2.onBeforeFinalizeFilter(PreparationCoordinator.java)
W StrictMode:     at com.android.systemui.statusbar.notification.collection.ShadeListBuilder$$ExternalSyntheticLambda12.accept(ShadeListBuilder.java)
W StrictMode:     at com.android.systemui.util.NamedListenerSet.forEachTraced(NamedListenerSet.java)
W StrictMode:     at com.android.systemui.statusbar.notification.collection.ShadeListBuilder$$ExternalSyntheticLambda7.run(ShadeListBuilder.java)
W StrictMode:     at com.android.systemui.statusbar.notification.collection.NotifPipelineChoreographerImpl$frameCallback$1.doFrame(NotifPipelineChoreographerImpl.kt)
W StrictMode:     at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1628)
W StrictMode:     at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1639)
W StrictMode:     at android.view.Choreographer.doCallbacks(Choreographer.java:1235)
W StrictMode:     at android.view.Choreographer.doFrame(Choreographer.java:1160)
W StrictMode:     at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1613)
```

There's also another path from
com.android.systemui.statusbar.notification.collection.coordinator.MediaCoordinator.shouldFilterOut not shown here.

The SystemUI crash only occurs on userdebug/eng, but any app using the BAL StrictMode methods or the StrictMode#enableDefaults will have this leak as well.

Note that StrictMode's BackgroundActivityLaunchCallback only calls static methods, so there's really no point in making new instances for every call. system_server doesn't do anything with newly added callbacks other than add it to an ArrayMap and link a death recipient. This also follows the approach of StrictMode's existing usage of sUnsafeIntentCallback.