### PR TITLE
enable lockscreen widgets feature by default (for stallion based on BD6A and emulator)

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2925,7 +2925,7 @@
     <string-array name="config_loggable_dream_prefixes"></string-array>
 
     <!-- Whether to enable glanceable hub features on this device. -->
-    <bool name="config_glanceableHubEnabled">false</bool>
+    <bool name="config_glanceableHubEnabled">true</bool>
 
     <!-- ComponentName of a dream to show whenever the system would otherwise have
          gone to sleep.  When the PowerManager is asked to go to sleep, it will instead

--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -1116,7 +1116,7 @@
     <string name="focal_area_target" translatable="false" />
 
     <!-- Configuration to swipe to open glanceable hub -->
-    <bool name="config_swipeToOpenGlanceableHub">false</bool>
+    <bool name="config_swipeToOpenGlanceableHub">true</bool>
 
     <!-- Whether or not to show the UMO on the glanceable hub when media is playing. -->
     <bool name="config_showUmoOnHub">false</bool>


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7700

Can merge with https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/427 for emulator support

Pixels enable this via GlanceableHubConfigOverlay (config_glanceableHubEnabled) and GlanceableHubSysuiConfigOverlay (config_swipeToOpenGlanceableHub). Stallion BD6A has the former but is missing config_swipeToOpenGlanceableHub in the SystemUI overlay, which leaves the swipe gesture blocked. Set the AOSP defaults so the feature works without overlays (emulator) and so stallion BD6A's swipe works.

The Settings app needs a matching config_show_glanceable_hub_toggle_setting_mobile flip too, normally provided by GlanceableHubSettingsConfigOverlay. stallion BD6A and other Pixels already have this in the overlay. The user still has to toggle "Widgets on lock screen" to opt in.