### PR TITLE
make temporary biometric lockouts into permanent lockouts and ensure only framework can clear lockout

### DIFF
--- a/core/tests/coretests/src/com/android/internal/widget/LockPatternUtilsTest.java
+++ b/core/tests/coretests/src/com/android/internal/widget/LockPatternUtilsTest.java
@@ -123,12 +123,12 @@ public class LockPatternUtilsTest {
         when(context.getContentResolver()).thenReturn(cr);
         Settings.Global.putInt(cr, Settings.Global.DEVICE_DEMO_MODE, deviceDemoMode);
 
-        when(mLockSettings.getCredentialType(DEMO_USER_ID)).thenReturn(
+        when(mLockSettings.getCredentialType(DEMO_USER_ID, LockDomain.Primary)).thenReturn(
                 isSecure ? LockPatternUtils.CREDENTIAL_TYPE_PASSWORD
                          : LockPatternUtils.CREDENTIAL_TYPE_NONE);
         when(mLockSettings.getLong("lockscreen.password_type", PASSWORD_QUALITY_UNSPECIFIED,
                 DEMO_USER_ID)).thenReturn((long) PASSWORD_QUALITY_MANAGED);
-        when(mLockSettings.getLockoutEndTime(USER_ID)).thenReturn(asParcel(LOCKOUT_END_TIME));
+        when(mLockSettings.getLockoutEndTime(USER_ID, LockDomain.Primary)).thenReturn(asParcel(LOCKOUT_END_TIME));
         when(mLockSettings.hasSecureLockScreen()).thenReturn(true);
         mLockPatternUtils = new LockPatternUtils(context, mLockSettings, mTimeSinceBootSupplier);
 
@@ -435,7 +435,7 @@ public class LockPatternUtilsTest {
         Duration lockoutEndTime = mLockPatternUtils.getLockoutEndTime(USER_ID);
 
         assertThat(lockoutEndTime).isEqualTo(LOCKOUT_END_TIME);
-        verify(mLockSettings).getLockoutEndTime(USER_ID);
+        verify(mLockSettings).getLockoutEndTime(USER_ID, LockDomain.Primary);
     }
 
     @Test
@@ -447,7 +447,7 @@ public class LockPatternUtilsTest {
             assertThat(lockoutEndTime).isEqualTo(LOCKOUT_END_TIME);
         }
 
-        verify(mLockSettings).getLockoutEndTime(USER_ID);
+        verify(mLockSettings).getLockoutEndTime(USER_ID, LockDomain.Primary);
     }
 
     @Test
@@ -461,12 +461,12 @@ public class LockPatternUtilsTest {
         reset(mTimeSinceBootSupplier, mLockSettings);
         when(mTimeSinceBootSupplier.get()).thenReturn(LOCKOUT_END_TIME.plusMillis(1));
         Duration secondLockoutEndTime = LOCKOUT_END_TIME.plusSeconds(1);
-        when(mLockSettings.getLockoutEndTime(USER_ID)).thenReturn(asParcel(secondLockoutEndTime));
+        when(mLockSettings.getLockoutEndTime(USER_ID, LockDomain.Primary)).thenReturn(asParcel(secondLockoutEndTime));
 
         Duration lockoutEndTime = mLockPatternUtils.getLockoutEndTime(USER_ID);
 
         assertThat(lockoutEndTime).isEqualTo(secondLockoutEndTime);
-        verify(mLockSettings).getLockoutEndTime(USER_ID);
+        verify(mLockSettings).getLockoutEndTime(USER_ID, LockDomain.Primary);
     }
 
     @Test
@@ -479,7 +479,7 @@ public class LockPatternUtilsTest {
             LockPatternUtils.invalidateLockoutEndTimeCache();
         }
 
-        verify(mLockSettings, times(5)).getLockoutEndTime(USER_ID);
+        verify(mLockSettings, times(5)).getLockoutEndTime(USER_ID, LockDomain.Primary);
     }
 
     private TestStrongAuthTracker createStrongAuthTracker() {

--- a/services/core/java/com/android/server/biometrics/sensors/face/aidl/AidlResponseHandler.java
+++ b/services/core/java/com/android/server/biometrics/sensors/face/aidl/AidlResponseHandler.java
@@ -300,6 +300,12 @@ public class AidlResponseHandler extends ISessionCallback.Stub {
      * Handles lockout changed messages sent by the HAL (specifically for HIDL HAL).
      */
     public void onLockoutChanged(long duration) {
+        if (duration == 0) {
+            // should never even call this function
+            throw new UnsupportedOperationException(
+                    "onLockoutChanged: HIDL face HAL is disabled on GrapheneOS");
+        }
+
         mScheduler.getHandler().post(() -> {
             @LockoutTracker.LockoutMode final int lockoutMode;
             if (duration == 0) {
@@ -307,7 +313,7 @@ public class AidlResponseHandler extends ISessionCallback.Stub {
             } else if (duration == -1 || duration == Long.MAX_VALUE) {
                 lockoutMode = LockoutTracker.LOCKOUT_PERMANENT;
             } else {
-                lockoutMode = LockoutTracker.LOCKOUT_TIMED;
+                lockoutMode = LockoutTracker.LOCKOUT_PERMANENT;
             }
 
             mLockoutTracker.setLockoutModeForUser(mUserId, lockoutMode);

--- a/services/core/java/com/android/server/biometrics/sensors/face/aidl/AidlResponseHandler.java
+++ b/services/core/java/com/android/server/biometrics/sensors/face/aidl/AidlResponseHandler.java
@@ -203,7 +203,11 @@ public class AidlResponseHandler extends ISessionCallback.Stub {
 
     @Override
     public void onLockoutTimed(long durationMillis) {
-        handleResponse(LockoutConsumer.class, (c) -> c.onLockoutTimed(durationMillis));
+        // old: handleResponse(LockoutConsumer.class, (c) -> c.onLockoutTimed(durationMillis));
+        Slog.d(TAG, "face AidlResponseHandler#onLockoutTimed("
+                + durationMillis
+                + "ms): Upgrading to a permanent lockout");
+        onLockoutPermanent();
     }
 
     @Override
@@ -214,9 +218,16 @@ public class AidlResponseHandler extends ISessionCallback.Stub {
     @Override
     public void onLockoutCleared() {
         handleResponse(FaceResetLockoutClient.class, FaceResetLockoutClient::onLockoutCleared,
-                (c) -> FaceResetLockoutClient.resetLocalLockoutStateToNone(mSensorId, mUserId,
-                        mLockoutTracker, mLockoutResetDispatcher, mAuthSessionCoordinator,
-                        Utils.getCurrentStrength(mSensorId), -1 /* requestId */));
+                (c) -> {
+                    // Previously, AOSP had a FaceResetLockoutClient.resetLocalLockoutStateToNone
+                    // call here. The comment on that function says it "should only be called when
+                    // the HAL sends a reset request directly to the framework (i.e. time based
+                    // reset, etc.)". Removing that call here should disable HAL service
+                    // calling this to do timed temporary lockout clearing.
+                    String name = c != null ? c.getClass().getName() : "null";
+                    Slog.d(TAG, "ignoring ISessionCallback::onLockoutCleared "
+                            + "from face HAL, current client " + name);
+                });
     }
 
     @Override

--- a/services/core/java/com/android/server/biometrics/sensors/face/aidl/FaceAuthenticationClient.java
+++ b/services/core/java/com/android/server/biometrics/sensors/face/aidl/FaceAuthenticationClient.java
@@ -386,6 +386,12 @@ public class FaceAuthenticationClient
 
     @Override
     public void onLockoutTimed(long durationMillis) {
+        if (true) {
+            Slog.w(TAG, "Upgrading timed lockout " + durationMillis + "ms to permanent lockout");
+            onLockoutPermanent();
+            return;
+        }
+
         mAuthSessionCoordinator.lockOutTimed(getTargetUserId(), getSensorStrength(), getSensorId(),
                 durationMillis, getRequestId());
         // Lockout metrics are logged as an error code.

--- a/services/core/java/com/android/server/biometrics/sensors/face/aidl/FaceProvider.java
+++ b/services/core/java/com/android/server/biometrics/sensors/face/aidl/FaceProvider.java
@@ -230,10 +230,7 @@ public class FaceProvider implements IBinder.DeathRecipient, ServiceProvider {
 
     private void initSensors(boolean resetLockoutRequiresChallenge, SensorProps[] props) {
         if (resetLockoutRequiresChallenge) {
-            Slog.d(getTag(), "Adding HIDL configs");
-            for (SensorProps prop : props) {
-                addHidlSensors(prop, resetLockoutRequiresChallenge);
-            }
+            Slog.wtf(getTag(), "HIDL face HAL is not supported, ignoring configs");
         } else {
             Slog.d(getTag(), "Adding AIDL configs");
             for (SensorProps prop : props) {

--- a/services/core/java/com/android/server/biometrics/sensors/face/aidl/FaceResetLockoutClient.java
+++ b/services/core/java/com/android/server/biometrics/sensors/face/aidl/FaceResetLockoutClient.java
@@ -85,6 +85,11 @@ public class FaceResetLockoutClient extends HalClientMonitor<AidlSession> implem
             final ISession session = getFreshDaemon().getSession();
             session.resetLockout(mHardwareAuthToken);
             if (session instanceof HidlToAidlSessionAdapter) {
+                // HIDL resetLockout is synchronous (returns Status), but
+                // HidlToAidlSessionAdapter ignores the return value. The HAL also
+                // asynchronously calls AidlResponseHandler.onLockoutChanged(0), but
+                // that arrives after onClientFinished removes this client, so it
+                // won't go through handleResponse's FaceResetLockoutClient check.
                 mCallback.onClientFinished(this, true /* success */);
             }
         } catch (RemoteException e) {

--- a/services/core/java/com/android/server/biometrics/sensors/fingerprint/aidl/AidlResponseHandler.java
+++ b/services/core/java/com/android/server/biometrics/sensors/fingerprint/aidl/AidlResponseHandler.java
@@ -195,22 +195,32 @@ public class AidlResponseHandler extends ISessionCallback.Stub {
 
     @Override
     public void onLockoutTimed(long durationMillis) {
-        handleResponse(LockoutConsumer.class, (c) -> c.onLockoutTimed(durationMillis));
+        // old: handleResponse(LockoutConsumer.class, (c) -> c.onLockoutTimed(durationMillis));
+        Slog.d(TAG, "fingerprint AidlResponseHandler#onLockoutTimed("
+                + durationMillis
+                + "ms): Upgrading to a permanent lockout");
+        onLockoutPermanent();
     }
 
     @Override
     public void onLockoutPermanent() {
-        handleResponse(LockoutConsumer.class, LockoutConsumer::onLockoutPermanent);
+        handleResponse(LockoutConsumer.class, LockoutConsumer::onLockoutPermanent, null);
     }
 
     @Override
     public void onLockoutCleared() {
         handleResponse(FingerprintResetLockoutClient.class,
                 FingerprintResetLockoutClient::onLockoutCleared,
-                (c) -> FingerprintResetLockoutClient.resetLocalLockoutStateToNone(
-                        mSensorId, mUserId, mLockoutTracker, mLockoutResetDispatcher,
-                        mAuthSessionCoordinator, Utils.getCurrentStrength(mSensorId),
-                        -1 /* requestId */));
+                (c) -> {
+                    // Previously, AOSP had a FingerprintResetLockoutClient#resetLocalLockoutStateToNone
+                    // call here. The comment on that function says it "should only be called when
+                    // the HAL sends a reset request directly to the framework (i.e. time based
+                    // reset, etc.)". Removing that call here should disable HAL fingerprint service
+                    // calling this to do timed temporary lockout clearing.
+                    String name = c != null ? c.getClass().getName() : "null";
+                    Slog.d(TAG, "ignoring ISessionCallback::onLockoutCleared "
+                            + "from fingerprint HAL, current client " + name);
+                });
     }
 
     @Override
@@ -291,6 +301,7 @@ public class AidlResponseHandler extends ISessionCallback.Stub {
             @Nullable Consumer<BaseClientMonitor> alternateAction) {
         mScheduler.getHandler().post(() -> {
             final BaseClientMonitor client = mScheduler.getCurrentClient();
+            String cls = client != null ? client.getClass().getName() : "null";
             if (className.isInstance(client)) {
                 action.accept((T) client);
             } else {

--- a/services/core/java/com/android/server/biometrics/sensors/fingerprint/aidl/FingerprintAuthenticationClient.java
+++ b/services/core/java/com/android/server/biometrics/sensors/fingerprint/aidl/FingerprintAuthenticationClient.java
@@ -425,6 +425,12 @@ public class FingerprintAuthenticationClient
 
     @Override
     public void onLockoutTimed(long durationMillis) {
+        if (true) {
+            Slog.w(TAG, "Upgrading timed lockout " + durationMillis + "ms to permanent lockout");
+            onLockoutPermanent();
+            return;
+        }
+
         mAuthSessionCoordinator.lockOutTimed(getTargetUserId(), getSensorStrength(), getSensorId(),
                 durationMillis, getRequestId());
         // Lockout metrics are logged as an error code.

--- a/services/tests/servicestests/src/com/android/server/biometrics/sensors/face/aidl/FaceAuthenticationClientTest.java
+++ b/services/tests/servicestests/src/com/android/server/biometrics/sensors/face/aidl/FaceAuthenticationClientTest.java
@@ -70,6 +70,7 @@ import androidx.test.filters.SmallTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 
 import com.android.internal.R;
+import com.android.internal.widget.LockPatternUtils;
 import com.android.server.biometrics.log.BiometricContext;
 import com.android.server.biometrics.log.BiometricLogger;
 import com.android.server.biometrics.log.OperationContextExt;
@@ -141,6 +142,8 @@ public class FaceAuthenticationClientTest {
     private BiometricManager mBiometricManager;
     @Mock
     private LockoutTracker mLockoutTracker;
+    @Mock
+    private LockPatternUtils mLockPatternUtils;
     @Captor
     private ArgumentCaptor<OperationContextExt> mOperationContextCaptor;
     @Captor
@@ -177,6 +180,8 @@ public class FaceAuthenticationClientTest {
         when(mBiometricContext.updateContext(any(), anyBoolean())).thenAnswer(
                 i -> i.getArgument(0));
         when(mBiometricContext.getAuthSessionCoordinator()).thenReturn(mAuthSessionCoordinator);
+        when(mBiometricContext.getLockPatternUtils()).thenReturn(mLockPatternUtils);
+        when(mLockPatternUtils.isBiometricSecondFactorEnabled(anyInt())).thenReturn(false);
     }
 
     @Test

--- a/services/tests/servicestests/src/com/android/server/biometrics/sensors/face/aidl/FaceAuthenticationClientTest.java
+++ b/services/tests/servicestests/src/com/android/server/biometrics/sensors/face/aidl/FaceAuthenticationClientTest.java
@@ -224,13 +224,13 @@ public class FaceAuthenticationClientTest {
     }
 
     @Test
-    public void testTemporaryLockoutEndsOperation() throws RemoteException {
+    public void testTemporaryLockoutUpgradedToPermanent() throws RemoteException {
         final FaceAuthenticationClient client = createClient(2);
         client.start(mCallback);
         client.onLockoutTimed(1000);
 
         verify(mClientMonitorCallbackConverter).onError(anyInt(), anyInt(),
-                eq(FACE_ERROR_LOCKOUT), anyInt());
+                eq(FACE_ERROR_LOCKOUT_PERMANENT), anyInt());
         verify(mCallback).onClientFinished(client, false);
     }
 

--- a/services/tests/servicestests/src/com/android/server/biometrics/sensors/face/aidl/FaceProviderTest.java
+++ b/services/tests/servicestests/src/com/android/server/biometrics/sensors/face/aidl/FaceProviderTest.java
@@ -176,7 +176,7 @@ public class FaceProviderTest {
     }
 
     @Test
-    public void testAddingHidlSensors() {
+    public void testAddingHidlSensors_rejected() {
         when(mResources.getIntArray(anyInt())).thenReturn(new int[]{});
         when(mResources.getBoolean(anyInt())).thenReturn(false);
 
@@ -194,13 +194,9 @@ public class FaceProviderTest {
                 true /* resetLockoutRequiresChallenge */,
                 true /* testHalEnabled */);
 
-        assertThat(mFaceProvider.mFaceSensors.get(faceId)
-                .getLazySession().get().getUserId()).isEqualTo(USER_NULL);
-
         waitForIdle();
 
-        assertThat(mFaceProvider.mFaceSensors.get(faceId)
-                .getLazySession().get().getUserId()).isEqualTo(USER_SYSTEM);
+        assertNull(mFaceProvider.mFaceSensors.get(faceId));
     }
 
     @SuppressWarnings("rawtypes")

--- a/services/tests/servicestests/src/com/android/server/biometrics/sensors/face/aidl/SensorTest.java
+++ b/services/tests/servicestests/src/com/android/server/biometrics/sensors/face/aidl/SensorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -138,13 +139,16 @@ public class SensorTest {
     }
 
     @Test
-    public void halSessionCallback_respondsToUnprovokedResetLockout() {
+    public void halSessionCallback_ignoresUnprovokedResetLockout() {
         mLockoutCache.setLockoutModeForUser(USER_ID, LockoutTracker.LOCKOUT_TIMED);
 
         mHalCallback.onLockoutCleared();
         mLooper.dispatchAll();
 
-        verifyNotLocked();
+        assertEquals(LockoutTracker.LOCKOUT_TIMED,
+                mLockoutCache.getLockoutModeForUser(USER_ID));
+        verify(mLockoutResetDispatcher, never()).notifyLockoutResetCallbacks(anyInt());
+        verify(mAuthSessionCoordinator, never()).resetLockoutFor(anyInt(), anyInt(), anyLong());
     }
 
     @Test

--- a/services/tests/servicestests/src/com/android/server/biometrics/sensors/face/hidl/HidlToAidlSensorAdapterTest.java
+++ b/services/tests/servicestests/src/com/android/server/biometrics/sensors/face/hidl/HidlToAidlSensorAdapterTest.java
@@ -56,12 +56,14 @@ import com.android.server.biometrics.sensors.face.aidl.FaceProvider;
 import com.android.server.biometrics.sensors.face.aidl.FaceResetLockoutClient;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+@Ignore("HIDL face HAL is not supported")
 public class HidlToAidlSensorAdapterTest {
     private static final String TAG = "HidlToAidlSensorAdapterTest";
     private static final int USER_ID = 2;

--- a/services/tests/servicestests/src/com/android/server/biometrics/sensors/face/hidl/HidlToAidlSessionAdapterTest.java
+++ b/services/tests/servicestests/src/com/android/server/biometrics/sensors/face/hidl/HidlToAidlSessionAdapterTest.java
@@ -55,6 +55,7 @@ import com.android.server.biometrics.sensors.face.aidl.AidlConversionUtils;
 import com.android.server.biometrics.sensors.face.aidl.AidlResponseHandler;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -66,6 +67,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 
+@Ignore("HIDL face HAL is not supported")
 @Presubmit
 @SmallTest
 public class HidlToAidlSessionAdapterTest {

--- a/services/tests/servicestests/src/com/android/server/biometrics/sensors/fingerprint/aidl/SensorTest.java
+++ b/services/tests/servicestests/src/com/android/server/biometrics/sensors/fingerprint/aidl/SensorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -145,13 +146,16 @@ public class SensorTest {
     }
 
     @Test
-    public void halSessionCallback_respondsToUnprovokedResetLockout() {
+    public void halSessionCallback_ignoresUnprovokedResetLockout() {
         mLockoutCache.setLockoutModeForUser(USER_ID, LockoutTracker.LOCKOUT_TIMED);
 
         mHalCallback.onLockoutCleared();
         mLooper.dispatchAll();
-
-        verifyNotLocked();
+        // lock out resets should only be from framework-initiated resets
+        assertEquals(LockoutTracker.LOCKOUT_TIMED,
+                mLockoutCache.getLockoutModeForUser(USER_ID));
+        verify(mLockoutResetDispatcher, never()).notifyLockoutResetCallbacks(anyInt());
+        verify(mAuthSessionCoordinator, never()).resetLockoutFor(anyInt(), anyInt(), anyLong());
     }
 
     @Test

--- a/services/tests/servicestests/src/com/android/server/biometrics/sensors/fingerprint/hidl/HidlToAidlSensorAdapterTest.java
+++ b/services/tests/servicestests/src/com/android/server/biometrics/sensors/fingerprint/hidl/HidlToAidlSensorAdapterTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -164,31 +165,27 @@ public class HidlToAidlSensorAdapterTest {
     }
 
     @Test
-    public void lockoutTimedResetViaCallback() {
+    public void lockoutTimedIgnoredViaCallback() {
         setLockoutTimed();
 
         mHidlToAidlSensorAdapter.getLazySession().get().getHalSessionCallback().onLockoutCleared();
         mLooper.dispatchAll();
 
-        verify(mLockoutResetDispatcherForSensor, times(2)).notifyLockoutResetCallbacks(eq(
-                SENSOR_ID));
         assertThat(mHidlToAidlSensorAdapter.getLockoutTracker(false /* forAuth */)
-                .getLockoutModeForUser(USER_ID)).isEqualTo(LockoutTracker.LOCKOUT_NONE);
-        verify(mAuthSessionCoordinator).resetLockoutFor(eq(USER_ID), anyInt(), anyLong());
+                .getLockoutModeForUser(USER_ID)).isEqualTo(LockoutTracker.LOCKOUT_PERMANENT);
+        verify(mAuthSessionCoordinator, never()).resetLockoutFor(anyInt(), anyInt(), anyLong());
     }
 
     @Test
-    public void lockoutPermanentResetViaCallback() {
+    public void lockoutIgnoredViaCallback() {
         setLockoutPermanent();
 
         mHidlToAidlSensorAdapter.getLazySession().get().getHalSessionCallback().onLockoutCleared();
         mLooper.dispatchAll();
-
-        verify(mLockoutResetDispatcherForSensor, times(2)).notifyLockoutResetCallbacks(eq(
-                SENSOR_ID));
+        // Lockout resets should only be done through framework code
         assertThat(mHidlToAidlSensorAdapter.getLockoutTracker(false /* forAuth */)
-                .getLockoutModeForUser(USER_ID)).isEqualTo(LockoutTracker.LOCKOUT_NONE);
-        verify(mAuthSessionCoordinator).resetLockoutFor(eq(USER_ID), anyInt(), anyLong());
+                .getLockoutModeForUser(USER_ID)).isEqualTo(LockoutTracker.LOCKOUT_PERMANENT);
+        verify(mAuthSessionCoordinator, never()).resetLockoutFor(anyInt(), anyInt(), anyLong());
     }
 
     @Test
@@ -241,7 +238,8 @@ public class HidlToAidlSensorAdapterTest {
                     .addFailedAttemptForUser(USER_ID);
         }
 
+        // Not allowing timed temporary lockouts
         assertThat(mHidlToAidlSensorAdapter.getLockoutTracker(false /* forAuth */)
-                .getLockoutModeForUser(USER_ID)).isEqualTo(LockoutTracker.LOCKOUT_TIMED);
+                .getLockoutModeForUser(USER_ID)).isEqualTo(LockoutTracker.LOCKOUT_PERMANENT);
     }
 }


### PR DESCRIPTION
Temporary biometric lockouts tend to allow more attempts overall before the permanent lockout.

Android CDD under 7.3.10 Biometric Sensors specifies "no more than twenty false trials and no less
than ninety-second backoff time for biometric verification" before permanent lockout [C-1-9] [^2].
This implies that a device opting into using backoff time (i.e. temporary lockouts) MUST have at
least 90s total of backoff time. [C-SR-5] strongly recommends 30 seconds per lockout period after
every 5 trials. A device following [C-SR-5] for temporary timeouts would have to allow 20 attempts
total: 5 attempts -> 30s temporary lockout -> 5 attempts -> 30s temporary lockout -> 5 attempts ->
30s temporary lockout -> 5 attempts -> permanent lockout. The total backoff time is 30s * 3 lockouts
= 90s, which satisfies [C-1-9]. (Note: I'm assuming [C-1-9]'s "backoff time" doesn't apply to
devices that use a permanent lockout right away; they're not using any backoff, so "backoff time"
doesn't apply.)

This seems to imply that using temporary lockouts while following the strong recommendation from
[C-SR-5] leads you to the maximum of 20 attempts. Of course, this is all assuming the device is even
CDD-compliant. Bugs can also make it violate any of these conditions. Allowing temporary lockouts
can thus reduce the security of biometric unlocks. Clearly, when more overall attempts are allowed,
this affects the chances a spoof attack can succeed. To clarify, the Spoof Acceptance Rate (SAR) for
fingerprints is calculated based on trials with physical molds of the target fingerprint, and there
is no Imposter Acceptance Rate (IAR) for fingerprints [^1].

For Class 3 (Strong) biometrics like fingerprint, Android CDD requires an upper bound of 7% on
the Spoof and Imposter Acceptance Rate. (For Level B PAI species, they only require an upper bound
of 20%, but [C-SR-16] strongly recommends the 7% upper bound.) [^2]

Assuming all spoof attempts are independent and assuming [C-SR-16] is followed (with every 30s
timeout waited out), we have $\Pr[\text{1 PAI species spoof attempt succeeds}] \leq 0.07$. Thus in the physical
mold spoofing case, we have

$$
\begin{align}
\Pr[\text{PAI species spoof succeeds, 20 total attempts}] &=1 - (1 - \Pr[\text{1 PAI species spoof attempt succeeds}])^{20} \\
&\leq 1 - (1 - 0.07)^{20} \\
&= 0.7658 \\
\Pr[\text{PAI species spoof succeeds, 5 total attempts}] &\leq 1 - (1 - 0.07)^{5} \\ 
&= 0.3043
\end{align}
$$

Of course, these are using the requirements on upper bounds from the CDD (with the assumption that
Level B PAI species follows the 7% upper bound recommendation from [C-SR-16]). The actual hardware
bounds can be tighter, and they may also use previous attempts to adjust their internal acceptance
rates, etc. which would violat the independence assumption. The 7% bound itself was chosen from what
was done in most fingerprint implementations at the time, and AOSP is interested in making it lower
[^3].

We make the framework treat temporary lockouts as permanent lockouts by redirecting the HAL's
temporary lockout calls to the permanent lockout path. When a temporary lockout is promoted to a
permanent lockout, the only other thing a user can do is unlock with correct primary credential
which would get the framework to reset the permanent lockout. From the perspective of the HAL, it
should be that it just went through its specified max trials before issuing a temporary lockout. The
HAL shouldn't receive anymore attempts from the framework when a permanent lockout is used (see
com.android.server.biometrics.sensors.AuthenticationClient#start where lockout mode disallows
authentication). After primary credential is entered, the framework tells the AIDL HAL to reset its
internal lockout counters.

For phones using temporary lockout (or bugged into using one), this makes the number of trials in a
temporary lockout period the new permanent lockout threshold. According to [C-1-9], temporary
lockouts can technically be something unrealistic like 1 attempts -> 90 seconds -> 1 attempts.

Note that the framework has no way of knowing a priori if an AIDL HAL implementation is using a
temporary lockout or permanent lockout. All of that is internal implementation detail (e.g. for
Pixels, likely the vendor's TEE trusted application for biometrics); the framework just has methods
to handle both cases unconditionally. For temporary lockouts, HAL biometric services may also keep
their own timer (at least 30 seconds if following strong recommendation from [C-SR-5]) and call
onLockoutCleared asynchronously. This is in constrast to deprecated HIDL HALs which have the limits
defined in the framework. See
com.android.server.biometrics.sensors.fingerprint.hidl.LockoutFrameworkImpl and its
MAX_FAILED_ATTEMPTS_LOCKOUT_TIMED and MAX_FAILED_ATTEMPTS_LOCKOUT_PERMANENT constants and how
they're used for HIDL. The AIDL version doesn't have any of these constants, as the lockout attempts
are intended to be handled in the HAL itself.

Thus, this change also makes it so that the HAL cannot clear the biometric lockout for any reason,
unless the framework is using e.g. FingerprintResetLockoutClient during the HAL AIDL transaction for
intended resets. FingerprintResetLockoutClient is used when the framework wants to reset the lockout
after e.g. successful authentication with primary credential or authentication with biometrics on
keyguard.

When the HAL biometric service clears the lockout from a temporary lockout or for any other
asynchronous reason, it will trigger ISessionCallback::onLockoutCleared, implemented by
AidlResponseHandler. For fingerprint, the current client in the case of a temporary lockout ending
won't be FingerprintResetLockoutClient; it'll likely be e.g. FingerprintDetectClient when on
keyguard.  handleResponse falls back to the alternateAction (third argument), which in AOSP used to
call FingerprintResetLockoutClient#resetLocalLockoutStateToNone. The comment on this static function
says it "should only be called when the HAL sends a reset request directly to the framework (i.e.
time based reset, etc.)". Removing that call there should disable HAL fingerprint service calling
this to do timed temporary lockout clearing. The case for face is similar.

Lockout clearing from successful authentication (e.g. good PIN / password) is intended to go through
FingerprintResetLockoutClient which is initiated from framework code. In the normal path,
FingerprintResetLockoutClient calls resetLockout on the HAL and only calls
mCallback.onClientFinished when the HAL responds with ISessionCallback::onLockoutCleared.  In this
case, handleResponse will route it to the intended action
(FingerprintResetLockoutClient#onLockoutCleared).

Note that if the HAL reports an error during resetLockout, FingerprintResetLockoutClient#onError
finishes the client, advancing the scheduler to the next operation. In the error case, lockout stays
in place, and the user must re-enter PIN / password.

Aside from the tests, this hasn't been tested with face (GrapheneOS doesn't support face
authentication).

For Pixels (e.g. shiba on stock OS CP21.260306.017), they usually 5 attempts before permanent
lockout (no backoff time) via an AIDL fingerprint HAL service (Goodix, Qualcomm, etc.).

The tests have been updated to reflect the expectation that temporary lockouts are now treated as
permanent.

Test: 
```
atest FrameworksCoreTests:android.hardware.fingerprint.FingerprintSensorConfigurationsTest \
  FrameworksCoreTests:android.hardware.face.FaceSensorConfigurationsTest \
  FrameworksServicesTests:com.android.server.biometrics.AuthServiceTest \
  FrameworksServicesTests:com.android.server.biometrics.sensors.face.FaceServiceTest \
  FrameworksServicesTests:com.android.server.biometrics.sensors.face.aidl.FaceProviderTest \
  FrameworksServicesTests:com.android.server.biometrics.sensors.face.aidl.SensorTest \
  FrameworksServicesTests:com.android.server.biometrics.sensors.fingerprint.FingerprintServiceTest \
  FrameworksServicesTests:com.android.server.biometrics.sensors.fingerprint.aidl.FingerprintProviderTest \
  FrameworksServicesTests:com.android.server.biometrics.sensors.fingerprint.aidl.SensorTest \
  FrameworksServicesTests:com.android.server.biometrics.sensors.fingerprint.hidl.HidlToAidlSensorAdapterTest \
  FrameworksServicesTests:com.android.server.biometrics.sensors.fingerprint.hidl.HidlToAidlSessionAdapterTest
```

[^1]: https://source.android.com/docs/security/features/biometric/measure
[^2]: https://source.android.com/docs/compatibility/16/android-16-cdd#7310_biometric_sensors
[^3]: https://android-developers.googleblog.com/2018/06/better-biometrics-in-android-p.html