### PR TITLE
fw/base: Add support to enable airplane mode on boot [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4498,6 +4498,7 @@ public final class Settings {
             MOVED_TO_GLOBAL.add(Settings.Global.RADIO_BLUETOOTH);
             MOVED_TO_GLOBAL.add(Settings.Global.RADIO_WIMAX);
             MOVED_TO_GLOBAL.add(Settings.Global.SHOW_PROCESSES);
+            MOVED_TO_GLOBAL.add(Settings.Global.AIRPLANE_MODE_ON_BOOT);
         }
 
         /** @hide */
@@ -20599,6 +20600,12 @@ public final class Settings {
          */
         public static final String WATCH_RANGING_AVAILABLE =
                 "watch_ranging_available";
+
+        /**
+         *  Whether Airplane mode should be toggled on during boot
+         * @hide
+         */
+        public static final String AIRPLANE_MODE_ON_BOOT = "airplane_mode_on_boot";
 
         /**
          * Settings migrated from Wear OS settings provider.

--- a/packages/SettingsProvider/src/android/provider/settings/validators/GlobalSettingsValidators.java
+++ b/packages/SettingsProvider/src/android/provider/settings/validators/GlobalSettingsValidators.java
@@ -485,5 +485,6 @@ public class GlobalSettingsValidators {
                 new InclusiveIntegerRangeValidator(0, 1));
         VALIDATORS.put(Global.MINMODE_ACTIVE, BOOLEAN_VALIDATOR);
         VALIDATORS.put(Global.WATCH_RANGING_AVAILABLE, BOOLEAN_VALIDATOR);
+        VALIDATORS.put(Global.AIRPLANE_MODE_ON_BOOT, BOOLEAN_VALIDATOR);
     }
 }

--- a/services/java/com/android/server/SystemServer.java
+++ b/services/java/com/android/server/SystemServer.java
@@ -1861,6 +1861,10 @@ public final class SystemServer implements Dumpable {
         // Before things start rolling, be sure we have decided whether
         // we are in safe mode.
         final boolean safeMode = wm.detectSafeMode();
+        boolean airplaneModeOnBoot = Settings.Global.getInt(
+            mContentResolver,
+            Settings.Global.AIRPLANE_MODE_ON_BOOT,
+            0) != 0;
         if (safeMode) {
             // If yes, immediately turn on the global setting for airplane mode.
             // Note that this does not send broadcasts at this stage because
@@ -1871,6 +1875,9 @@ public final class SystemServer implements Dumpable {
         } else if (context.getResources().getBoolean(R.bool.config_autoResetAirplaneMode)) {
             Settings.Global.putInt(context.getContentResolver(),
                     Settings.Global.AIRPLANE_MODE_ON, 0);
+        }if (airplaneModeOnBoot) {
+            Settings.Global.putInt(context.getContentResolver(),
+                    Settings.Global.AIRPLANE_MODE_ON, 1);
         }
 
         StatusBarManagerService statusBar = null;
@@ -3422,12 +3429,12 @@ public final class SystemServer implements Dumpable {
             // TODO: This may actually be too late if radio firmware already started leaking
             // RF before the respective services start. However, fixing this requires changes
             // to radio firmware and interfaces.
-            if (safeMode) {
-                t.traceBegin("EnableAirplaneModeInSafeMode");
+            if (safeMode || airplaneModeOnBoot) {
+                t.traceBegin("EnableAirplaneModeInSafeMode: " + safeMode + " EnableAirplaneModeOnBoot: " + airplaneModeOnBoot);
                 try {
                     connectivityF.setAirplaneMode(true);
                 } catch (Throwable e) {
-                    reportWtf("enabling Airplane Mode during Safe Mode bootup", e);
+                    reportWtf("enabling Airplane Mode during Safe Mode bootup: " + safeMode + " EnableAirplaneModeOnBoot: " + airplaneModeOnBoot, e);
                 }
                 t.traceEnd();
             }


### PR DESCRIPTION
Reuses same logic as safe boot to enable airplane mode
Resolves airplane mode part of https://github.com/GrapheneOS/os-issue-tracker/issues/7311