### PR TITLE
SystemUI: backport CP1A fix for getBubblePackageForLogging crash

### DIFF
--- a/libs/WindowManager/Shell/src/com/android/wm/shell/bubbles/logging/BubbleSessionTracker.kt
+++ b/libs/WindowManager/Shell/src/com/android/wm/shell/bubbles/logging/BubbleSessionTracker.kt
@@ -19,6 +19,7 @@ package com.android.wm.shell.bubbles.logging
 import com.android.wm.shell.bubbles.Bubble
 import com.android.wm.shell.bubbles.BubbleOverflow
 import com.android.wm.shell.bubbles.BubbleViewProvider
+import com.android.wm.shell.shared.bubbles.logging.BubbleLog
 
 /**
  * Keeps track of the current Bubble session.
@@ -81,10 +82,20 @@ fun interface BubbleSessionTracker {
 
     companion object {
         @JvmStatic
-        fun BubbleViewProvider.getBubblePackageForLogging() = when (this) {
+        fun BubbleViewProvider?.getBubblePackageForLogging() = when (this) {
             is Bubble -> packageName
             is BubbleOverflow -> "Overflow"
-            else -> throw IllegalArgumentException("Unsupported type of BubbleViewProvider")
+            null -> {
+                BubbleLog.w("BubbleSessionTracker.getBubblePackageForLogging: null BubbleViewProvider")
+                "null"
+            }
+            else -> {
+                BubbleLog.w(
+                    "BubbleSessionTracker.getBubblePackageForLogging: Unsupported type of BubbleViewProvider with key %s",
+                    getKey()
+                )
+                "unknown"
+            }
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7662

A function meant for logging purposes throwing an uncaught exception seems wrong, and Google seems to agree. This fix was present in SystemUIGoogle in CP1A April. Doesn't appear to be any other changes in CP1A related to how the receiver BubbleViewProvider was handled at getBubblePackageForLogging call sites.

Test: manual, with bubbles in Signal as reported in original issue. Note that I was never able to
reproduce the crash myself.

Test: atest WMShellMultivalentTestsOnDevice:com.android.wm.shell.bubbles.logging.BubbleSessionTrackerImplTest \ WMShellMultivalentTestsOnDevice:com.android.wm.shell.bubbles.BubbleStackViewTest \ WMShellMultivalentTestsOnDevice:com.android.wm.shell.bubbles.BubbleControllerTest \ WMShellMultivalentTestsOnDevice:com.android.wm.shell.bubbles.BubbleControllerBubbleBarTest