### PR TITLE
add GosCompatTests with maps scan test

### DIFF
--- a/tests/GosCompatTests/Android.bp
+++ b/tests/GosCompatTests/Android.bp
@@ -1,0 +1,10 @@
+android_library {
+    name: "GosCompatCheckCommon",
+    srcs: ["common/src/**/*.java"],
+    manifest: "common/AndroidManifest.xml",
+    static_libs: [
+        // Shared by the helper UI and tests for parsing native crash tombstone protobufs.
+        "framework-protos",
+    ],
+    sdk_version: "system_current",
+}

--- a/tests/GosCompatTests/GosCompatCheckApp/Android.bp
+++ b/tests/GosCompatTests/GosCompatCheckApp/Android.bp
@@ -1,0 +1,46 @@
+cc_library_shared {
+    name: "libgoscompat_maps_scan_jni",
+    srcs: ["jni/maps_scan_jni.c"],
+    // The helper app is SDK-built, so the JNI dependency needs a matching SDK variant.
+    sdk_version: "current",
+    header_libs: ["jni_headers"],
+    cflags: [
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+    ],
+    stl: "none",
+}
+
+android_test_helper_app {
+    name: "GosCompatCheckApp",
+    srcs: [
+        "src/**/*.java",
+        "src/**/*.kt",
+    ],
+    manifest: "AndroidManifest.xml",
+    jni_libs: ["libgoscompat_maps_scan_jni"],
+    // Keep the JNI library inside the standalone helper APK loaded by Tradefed and manual installs.
+    use_embedded_native_libs: true,
+    // Build both ABIs so the helper can run under either app process ABI in multi-ABI test runs.
+    compile_multilib: "both",
+    static_libs: [
+        "GosCompatCheckCommon",
+        "androidx.activity_activity",
+        "androidx.activity_activity-compose",
+        "androidx.core_core",
+        "androidx.compose.foundation_foundation",
+        "androidx.compose.foundation_foundation-layout",
+        "androidx.compose.material3_material3",
+        "androidx.compose.runtime_runtime",
+        "androidx.compose.ui_ui",
+        "androidx.compose.ui_ui-graphics",
+        "androidx.compose.ui_ui-text",
+        "androidx.compose.ui_ui-unit",
+    ],
+    kotlincflags: [
+        "-Xjvm-default=all",
+        "-P plugin:androidx.compose.compiler.plugins.kotlin:sourceInformation=true",
+    ],
+    sdk_version: "system_current",
+}

--- a/tests/GosCompatTests/GosCompatCheckApp/AndroidManifest.xml
+++ b/tests/GosCompatTests/GosCompatCheckApp/AndroidManifest.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="app.grapheneos.goscompat.checks">
+
+    <application
+        android:debuggable="true"
+        android:label="GOS Compat Checks"
+        android:theme="@android:style/Theme.DeviceDefault.DayNight">
+        <activity
+            android:name=".GosCompatCheckActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <!-- Shell holds DUMP; gate this exported crash trigger to shell-driven tests. -->
+        <activity
+            android:name=".MapsScanCrashActivity"
+            android:exported="true"
+            android:permission="android.permission.DUMP"
+            android:process=":maps_scan"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
+        <provider
+            android:name=".MapsScanProvider"
+            android:authorities="app.grapheneos.goscompat.checks.maps_scan_provider"
+            android:exported="false"
+            android:process=":maps_scan" />
+    </application>
+</manifest>

--- a/tests/GosCompatTests/GosCompatCheckApp/jni/maps_scan_jni.c
+++ b/tests/GosCompatTests/GosCompatCheckApp/jni/maps_scan_jni.c
@@ -1,0 +1,257 @@
+#define _GNU_SOURCE
+
+#include <jni.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+struct scan_result {
+    bool completed;
+    int selected_ranges;
+    uint64_t scanned_bytes;
+    pid_t caller_tid;
+    pid_t worker_tid;
+    uintptr_t first_range_start;
+    uintptr_t first_range_end;
+    uint8_t checksum;
+    char error[160];
+};
+
+static pid_t get_thread_id(void) {
+    return (pid_t) syscall(SYS_gettid);
+}
+
+static void set_error(struct scan_result* result, const char* message) {
+    if (result->error[0] == '\0') {
+        snprintf(result->error, sizeof(result->error), "%s", message);
+    }
+}
+
+static int char_value(char c) {
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    }
+    if (c >= 'a' && c <= 'f') {
+        return c - 'a' + 10;
+    }
+    return -1;
+}
+
+static uint8_t dereff(const uint8_t* p, struct scan_result* result) {
+    uint8_t value = *(volatile const uint8_t*) p;
+    result->checksum ^= value;
+    result->scanned_bytes++;
+    return value;
+}
+
+static void scan_memory_range(uintptr_t start, uintptr_t end, struct scan_result* result) {
+    uint8_t* p = (uint8_t*) start;
+    uint8_t* range_end = (uint8_t*) end;
+
+    while (p < range_end) {
+        uint8_t first = dereff(p, result);
+        if (first == 0) {
+            p++;
+            continue;
+        }
+
+        uint8_t* q = p;
+        while (q < range_end && dereff(q, result) != 0) {
+            q++;
+        }
+
+        if (q >= range_end) {
+            break;
+        }
+
+        uint8_t* second = q + 1;
+        uint8_t* next = second;
+        for (int i = 0; i < 4; i++) {
+            while (next < range_end) {
+                if (dereff(next, result) == 0) {
+                    next++;
+                    break;
+                }
+                next++;
+            }
+        }
+
+        size_t second_len = 0;
+        while (second + second_len < range_end
+                && dereff(second + second_len, result) != 0) {
+            second_len++;
+        }
+
+        for (size_t i = 0; i < second_len; i++) {
+            dereff(second + i, result);
+        }
+        for (size_t i = 0; i < second_len; i++) {
+            dereff(second + i, result);
+        }
+
+        p = next;
+    }
+}
+
+static void process_maps_line(const char* line, size_t line_len, struct scan_result* result) {
+    size_t i = 0;
+    uint64_t state = 0;
+    for (; i < line_len; i++) {
+        state = (((state << 5) & 0x01ffffffffffffe0)
+                + ((uint64_t) (uint8_t) line[i] * 0x13) + 0x2b)
+                & 0x01ffffffffffffe0;
+        if (state == 0x01f768198a3e0440) {
+            break;
+        }
+    }
+    if (i == line_len) {
+        return;
+    }
+
+    uintptr_t start = 0;
+    const char* p = line;
+    for (;;) {
+        int value = char_value(*p);
+        if (value < 0) {
+            break;
+        }
+        start = (start << 4) | (uintptr_t) value;
+        p++;
+    }
+
+    p = line;
+    while (*p != '\0' && *p != '-') {
+        p++;
+    }
+    if (*p == '-') {
+        p++;
+    }
+
+    uintptr_t end = 0;
+    for (;;) {
+        int value = char_value(*p);
+        if (value < 0) {
+            break;
+        }
+        end = (end << 4) | (uintptr_t) value;
+        p++;
+    }
+
+    // intentionally ignore the permissions field, so unreadable ranges are scanned too
+    result->selected_ranges++;
+    if (result->selected_ranges == 1) {
+        result->first_range_start = start;
+        result->first_range_end = end;
+    }
+
+    scan_memory_range(start, end, result);
+}
+
+static void run_maps_scan(struct scan_result* result) {
+    result->worker_tid = get_thread_id();
+
+    int fd = (int) syscall(SYS_openat, AT_FDCWD, "/proc/self/maps", O_RDONLY, 0);
+    if (fd < 0) {
+        snprintf(result->error, sizeof(result->error), "openat(%s) failed: errno=%d",
+                "/proc/self/maps", errno);
+        return;
+    }
+
+    char read_buf[0x800];
+    char line[0x800];
+    size_t line_len = 0;
+
+    for (;;) {
+        ssize_t n = (ssize_t) syscall(SYS_read, fd, read_buf, sizeof(read_buf));
+        if (n < 0) {
+            snprintf(result->error, sizeof(result->error), "read(%s) failed: errno=%d",
+                    "/proc/self/maps", errno);
+            break;
+        }
+        if (n == 0) {
+            result->completed = result->error[0] == '\0' && result->selected_ranges > 0;
+            break;
+        }
+
+        for (ssize_t i = 0; i < n; i++) {
+            char c = read_buf[i];
+            line[line_len++] = c;
+
+            if (c != '\n') {
+                continue;
+            }
+
+            line[line_len] = '\0';
+            process_maps_line(line, line_len, result);
+            line_len = 0;
+        }
+    }
+
+    if (result->error[0] == '\0' && result->selected_ranges == 0) {
+        set_error(result, "No entry found");
+    }
+
+    syscall(SYS_close, fd);
+}
+
+static void set_string(JNIEnv* env, jobjectArray array, jsize index, const char* value) {
+    jstring string = (*env)->NewStringUTF(env, value != NULL ? value : "");
+    (*env)->SetObjectArrayElement(env, array, index, string);
+    (*env)->DeleteLocalRef(env, string);
+}
+
+static jobjectArray result_to_array(JNIEnv* env, const struct scan_result* result) {
+    jclass string_class = (*env)->FindClass(env, "java/lang/String");
+    jobjectArray array = (*env)->NewObjectArray(env, 9, string_class, NULL);
+
+    char completed[8];
+    char selected_ranges[32];
+    char scanned_bytes[32];
+    char caller_tid[32];
+    char worker_tid[32];
+    char first_range_start[32];
+    char first_range_end[32];
+    char checksum[16];
+
+    snprintf(completed, sizeof(completed), "%s", result->completed ? "true" : "false");
+    snprintf(selected_ranges, sizeof(selected_ranges), "%d", result->selected_ranges);
+    snprintf(scanned_bytes, sizeof(scanned_bytes), "%" PRIu64, result->scanned_bytes);
+    snprintf(caller_tid, sizeof(caller_tid), "%d", result->caller_tid);
+    snprintf(worker_tid, sizeof(worker_tid), "%d", result->worker_tid);
+    snprintf(first_range_start, sizeof(first_range_start), "0x%" PRIxPTR,
+            result->first_range_start);
+    snprintf(first_range_end, sizeof(first_range_end), "0x%" PRIxPTR, result->first_range_end);
+    snprintf(checksum, sizeof(checksum), "0x%02x", result->checksum);
+
+    set_string(env, array, 0, completed);
+    set_string(env, array, 1, selected_ranges);
+    set_string(env, array, 2, scanned_bytes);
+    set_string(env, array, 3, caller_tid);
+    set_string(env, array, 4, worker_tid);
+    set_string(env, array, 5, first_range_start);
+    set_string(env, array, 6, first_range_end);
+    set_string(env, array, 7, checksum);
+    set_string(env, array, 8, result->error);
+
+    return array;
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_app_grapheneos_goscompat_checks_MapsScanRunner_nativeRunMapsScan(
+        JNIEnv* env, jclass clazz, jint caller_tid) {
+    (void) clazz;
+
+    struct scan_result result = {
+            .caller_tid = (pid_t) caller_tid,
+    };
+
+    run_maps_scan(&result);
+    return result_to_array(env, &result);
+}

--- a/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/GosCompatCheckActivity.kt
+++ b/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/GosCompatCheckActivity.kt
@@ -1,0 +1,263 @@
+package app.grapheneos.goscompat.checks
+
+import android.content.Context
+import android.graphics.Color as AndroidColor
+import android.os.Bundle
+import android.os.DeadObjectException
+import android.view.Window
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+class GosCompatCheckActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        requestWindowFeature(Window.FEATURE_NO_TITLE)
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.auto(AndroidColor.TRANSPARENT, AndroidColor.TRANSPARENT),
+            navigationBarStyle = SystemBarStyle.auto(AndroidColor.TRANSPARENT, AndroidColor.TRANSPARENT),
+        )
+
+        setContent {
+            val colorScheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()
+            MaterialTheme(colorScheme = colorScheme) {
+                val directMapsScanResult = remember { mutableStateOf<MapsScanResult?>(null) }
+                val directMapsScanRunning = remember { mutableStateOf(false) }
+                val reflectiveMapsScanResult = remember { mutableStateOf<MapsScanResult?>(null) }
+                val reflectiveMapsScanRunning = remember { mutableStateOf(false) }
+
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background,
+                ) {
+                    GosCompatCheckScreen(
+                        directMapsScanResult = directMapsScanResult.value,
+                        directMapsScanRunning = directMapsScanRunning.value,
+                        reflectiveMapsScanResult = reflectiveMapsScanResult.value,
+                        reflectiveMapsScanRunning = reflectiveMapsScanRunning.value,
+                        onRunDirectMapsScan = {
+                            startMapsScan(
+                                GosCompatContract.METHOD_RUN_DIRECT_MAPS_SCAN_CHECK,
+                                directMapsScanResult,
+                                directMapsScanRunning,
+                            )
+                        },
+                        onRunReflectiveMapsScan = {
+                            startMapsScan(
+                                GosCompatContract.METHOD_RUN_REFLECTIVE_MAPS_SCAN_CHECK,
+                                reflectiveMapsScanResult,
+                                reflectiveMapsScanRunning,
+                            )
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    private fun startMapsScan(
+        method: String,
+        result: MutableState<MapsScanResult?>,
+        running: MutableState<Boolean>,
+    ) {
+        if (running.value) {
+            return
+        }
+        running.value = true
+        Thread {
+            val checkResult = runMapsScanProvider(this, method)
+            runOnUiThread {
+                result.value = checkResult
+                running.value = false
+            }
+        }.start()
+    }
+
+    private fun runMapsScanProvider(context: Context, method: String): MapsScanResult {
+        val startTimeMillis = System.currentTimeMillis()
+        return try {
+            val client = context.contentResolver.acquireUnstableContentProviderClient(
+                GosCompatContract.MAPS_SCAN_CONTENT_URI,
+            ) ?: return MapsScanResult.failed("Maps scan provider was unavailable")
+            val bundle = try {
+                // Keep the UI process from becoming a stable provider dependent. The scanner is
+                // expected to crash when reproducing the compatibility issue on unfixed builds.
+                client.call(method, null, null)
+            } finally {
+                client.close()
+            }
+            if (bundle != null) {
+                MapsScanResult.fromBundle(bundle)
+            } else {
+                MapsScanResult.failed("Maps scan provider returned no result")
+            }
+        } catch (e: DeadObjectException) {
+            MapsScanTombstoneReporter.getNativeCrashResult(context, startTimeMillis)
+        } catch (t: Throwable) {
+            MapsScanResult.failed(
+                "Maps scan provider failed: ${t.javaClass.simpleName}: ${t.message}",
+            )
+        }
+    }
+}
+
+@Composable
+private fun GosCompatCheckScreen(
+    directMapsScanResult: MapsScanResult?,
+    directMapsScanRunning: Boolean,
+    reflectiveMapsScanResult: MapsScanResult?,
+    reflectiveMapsScanRunning: Boolean,
+    onRunDirectMapsScan: () -> Unit,
+    onRunReflectiveMapsScan: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .safeDrawingPadding()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(18.dp),
+    ) {
+        Text(
+            text = "GOS Compat Checks",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold,
+        )
+
+        MapsScanControl(
+            title = "Direct JNI maps scan",
+            mapsScanResult = directMapsScanResult,
+            mapsScanRunning = directMapsScanRunning,
+            onRunMapsScan = onRunDirectMapsScan,
+        )
+        ResultSection("Direct JNI details", directMapsScanResult?.details.orEmpty())
+        ResultSection("Direct JNI errors", directMapsScanResult?.errors.orEmpty())
+
+        MapsScanControl(
+            title = "Reflective JNI maps scan",
+            mapsScanResult = reflectiveMapsScanResult,
+            mapsScanRunning = reflectiveMapsScanRunning,
+            onRunMapsScan = onRunReflectiveMapsScan,
+        )
+        ResultSection("Reflective JNI details", reflectiveMapsScanResult?.details.orEmpty())
+        ResultSection("Reflective JNI errors", reflectiveMapsScanResult?.errors.orEmpty())
+    }
+}
+
+@Composable
+private fun MapsScanControl(
+    title: String,
+    mapsScanResult: MapsScanResult?,
+    mapsScanRunning: Boolean,
+    onRunMapsScan: () -> Unit,
+) {
+    val status = when {
+        mapsScanRunning -> "Running"
+        mapsScanResult != null -> mapsScanResult.statusText
+        else -> "Not run"
+    }
+    val statusColor = when {
+        mapsScanRunning -> MaterialTheme.colorScheme.tertiary
+        mapsScanResult?.isCompleted == true && mapsScanResult.usedWorkerThread() ->
+            MaterialTheme.colorScheme.primary
+        mapsScanResult != null -> MaterialTheme.colorScheme.error
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = status,
+                modifier = Modifier
+                    .background(statusColor.copy(alpha = 0.12f), RoundedCornerShape(6.dp))
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                    .semantics {
+                        contentDescription = "Memory maps scan status: $status"
+                    },
+                color = statusColor,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Button(onClick = onRunMapsScan, enabled = !mapsScanRunning) {
+                Text("Run")
+            }
+        }
+
+        Text(
+            text = mapsScanResult?.summary ?: "Memory maps scan has not been run.",
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}
+
+@Composable
+private fun ResultSection(title: String, lines: List<String>) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(modifier = Modifier.height(6.dp))
+        if (lines.isEmpty()) {
+            Text("None", style = MaterialTheme.typography.bodyMedium)
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+            ) {
+                lines.forEach { line ->
+                    Text(
+                        text = line,
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            fontFamily = FontFamily.Monospace,
+                        ),
+                        softWrap = false,
+                        modifier = Modifier.padding(bottom = 4.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/MapsScanCrashActivity.java
+++ b/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/MapsScanCrashActivity.java
@@ -1,0 +1,26 @@
+package app.grapheneos.goscompat.checks;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+public final class MapsScanCrashActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        String mode = getIntent().getStringExtra(GosCompatContract.EXTRA_MAPS_SCAN_MODE);
+        String token = getIntent().getStringExtra(GosCompatContract.EXTRA_MAPS_SCAN_TOKEN);
+        MapsScanResultStore.clear(this);
+
+        // Keep the native scan outside the launch transaction so a segfault is attributed
+        // to this isolated app process rather than the instrumentation shell command.
+        Thread launcher = new Thread(() -> {
+            MapsScanResult result = GosCompatContract.MODE_REFLECTIVE.equals(mode)
+                    ? MapsScanRunner.runReflective()
+                    : MapsScanRunner.runDirect();
+            MapsScanResultStore.save(getApplicationContext(), token, result);
+            runOnUiThread(this::finish);
+        }, "maps-scan-launcher");
+        launcher.start();
+    }
+}

--- a/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/MapsScanProvider.java
+++ b/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/MapsScanProvider.java
@@ -1,0 +1,58 @@
+package app.grapheneos.goscompat.checks;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+
+public final class MapsScanProvider extends ContentProvider {
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public Bundle call(String method, String arg, Bundle extras) {
+        if (GosCompatContract.METHOD_RUN_MAPS_SCAN_CHECK.equals(method)
+                || GosCompatContract.METHOD_RUN_DIRECT_MAPS_SCAN_CHECK.equals(method)) {
+            return MapsScanRunner.runDirect().toBundle();
+        }
+        if (GosCompatContract.METHOD_RUN_REFLECTIVE_MAPS_SCAN_CHECK.equals(method)) {
+            return MapsScanRunner.runReflective().toBundle();
+        }
+        if (GosCompatContract.METHOD_GET_MAPS_SCAN_RESULT.equals(method)) {
+            return MapsScanResultStore.load(getContext(), arg);
+        }
+        if (GosCompatContract.METHOD_CLEAR_MAPS_SCAN_RESULT.equals(method)) {
+            return MapsScanResultStore.clear(getContext());
+        }
+        return super.call(method, arg, extras);
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs,
+            String sortOrder) {
+        return null;
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        return null;
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        return 0;
+    }
+}

--- a/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/MapsScanResult.java
+++ b/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/MapsScanResult.java
@@ -1,0 +1,121 @@
+package app.grapheneos.goscompat.checks;
+
+import android.os.Bundle;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class MapsScanResult {
+    private final boolean mCompleted;
+    private final boolean mWorkerThread;
+    private final int mSelectedRanges;
+    private final long mScannedBytes;
+    private final int mCallerTid;
+    private final int mWorkerTid;
+    private final ArrayList<String> mDetails;
+    private final ArrayList<String> mErrors;
+
+    MapsScanResult(boolean completed, boolean workerThread, int selectedRanges, long scannedBytes,
+            int callerTid, int workerTid, ArrayList<String> details, ArrayList<String> errors) {
+        mCompleted = completed;
+        mWorkerThread = workerThread;
+        mSelectedRanges = selectedRanges;
+        mScannedBytes = scannedBytes;
+        mCallerTid = callerTid;
+        mWorkerTid = workerTid;
+        mDetails = details;
+        mErrors = errors;
+    }
+
+    public boolean isCompleted() {
+        return mCompleted;
+    }
+
+    public boolean usedWorkerThread() {
+        return mWorkerThread;
+    }
+
+    public int getSelectedRanges() {
+        return mSelectedRanges;
+    }
+
+    public long getScannedBytes() {
+        return mScannedBytes;
+    }
+
+    public int getCallerTid() {
+        return mCallerTid;
+    }
+
+    public int getWorkerTid() {
+        return mWorkerTid;
+    }
+
+    public String getStatusText() {
+        return mCompleted && mWorkerThread ? "Completed" : "Failed";
+    }
+
+    public String getSummary() {
+        if (mCompleted && mWorkerThread) {
+            return "Native maps scan completed from a worker thread.";
+        }
+        if (!mWorkerThread) {
+            return "Native maps scan did not run from a distinct worker thread.";
+        }
+        return "Native maps scan did not complete.";
+    }
+
+    public List<String> getDetails() {
+        return Collections.unmodifiableList(mDetails);
+    }
+
+    public List<String> getErrors() {
+        return Collections.unmodifiableList(mErrors);
+    }
+
+    public Bundle toBundle() {
+        Bundle bundle = new Bundle();
+        bundle.putBoolean(GosCompatContract.KEY_MAPS_SCAN_COMPLETED, mCompleted);
+        bundle.putBoolean(GosCompatContract.KEY_MAPS_SCAN_WORKER_THREAD, mWorkerThread);
+        bundle.putInt(GosCompatContract.KEY_MAPS_SCAN_SELECTED_RANGES, mSelectedRanges);
+        bundle.putLong(GosCompatContract.KEY_MAPS_SCAN_SCANNED_BYTES, mScannedBytes);
+        bundle.putInt(GosCompatContract.KEY_MAPS_SCAN_CALLER_TID, mCallerTid);
+        bundle.putInt(GosCompatContract.KEY_MAPS_SCAN_WORKER_TID, mWorkerTid);
+        bundle.putString(GosCompatContract.KEY_STATUS_TEXT, getStatusText());
+        bundle.putString(GosCompatContract.KEY_SUMMARY, getSummary());
+        bundle.putStringArrayList(GosCompatContract.KEY_MAPS_SCAN_DETAILS,
+                new ArrayList<>(mDetails));
+        bundle.putStringArrayList(GosCompatContract.KEY_MAPS_SCAN_ERRORS,
+                new ArrayList<>(mErrors));
+        return bundle;
+    }
+
+    public static MapsScanResult fromBundle(Bundle bundle) {
+        return new MapsScanResult(
+                bundle.getBoolean(GosCompatContract.KEY_MAPS_SCAN_COMPLETED),
+                bundle.getBoolean(GosCompatContract.KEY_MAPS_SCAN_WORKER_THREAD),
+                bundle.getInt(GosCompatContract.KEY_MAPS_SCAN_SELECTED_RANGES),
+                bundle.getLong(GosCompatContract.KEY_MAPS_SCAN_SCANNED_BYTES),
+                bundle.getInt(GosCompatContract.KEY_MAPS_SCAN_CALLER_TID),
+                bundle.getInt(GosCompatContract.KEY_MAPS_SCAN_WORKER_TID),
+                getStringArrayList(bundle, GosCompatContract.KEY_MAPS_SCAN_DETAILS),
+                getStringArrayList(bundle, GosCompatContract.KEY_MAPS_SCAN_ERRORS));
+    }
+
+    public static MapsScanResult failed(String error) {
+        return failed(error, Collections.emptyList(), false);
+    }
+
+    public static MapsScanResult failed(String error, List<String> details, boolean workerThread) {
+        ArrayList<String> errors = new ArrayList<>();
+        errors.add(error);
+        return new MapsScanResult(false, workerThread, 0, 0, 0, 0,
+                new ArrayList<>(details), errors);
+    }
+
+    private static ArrayList<String> getStringArrayList(Bundle bundle, String key) {
+        ArrayList<String> value = bundle.getStringArrayList(key);
+        return value != null ? value : new ArrayList<>();
+    }
+}

--- a/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/MapsScanResultStore.java
+++ b/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/MapsScanResultStore.java
@@ -1,0 +1,111 @@
+package app.grapheneos.goscompat.checks;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Properties;
+
+final class MapsScanResultStore {
+    private static final String PREFS = "maps_scan_results";
+    private static final String KEY_TOKEN = "token";
+    private static final String KEY_COMPLETED = "completed";
+    private static final String KEY_WORKER_THREAD = "worker_thread";
+    private static final String KEY_SELECTED_RANGES = "selected_ranges";
+    private static final String KEY_SCANNED_BYTES = "scanned_bytes";
+    private static final String KEY_CALLER_TID = "caller_tid";
+    private static final String KEY_WORKER_TID = "worker_tid";
+
+    private MapsScanResultStore() {
+    }
+
+    // Crash-mode tests start the scan asynchronously in an isolated process. A current-token
+    // result here means that process completed the native scan without crashing.
+    static void save(Context context, String token, MapsScanResult result) {
+        if (token == null || token.isEmpty()) {
+            return;
+        }
+
+        prefs(context).edit()
+                .putString(KEY_TOKEN, token)
+                .putBoolean(KEY_COMPLETED, result.isCompleted())
+                .putBoolean(KEY_WORKER_THREAD, result.usedWorkerThread())
+                .putInt(KEY_SELECTED_RANGES, result.getSelectedRanges())
+                .putLong(KEY_SCANNED_BYTES, result.getScannedBytes())
+                .putInt(KEY_CALLER_TID, result.getCallerTid())
+                .putInt(KEY_WORKER_TID, result.getWorkerTid())
+                .commit();
+
+        Properties properties = new Properties();
+        properties.setProperty(GosCompatContract.EXTRA_MAPS_SCAN_TOKEN, token);
+        properties.setProperty(GosCompatContract.KEY_MAPS_SCAN_COMPLETED,
+                Boolean.toString(result.isCompleted()));
+        properties.setProperty(GosCompatContract.KEY_MAPS_SCAN_WORKER_THREAD,
+                Boolean.toString(result.usedWorkerThread()));
+        properties.setProperty(GosCompatContract.KEY_MAPS_SCAN_SELECTED_RANGES,
+                Integer.toString(result.getSelectedRanges()));
+        properties.setProperty(GosCompatContract.KEY_MAPS_SCAN_SCANNED_BYTES,
+                Long.toString(result.getScannedBytes()));
+        properties.setProperty(GosCompatContract.KEY_MAPS_SCAN_CALLER_TID,
+                Integer.toString(result.getCallerTid()));
+        properties.setProperty(GosCompatContract.KEY_MAPS_SCAN_WORKER_TID,
+                Integer.toString(result.getWorkerTid()));
+        try (FileOutputStream output = new FileOutputStream(resultFile(context))) {
+            properties.store(output, null);
+        } catch (IOException ignored) {
+        }
+    }
+
+    static Bundle load(Context context, String token) {
+        Bundle bundle = new Bundle();
+        SharedPreferences prefs = prefs(context);
+        if (token == null || !token.equals(prefs.getString(KEY_TOKEN, null))) {
+            bundle.putBoolean(GosCompatContract.KEY_MAPS_SCAN_RESULT_AVAILABLE, false);
+            return bundle;
+        }
+
+        boolean completed = prefs.getBoolean(KEY_COMPLETED, false);
+        boolean workerThread = prefs.getBoolean(KEY_WORKER_THREAD, false);
+        bundle.putBoolean(GosCompatContract.KEY_MAPS_SCAN_RESULT_AVAILABLE, true);
+        bundle.putBoolean(GosCompatContract.KEY_MAPS_SCAN_COMPLETED, completed);
+        bundle.putBoolean(GosCompatContract.KEY_MAPS_SCAN_WORKER_THREAD, workerThread);
+        bundle.putInt(GosCompatContract.KEY_MAPS_SCAN_SELECTED_RANGES,
+                prefs.getInt(KEY_SELECTED_RANGES, 0));
+        bundle.putLong(GosCompatContract.KEY_MAPS_SCAN_SCANNED_BYTES,
+                prefs.getLong(KEY_SCANNED_BYTES, 0));
+        bundle.putInt(GosCompatContract.KEY_MAPS_SCAN_CALLER_TID,
+                prefs.getInt(KEY_CALLER_TID, 0));
+        bundle.putInt(GosCompatContract.KEY_MAPS_SCAN_WORKER_TID,
+                prefs.getInt(KEY_WORKER_TID, 0));
+        bundle.putString(GosCompatContract.KEY_STATUS_TEXT,
+                completed && workerThread ? "Completed" : "Failed");
+        bundle.putString(GosCompatContract.KEY_SUMMARY,
+                completed && workerThread
+                        ? "Native maps scan completed from a worker thread."
+                        : "Native maps scan did not complete from a worker thread.");
+        bundle.putStringArrayList(GosCompatContract.KEY_MAPS_SCAN_DETAILS, new ArrayList<>());
+        bundle.putStringArrayList(GosCompatContract.KEY_MAPS_SCAN_ERRORS, new ArrayList<>());
+        return bundle;
+    }
+
+    static Bundle clear(Context context) {
+        prefs(context).edit().clear().commit();
+        resultFile(context).delete();
+
+        Bundle bundle = new Bundle();
+        bundle.putBoolean(GosCompatContract.KEY_MAPS_SCAN_RESULT_AVAILABLE, false);
+        return bundle;
+    }
+
+    private static SharedPreferences prefs(Context context) {
+        return context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
+    }
+
+    private static File resultFile(Context context) {
+        return new File(context.getFilesDir(), GosCompatContract.MAPS_SCAN_RESULT_FILE);
+    }
+}

--- a/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/MapsScanRunner.java
+++ b/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/MapsScanRunner.java
@@ -1,0 +1,163 @@
+package app.grapheneos.goscompat.checks;
+
+import android.os.Process;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public final class MapsScanRunner {
+    private static final int RESULT_COMPLETED = 0;
+    private static final int RESULT_SELECTED_RANGES = 1;
+    private static final int RESULT_SCANNED_BYTES = 2;
+    private static final int RESULT_CALLER_TID = 3;
+    private static final int RESULT_WORKER_TID = 4;
+    private static final int RESULT_FIRST_RANGE_START = 5;
+    private static final int RESULT_FIRST_RANGE_END = 6;
+    private static final int RESULT_CHECKSUM = 7;
+    private static final int RESULT_ERROR = 8;
+    private static final int RESULT_FIELD_COUNT = 9;
+    private static final long WORKER_TIMEOUT_SECONDS = 20;
+
+    private static boolean sNativeLoaded;
+
+    private MapsScanRunner() {
+    }
+
+    public static MapsScanResult run() {
+        return runDirect();
+    }
+
+    public static MapsScanResult runDirect() {
+        return runOnJavaWorker("direct JNI", new NativeInvocation() {
+            @Override
+            public String[] invoke(int callerTid) {
+                return nativeRunMapsScan(callerTid);
+            }
+        });
+    }
+
+    public static MapsScanResult runReflective() {
+        return runOnJavaWorker("reflective JNI", new NativeInvocation() {
+            @Override
+            public String[] invoke(int callerTid) throws ReflectiveOperationException {
+                Method method = MapsScanRunner.class.getDeclaredMethod(
+                        "nativeRunMapsScan", int.class);
+                method.setAccessible(true);
+                try {
+                    return (String[]) method.invoke(null, callerTid);
+                } catch (InvocationTargetException e) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof RuntimeException) {
+                        throw (RuntimeException) cause;
+                    }
+                    if (cause instanceof Error) {
+                        throw (Error) cause;
+                    }
+                    throw e;
+                }
+            }
+        });
+    }
+
+    private static MapsScanResult runOnJavaWorker(String invocationMode,
+            NativeInvocation invocation) {
+        ArrayList<String> details = new ArrayList<>();
+        ArrayList<String> errors = new ArrayList<>();
+        ExecutorService executor = null;
+
+        try {
+            ensureNativeLoaded();
+            final int providerTid = Process.myTid();
+            executor = Executors.newSingleThreadExecutor();
+            Future<String[]> future = executor.submit(new Callable<String[]>() {
+                @Override
+                public String[] call() throws Exception {
+                    return invocation.invoke(providerTid);
+                }
+            });
+            String[] fields = future.get(WORKER_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            if (fields == null || fields.length != RESULT_FIELD_COUNT) {
+                errors.add("Native maps scan returned an invalid result");
+                return new MapsScanResult(false, false, 0, 0, 0, 0, details, errors);
+            }
+
+            boolean completed = Boolean.parseBoolean(fields[RESULT_COMPLETED]);
+            int selectedRanges = parseInt(fields[RESULT_SELECTED_RANGES]);
+            long scannedBytes = parseLong(fields[RESULT_SCANNED_BYTES]);
+            int callerTid = parseInt(fields[RESULT_CALLER_TID]);
+            int workerTid = parseInt(fields[RESULT_WORKER_TID]);
+            boolean workerThread = workerTid > 0 && workerTid != callerTid;
+
+            details.add("Invocation mode: " + invocationMode);
+            details.add("Selected " + selectedRanges + " maps range(s)");
+            details.add("Executed " + scannedBytes + " selected-range byte load(s)");
+            details.add("callerTid=" + callerTid + ", workerTid=" + workerTid);
+            details.add("First selected range " + fields[RESULT_FIRST_RANGE_START]
+                    + "-" + fields[RESULT_FIRST_RANGE_END]);
+            details.add("Read checksum " + fields[RESULT_CHECKSUM]);
+
+            String error = fields[RESULT_ERROR];
+            if (error != null && !error.isEmpty()) {
+                errors.add(error);
+            }
+            if (!workerThread) {
+                errors.add("Native maps scan did not run on a distinct worker thread");
+            }
+            if (selectedRanges == 0) {
+                errors.add("Native maps scan did not find the expected main stack/TLS entry");
+            }
+
+            return new MapsScanResult(completed, workerThread, selectedRanges, scannedBytes,
+                    callerTid, workerTid, details, errors);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            errors.add("Native maps scan failed: " + cause.getClass().getSimpleName()
+                    + ": " + cause.getMessage());
+            return new MapsScanResult(false, false, 0, 0, 0, 0, details, errors);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            errors.add("Native maps scan interrupted");
+            return new MapsScanResult(false, false, 0, 0, 0, 0, details, errors);
+        } catch (TimeoutException e) {
+            errors.add("Native maps scan timed out");
+            return new MapsScanResult(false, false, 0, 0, 0, 0, details, errors);
+        } catch (RuntimeException | UnsatisfiedLinkError e) {
+            errors.add("Native maps scan failed: " + e.getClass().getSimpleName()
+                    + ": " + e.getMessage());
+            return new MapsScanResult(false, false, 0, 0, 0, 0, details, errors);
+        } finally {
+            if (executor != null) {
+                executor.shutdownNow();
+            }
+        }
+    }
+
+    private static int parseInt(String value) {
+        return value == null || value.isEmpty() ? 0 : Integer.parseInt(value);
+    }
+
+    private static long parseLong(String value) {
+        return value == null || value.isEmpty() ? 0 : Long.parseLong(value);
+    }
+
+    private static synchronized void ensureNativeLoaded() {
+        if (!sNativeLoaded) {
+            System.loadLibrary("goscompat_maps_scan_jni");
+            sNativeLoaded = true;
+        }
+    }
+
+    private interface NativeInvocation {
+        String[] invoke(int callerTid) throws Exception;
+    }
+
+    private static native String[] nativeRunMapsScan(int callerTid);
+}

--- a/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/MapsScanTombstoneReporter.java
+++ b/tests/GosCompatTests/GosCompatCheckApp/src/app/grapheneos/goscompat/checks/MapsScanTombstoneReporter.java
@@ -1,0 +1,102 @@
+package app.grapheneos.goscompat.checks;
+
+import android.app.ActivityManager;
+import android.app.ApplicationExitInfo;
+import android.content.Context;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+final class MapsScanTombstoneReporter {
+    private static final long TOMBSTONE_FETCH_TIMEOUT_MILLIS = 10_000;
+    private static final long POLL_INTERVAL_MILLIS = 200;
+
+    private MapsScanTombstoneReporter() {
+    }
+
+    static MapsScanResult getNativeCrashResult(Context context, long startTimeMillis) {
+        ActivityManager activityManager = context.getSystemService(ActivityManager.class);
+        if (activityManager == null) {
+            return MapsScanResult.failed(
+                    "Maps scan process crashed before returning; ActivityManager unavailable.");
+        }
+
+        ApplicationExitInfo latestCrash = null;
+        Throwable lastError = null;
+        long deadline = System.currentTimeMillis() + TOMBSTONE_FETCH_TIMEOUT_MILLIS;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                List<ApplicationExitInfo> exits =
+                        activityManager.getHistoricalProcessExitReasons(null, 0, 16);
+                for (ApplicationExitInfo exit : exits) {
+                    if (!isMatchingNativeCrash(exit, startTimeMillis)) {
+                        continue;
+                    }
+                    latestCrash = exit;
+                    String formattedTombstone = formatTombstone(exit);
+                    if (formattedTombstone != null) {
+                        return MapsScanResult.failed(
+                                "Maps scan process crashed before returning.",
+                                splitLines(formattedTombstone),
+                                true);
+                    }
+                }
+            } catch (Throwable t) {
+                lastError = t;
+            }
+
+            try {
+                Thread.sleep(POLL_INTERVAL_MILLIS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                lastError = e;
+                break;
+            }
+        }
+
+        ArrayList<String> details = new ArrayList<>();
+        if (latestCrash != null) {
+            details.add("Native crash was recorded, but its tombstone trace was unavailable.");
+            details.add("pid=" + latestCrash.getPid()
+                    + ", process=" + latestCrash.getProcessName()
+                    + ", description=" + latestCrash.getDescription());
+        }
+        if (lastError != null) {
+            details.add("tombstone lookup error=" + lastError.getClass().getSimpleName()
+                    + ": " + lastError.getMessage());
+        }
+
+        return MapsScanResult.failed(
+                "Maps scan process crashed before returning; no parsed tombstone was available.",
+                details,
+                true);
+    }
+
+    private static boolean isMatchingNativeCrash(ApplicationExitInfo exit, long startTimeMillis) {
+        return exit.getTimestamp() >= startTimeMillis
+                && exit.getReason() == ApplicationExitInfo.REASON_CRASH_NATIVE
+                && GosCompatContract.MAPS_SCAN_PROCESS.equals(exit.getProcessName());
+    }
+
+    private static String formatTombstone(ApplicationExitInfo exit) throws Exception {
+        try (InputStream input = exit.getTraceInputStream()) {
+            if (input == null) {
+                return null;
+            }
+            return MapsScanTombstoneFormatter.format(MapsScanTombstoneFormatter.readFully(input));
+        }
+    }
+
+    private static ArrayList<String> splitLines(String text) {
+        ArrayList<String> lines = new ArrayList<>();
+        String[] split = text.split("\\R", -1);
+        for (int i = 0; i < split.length; i++) {
+            if (i == split.length - 1 && split[i].isEmpty()) {
+                continue;
+            }
+            lines.add(split[i]);
+        }
+        return lines;
+    }
+}

--- a/tests/GosCompatTests/GosCompatMapsScanTests/Android.bp
+++ b/tests/GosCompatTests/GosCompatMapsScanTests/Android.bp
@@ -1,0 +1,32 @@
+android_test {
+    name: "GosCompatMapsScanTests",
+    srcs: [
+        "src/**/*.java",
+    ],
+    manifest: "AndroidManifest.xml",
+    test_config: "AndroidTest.xml",
+    static_libs: [
+        "GosCompatCheckCommon",
+        "androidx.test.ext.junit",
+        "androidx.test.runner",
+        "androidx.test.rules",
+        "androidx.test.uiautomator_uiautomator",
+        // Provides TestLogData and LogFileLogger for tombstone artifacts.
+        "collector-device-lib",
+        // Provides PollingCheck and shell-permission helpers for ApplicationExitInfo access.
+        "compatibility-device-util-axt",
+        "truth",
+    ],
+    libs: ["android.test.runner.stubs"],
+    data: [
+        // Install the standalone helper app that owns the crashing :maps_scan process.
+        ":GosCompatCheckApp",
+    ],
+    // Tradefed failure reporting loads LogcatParser from loganalysis.
+    host_required: [
+        "loganalysis",
+    ],
+    platform_apis: true,
+    certificate: "platform",
+    test_suites: ["device-tests"],
+}

--- a/tests/GosCompatTests/GosCompatMapsScanTests/AndroidManifest.xml
+++ b/tests/GosCompatTests/GosCompatMapsScanTests/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="app.grapheneos.goscompat.tests">
+
+    <queries>
+        <package android:name="app.grapheneos.goscompat.checks" />
+    </queries>
+
+    <application
+        android:debuggable="true"
+        android:label="GOS Compat Tests" />
+
+    <instrumentation
+        android:name="androidx.test.runner.AndroidJUnitRunner"
+        android:targetPackage="app.grapheneos.goscompat.tests" />
+</manifest>

--- a/tests/GosCompatTests/GosCompatMapsScanTests/AndroidTest.xml
+++ b/tests/GosCompatTests/GosCompatMapsScanTests/AndroidTest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration description="Runs GosCompatMapsScanTests">
+    <target_preparer class="com.android.tradefed.targetprep.suite.SuiteApkInstaller">
+        <option name="cleanup-apks" value="true" />
+        <option name="install-arg" value="-r" />
+        <option name="install-arg" value="-d" />
+        <option name="install-arg" value="-g" />
+        <option name="install-arg" value="-t" />
+        <option name="test-file-name" value="GosCompatCheckApp.apk" />
+        <option name="test-file-name" value="GosCompatMapsScanTests.apk" />
+    </target_preparer>
+
+    <test class="com.android.tradefed.testtype.AndroidJUnitTest">
+        <option name="package" value="app.grapheneos.goscompat.tests" />
+        <option name="runner" value="androidx.test.runner.AndroidJUnitRunner" />
+        <!-- Sends TestLogData files to Tradefed so the collector below can pull them. -->
+        <option name="device-listeners" value="android.device.loggers.LogFileLogger" />
+        <option name="hidden-api-checks" value="false" />
+    </test>
+
+    <metrics_collector class="com.android.tradefed.device.metric.FilePullerLogCollector">
+        <!-- Pull formatted and raw tombstone artifacts reported by failed scan attempts. -->
+        <option name="pull-pattern-keys" value="goscompat_maps_scan_tombstone_.*" />
+        <option name="collect-on-run-ended-only" value="false" />
+    </metrics_collector>
+</configuration>

--- a/tests/GosCompatTests/GosCompatMapsScanTests/src/app/grapheneos/goscompat/tests/MapsScanTests.java
+++ b/tests/GosCompatTests/GosCompatMapsScanTests/src/app/grapheneos/goscompat/tests/MapsScanTests.java
@@ -1,0 +1,295 @@
+package app.grapheneos.goscompat.tests;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.fail;
+
+import android.Manifest;
+import android.app.ActivityManager;
+import android.app.ApplicationExitInfo;
+import android.app.Instrumentation;
+import android.content.Context;
+import android.device.loggers.TestLogData;
+import android.os.Bundle;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.uiautomator.UiDevice;
+
+import app.grapheneos.goscompat.checks.GosCompatContract;
+import app.grapheneos.goscompat.checks.MapsScanTombstoneFormatter;
+
+import com.android.compatibility.common.util.PollingCheck;
+import com.android.compatibility.common.util.ShellIdentityUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+
+public final class MapsScanTests {
+    private static final long OUTCOME_TIMEOUT_MILLIS = 30_000;
+    private static final long TOMBSTONE_FETCH_TIMEOUT_MILLIS = 10_000;
+    private static final long POLL_INTERVAL_MILLIS = 200;
+    private static final int SCAN_ATTEMPTS = 10;
+    private static final String TOMBSTONE_ARTIFACT_KEY_PREFIX =
+            "goscompat_maps_scan_tombstone_";
+
+    @Rule
+    public final TestLogData mLogs = new TestLogData();
+
+    private Context mContext;
+    private UiDevice mDevice;
+    private ActivityManager mActivityManager;
+
+    @Before
+    public void setUp() {
+        Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+        mContext = instrumentation.getContext();
+        mDevice = UiDevice.getInstance(instrumentation);
+        mActivityManager = mContext.getSystemService(ActivityManager.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mDevice.executeShellCommand("am force-stop " + GosCompatContract.APP_PACKAGE);
+    }
+
+    @Test
+    public void directNativeMapsScanDoesNotCrashFromJavaWorkerThread() throws Exception {
+        assertMapsScanModeDoesNotCrash(GosCompatContract.MODE_DIRECT);
+    }
+
+    @Test
+    public void reflectiveNativeMapsScanDoesNotCrashFromJavaWorkerThread() throws Exception {
+        assertMapsScanModeDoesNotCrash(GosCompatContract.MODE_REFLECTIVE);
+    }
+
+    private void assertMapsScanModeDoesNotCrash(String mode) throws Exception {
+        for (int attempt = 1; attempt <= SCAN_ATTEMPTS; attempt++) {
+            assertMapsScanAttemptDoesNotCrash(mode, attempt);
+        }
+    }
+
+    private void assertMapsScanAttemptDoesNotCrash(String mode, int attempt) throws Exception {
+        String token = UUID.randomUUID().toString();
+
+        // The translucent trigger activity starts the scan asynchronously. Force-stop first so each
+        // attempt gets a newly created helper process with fresh bionic thread mappings.
+        mDevice.executeShellCommand("am force-stop " + GosCompatContract.APP_PACKAGE);
+
+        long startTimeMillis = System.currentTimeMillis();
+        // Use an activity launch because shell-started background services are rejected by
+        // ActivityManager background-start restrictions.
+        String output = mDevice.executeShellCommand("am start -n "
+                + GosCompatContract.MAPS_SCAN_CRASH_ACTIVITY
+                + " --es " + GosCompatContract.EXTRA_MAPS_SCAN_MODE + " " + mode
+                + " --es " + GosCompatContract.EXTRA_MAPS_SCAN_TOKEN + " " + token);
+        assertWithMessage(output).that(output).doesNotContain("Error");
+
+        ScanOutcome outcome = waitForOutcome(token, startTimeMillis, mode, attempt);
+        if (outcome.result != null) {
+            assertCompletedResult(outcome.result, mode, attempt);
+            mDevice.executeShellCommand("am force-stop " + GosCompatContract.APP_PACKAGE);
+            return;
+        }
+
+        byte[] tombstoneProto = fetchTombstone(outcome.nativeCrash);
+        String formattedTombstone = MapsScanTombstoneFormatter.format(tombstoneProto);
+        reportTombstoneArtifacts(mode, attempt, formattedTombstone, tombstoneProto);
+        fail("Maps scan crashed in " + mode + " mode on attempt " + attempt + " of "
+                + SCAN_ATTEMPTS + ":\n" + formattedTombstone);
+    }
+
+    private ScanOutcome waitForOutcome(String token, long startTimeMillis, String mode,
+            int attempt) throws Exception {
+        long deadline = System.currentTimeMillis() + OUTCOME_TIMEOUT_MILLIS;
+        while (System.currentTimeMillis() < deadline) {
+            ApplicationExitInfo nativeCrash = findNativeCrash(startTimeMillis);
+            if (nativeCrash != null) {
+                return ScanOutcome.forNativeCrash(nativeCrash);
+            }
+
+            Bundle result = getStoredResult(token);
+            if (result != null
+                    && result.getBoolean(GosCompatContract.KEY_MAPS_SCAN_RESULT_AVAILABLE)) {
+                return ScanOutcome.forResult(result);
+            }
+
+            java.lang.Thread.sleep(POLL_INTERVAL_MILLIS);
+        }
+
+        fail("Timed out waiting for maps scan result or native crash in " + mode
+                + " mode on attempt " + attempt + " of " + SCAN_ATTEMPTS);
+        return null;
+    }
+
+    private Bundle getStoredResult(String token) {
+        try {
+            // Poll a file instead of the provider so the instrumentation process never depends
+            // on a binder transaction into a helper process that may be crashing.
+            String output = mDevice.executeShellCommand("run-as " + GosCompatContract.APP_PACKAGE
+                    + " cat files/" + GosCompatContract.MAPS_SCAN_RESULT_FILE + " 2>/dev/null");
+            if (output == null || output.trim().isEmpty()) {
+                return null;
+            }
+
+            Properties properties = new Properties();
+            properties.load(new StringReader(output));
+            if (!token.equals(properties.getProperty(GosCompatContract.EXTRA_MAPS_SCAN_TOKEN))) {
+                return null;
+            }
+
+            boolean completed = getBoolean(properties,
+                    GosCompatContract.KEY_MAPS_SCAN_COMPLETED);
+            boolean workerThread = getBoolean(properties,
+                    GosCompatContract.KEY_MAPS_SCAN_WORKER_THREAD);
+
+            Bundle result = new Bundle();
+            result.putBoolean(GosCompatContract.KEY_MAPS_SCAN_RESULT_AVAILABLE, true);
+            result.putBoolean(GosCompatContract.KEY_MAPS_SCAN_COMPLETED, completed);
+            result.putBoolean(GosCompatContract.KEY_MAPS_SCAN_WORKER_THREAD, workerThread);
+            result.putInt(GosCompatContract.KEY_MAPS_SCAN_SELECTED_RANGES,
+                    getInt(properties, GosCompatContract.KEY_MAPS_SCAN_SELECTED_RANGES));
+            result.putLong(GosCompatContract.KEY_MAPS_SCAN_SCANNED_BYTES,
+                    getLong(properties, GosCompatContract.KEY_MAPS_SCAN_SCANNED_BYTES));
+            result.putInt(GosCompatContract.KEY_MAPS_SCAN_CALLER_TID,
+                    getInt(properties, GosCompatContract.KEY_MAPS_SCAN_CALLER_TID));
+            result.putInt(GosCompatContract.KEY_MAPS_SCAN_WORKER_TID,
+                    getInt(properties, GosCompatContract.KEY_MAPS_SCAN_WORKER_TID));
+            result.putString(GosCompatContract.KEY_STATUS_TEXT,
+                    completed && workerThread ? "Completed" : "Failed");
+            return result;
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    private static boolean getBoolean(Properties properties, String key) {
+        return Boolean.parseBoolean(properties.getProperty(key));
+    }
+
+    private static int getInt(Properties properties, String key) {
+        return Integer.parseInt(properties.getProperty(key, "0"));
+    }
+
+    private static long getLong(Properties properties, String key) {
+        return Long.parseLong(properties.getProperty(key, "0"));
+    }
+
+    private ApplicationExitInfo findNativeCrash(long startTimeMillis) throws Exception {
+        List<ApplicationExitInfo> exits = ShellIdentityUtils.invokeMethodWithShellPermissions(
+                GosCompatContract.APP_PACKAGE,
+                0,
+                16,
+                mActivityManager::getHistoricalProcessExitReasons,
+                Manifest.permission.DUMP);
+        for (ApplicationExitInfo exit : exits) {
+            if (exit.getTimestamp() < startTimeMillis) {
+                continue;
+            }
+            if (exit.getReason() != ApplicationExitInfo.REASON_CRASH_NATIVE) {
+                continue;
+            }
+            if (!GosCompatContract.MAPS_SCAN_PROCESS.equals(exit.getProcessName())) {
+                continue;
+            }
+            return exit;
+        }
+        return null;
+    }
+
+    private byte[] fetchTombstone(ApplicationExitInfo exitInfo) throws Exception {
+        InputStream[] trace = new InputStream[1];
+        PollingCheck.check("not able to get tombstone", TOMBSTONE_FETCH_TIMEOUT_MILLIS, () -> {
+            trace[0] = ShellIdentityUtils.invokeMethodWithShellPermissions(
+                    exitInfo,
+                    (i) -> {
+                        try {
+                            return i.getTraceInputStream();
+                        } catch (IOException e) {
+                            return null;
+                        }
+                    },
+                    Manifest.permission.DUMP);
+            return trace[0] != null;
+        });
+
+        try (InputStream input = trace[0]) {
+            return MapsScanTombstoneFormatter.readFully(input);
+        }
+    }
+
+    private void assertCompletedResult(Bundle result, String mode, int attempt) {
+        String message = "mode=" + mode
+                + ", attempt=" + attempt + "/" + SCAN_ATTEMPTS
+                + ", status=" + result.getString(GosCompatContract.KEY_STATUS_TEXT)
+                + ", selectedRanges="
+                + result.getInt(GosCompatContract.KEY_MAPS_SCAN_SELECTED_RANGES)
+                + ", scannedBytes="
+                + result.getLong(GosCompatContract.KEY_MAPS_SCAN_SCANNED_BYTES)
+                + ", callerTid=" + result.getInt(GosCompatContract.KEY_MAPS_SCAN_CALLER_TID)
+                + ", workerTid=" + result.getInt(GosCompatContract.KEY_MAPS_SCAN_WORKER_TID);
+
+        assertWithMessage(message).that(result.getBoolean(
+                GosCompatContract.KEY_MAPS_SCAN_COMPLETED)).isTrue();
+        assertWithMessage(message).that(result.getBoolean(
+                GosCompatContract.KEY_MAPS_SCAN_WORKER_THREAD)).isTrue();
+        assertWithMessage(message).that(result.getInt(
+                GosCompatContract.KEY_MAPS_SCAN_SELECTED_RANGES)).isAtLeast(1);
+        assertWithMessage(message).that(result.getLong(
+                GosCompatContract.KEY_MAPS_SCAN_SCANNED_BYTES)).isGreaterThan(0L);
+    }
+
+    private void reportTombstoneArtifacts(String mode, int attempt, String formattedTombstone,
+            byte[] proto) throws IOException {
+        File directory = mContext.getExternalCacheDir();
+        if (directory == null) {
+            directory = mContext.getCacheDir();
+        }
+        directory.mkdirs();
+
+        String baseName = TOMBSTONE_ARTIFACT_KEY_PREFIX + mode.replaceAll("[^A-Za-z0-9._-]", "_")
+                + "_attempt_" + attempt + "_" + System.nanoTime();
+        File textFile = new File(directory, baseName + ".txt");
+        try (OutputStreamWriter writer = new OutputStreamWriter(
+                new FileOutputStream(textFile), StandardCharsets.UTF_8)) {
+            writer.write(formattedTombstone);
+        }
+
+        mLogs.addTestLog(baseName + "_text", textFile);
+
+        File protoFile = new File(directory, baseName + ".pb");
+        try (FileOutputStream output = new FileOutputStream(protoFile)) {
+            output.write(proto);
+        }
+        mLogs.addTestLog(baseName + "_proto", protoFile);
+    }
+
+    private static final class ScanOutcome {
+        final Bundle result;
+        final ApplicationExitInfo nativeCrash;
+
+        private ScanOutcome(Bundle result, ApplicationExitInfo nativeCrash) {
+            this.result = result;
+            this.nativeCrash = nativeCrash;
+        }
+
+        static ScanOutcome forResult(Bundle result) {
+            return new ScanOutcome(result, null);
+        }
+
+        static ScanOutcome forNativeCrash(ApplicationExitInfo nativeCrash) {
+            return new ScanOutcome(null, nativeCrash);
+        }
+    }
+}

--- a/tests/GosCompatTests/README.md
+++ b/tests/GosCompatTests/README.md
@@ -1,0 +1,15 @@
+# GosCompatTests
+
+`GosCompatCheckApp` is a standalone helper app with a manual UI.
+
+`GosCompatMapsScanTests` covers compatibility with apps using native libraries that scan 
+`/proc/self/maps` and read selected mapped memory ranges.
+
+You can run tests from the checkout root via this directory's `TEST_MAPPING`:
+
+```sh
+atest --test-mapping frameworks/base/tests/GosCompatTests:gos_postsubmit
+```
+
+Alternatively, view the `TEST_MAPPING` file or Android.bp files and run test modules directly with 
+`atest`.

--- a/tests/GosCompatTests/TEST_MAPPING
+++ b/tests/GosCompatTests/TEST_MAPPING
@@ -1,0 +1,7 @@
+{
+  "gos_postsubmit": [
+    {
+      "name": "GosCompatMapsScanTests"
+    }
+  ]
+}

--- a/tests/GosCompatTests/common/AndroidManifest.xml
+++ b/tests/GosCompatTests/common/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="app.grapheneos.goscompat.checks.common" />

--- a/tests/GosCompatTests/common/src/app/grapheneos/goscompat/checks/GosCompatContract.java
+++ b/tests/GosCompatTests/common/src/app/grapheneos/goscompat/checks/GosCompatContract.java
@@ -1,0 +1,41 @@
+package app.grapheneos.goscompat.checks;
+
+import android.net.Uri;
+
+public final class GosCompatContract {
+    public static final String APP_PACKAGE = "app.grapheneos.goscompat.checks";
+    public static final String MAPS_SCAN_PROCESS = APP_PACKAGE + ":maps_scan";
+    public static final String ACTIVITY = APP_PACKAGE + "/.GosCompatCheckActivity";
+    public static final String MAPS_SCAN_CRASH_ACTIVITY =
+            APP_PACKAGE + "/.MapsScanCrashActivity";
+    public static final String MAPS_SCAN_AUTHORITY = APP_PACKAGE + ".maps_scan_provider";
+    public static final Uri MAPS_SCAN_CONTENT_URI = Uri.parse("content://" + MAPS_SCAN_AUTHORITY);
+    public static final String MAPS_SCAN_RESULT_FILE = "maps_scan_result.properties";
+
+    public static final String EXTRA_MAPS_SCAN_MODE = "maps_scan_mode";
+    public static final String EXTRA_MAPS_SCAN_TOKEN = "maps_scan_token";
+    public static final String MODE_DIRECT = "direct";
+    public static final String MODE_REFLECTIVE = "reflective";
+
+    public static final String METHOD_RUN_MAPS_SCAN_CHECK = "run_maps_scan_check";
+    public static final String METHOD_RUN_DIRECT_MAPS_SCAN_CHECK = "run_direct_maps_scan_check";
+    public static final String METHOD_RUN_REFLECTIVE_MAPS_SCAN_CHECK =
+            "run_reflective_maps_scan_check";
+    public static final String METHOD_GET_MAPS_SCAN_RESULT = "get_maps_scan_result";
+    public static final String METHOD_CLEAR_MAPS_SCAN_RESULT = "clear_maps_scan_result";
+
+    public static final String KEY_STATUS_TEXT = "status_text";
+    public static final String KEY_SUMMARY = "summary";
+    public static final String KEY_MAPS_SCAN_RESULT_AVAILABLE = "maps_scan_result_available";
+    public static final String KEY_MAPS_SCAN_COMPLETED = "maps_scan_completed";
+    public static final String KEY_MAPS_SCAN_WORKER_THREAD = "maps_scan_worker_thread";
+    public static final String KEY_MAPS_SCAN_SELECTED_RANGES = "maps_scan_selected_ranges";
+    public static final String KEY_MAPS_SCAN_SCANNED_BYTES = "maps_scan_scanned_bytes";
+    public static final String KEY_MAPS_SCAN_CALLER_TID = "maps_scan_caller_tid";
+    public static final String KEY_MAPS_SCAN_WORKER_TID = "maps_scan_worker_tid";
+    public static final String KEY_MAPS_SCAN_DETAILS = "maps_scan_details";
+    public static final String KEY_MAPS_SCAN_ERRORS = "maps_scan_errors";
+
+    private GosCompatContract() {
+    }
+}

--- a/tests/GosCompatTests/common/src/app/grapheneos/goscompat/checks/MapsScanTombstoneFormatter.java
+++ b/tests/GosCompatTests/common/src/app/grapheneos/goscompat/checks/MapsScanTombstoneFormatter.java
@@ -1,0 +1,224 @@
+package app.grapheneos.goscompat.checks;
+
+import com.android.server.os.nano.TombstoneProtos;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Locale;
+
+public final class MapsScanTombstoneFormatter {
+    private static final int MAP_CONTEXT_LINES = 5;
+
+    private MapsScanTombstoneFormatter() {
+    }
+
+    public static String format(byte[] proto) throws IOException {
+        return format(TombstoneProtos.Tombstone.parseFrom(proto));
+    }
+
+    public static byte[] readFully(InputStream input) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        int read;
+        while ((read = input.read(buffer)) != -1) {
+            output.write(buffer, 0, read);
+        }
+        return output.toByteArray();
+    }
+
+    private static String format(TombstoneProtos.Tombstone tombstone) {
+        TombstoneProtos.Thread thread = tombstone.threads != null
+                ? tombstone.threads.get(tombstone.tid) : null;
+        if (thread == null) {
+            TombstoneProtos.Signal signal = tombstone.signalInfo;
+            return "pid=" + tombstone.pid
+                    + ", tid=" + tombstone.tid
+                    + ", signal=" + (signal != null ? signal.name : "<none>")
+                    + ", commandLine=" + Arrays.toString(tombstone.commandLine)
+                    + "\nNo crashing thread in tombstone";
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append("pid=").append(tombstone.pid)
+                .append(", tid=").append(tombstone.tid)
+                .append(", thread=").append(thread.name)
+                .append(", commandLine=").append(Arrays.toString(tombstone.commandLine))
+                .append('\n')
+                .append(formatSignalLine(tombstone, thread))
+                .append("\n\nmaps around fault address:\n")
+                .append(formatFaultMapContext(tombstone))
+                .append("\nbacktrace:\n");
+        TombstoneProtos.BacktraceFrame[] frames = thread.currentBacktrace;
+        if (frames != null) {
+            for (int i = 0; i < frames.length; i++) {
+                TombstoneProtos.BacktraceFrame frame = frames[i];
+                builder.append('#').append(i)
+                        .append(' ')
+                        .append(frame.fileName)
+                        .append(" (")
+                        .append(frame.functionName)
+                        .append(")\n");
+            }
+        }
+        return builder.toString();
+    }
+
+    private static String formatSignalLine(TombstoneProtos.Tombstone tombstone,
+            TombstoneProtos.Thread thread) {
+        TombstoneProtos.Signal signal = tombstone.signalInfo;
+        if (signal == null) {
+            return "signal <none>";
+        }
+        String faultAddress = "--------";
+        if (signal.hasFaultAddress) {
+            faultAddress = "0x" + formatPlainAddress(tombstone, signal.faultAddress)
+                    + getReadWriteDesc(tombstone.arch, thread);
+        }
+        return "signal " + signal.number
+                + " (" + signal.name + ")"
+                + ", code " + signal.code
+                + " (" + signal.codeName + ")"
+                + ", fault addr " + faultAddress;
+    }
+
+    private static String formatFaultMapContext(TombstoneProtos.Tombstone tombstone) {
+        TombstoneProtos.MemoryMapping[] mappings = tombstone.memoryMappings;
+        if (mappings == null || mappings.length == 0) {
+            return "    <no memory mappings>\n";
+        }
+
+        TombstoneProtos.Signal signal = tombstone.signalInfo;
+        if (signal == null || !signal.hasFaultAddress) {
+            return "    <no fault address>\n";
+        }
+
+        long faultAddress = untagAddress(tombstone.arch, signal.faultAddress);
+        int faultIndex = -1;
+        int insertionIndex = mappings.length;
+        for (int i = 0; i < mappings.length; i++) {
+            TombstoneProtos.MemoryMapping mapping = mappings[i];
+            if (faultAddress < mapping.beginAddress) {
+                insertionIndex = i;
+                break;
+            }
+            if (faultAddress >= mapping.beginAddress && faultAddress < mapping.endAddress) {
+                faultIndex = i;
+                insertionIndex = i;
+                break;
+            }
+        }
+
+        int center = faultIndex >= 0
+                ? faultIndex
+                : Math.min(insertionIndex, mappings.length - 1);
+        int start = Math.max(0, center - MAP_CONTEXT_LINES);
+        int end = Math.min(mappings.length, center + MAP_CONTEXT_LINES + 1);
+
+        StringBuilder builder = new StringBuilder();
+        boolean markerPrinted = false;
+        for (int i = start; i < end; i++) {
+            if (faultIndex < 0 && i == insertionIndex) {
+                builder.append("--->Fault address falls at 0x")
+                        .append(formatPlainAddress(tombstone, faultAddress))
+                        .append(" between mapped regions\n");
+                markerPrinted = true;
+            }
+            builder.append(formatMapLine(tombstone, mappings[i], i == faultIndex));
+        }
+        if (faultIndex < 0 && !markerPrinted) {
+            builder.append("--->Fault address falls at 0x")
+                    .append(formatPlainAddress(tombstone, faultAddress));
+            if (insertionIndex == 0) {
+                builder.append(" before any mapped regions");
+            } else {
+                builder.append(" after any mapped regions");
+            }
+            builder.append('\n');
+        }
+        return builder.toString();
+    }
+
+    private static String formatMapLine(TombstoneProtos.Tombstone tombstone,
+            TombstoneProtos.MemoryMapping mapping, boolean containsFault) {
+        StringBuilder builder = new StringBuilder(containsFault ? "--->" : "    ");
+        builder.append(formatMapAddress(tombstone, mapping.beginAddress))
+                .append('-')
+                .append(formatMapAddress(tombstone, mapping.endAddress - 1))
+                .append(' ')
+                .append(mapping.read ? 'r' : '-')
+                .append(mapping.write ? 'w' : '-')
+                .append(mapping.execute ? 'x' : '-')
+                .append(String.format(Locale.US, "  %8x  %8x",
+                        mapping.offset, mapping.endAddress - mapping.beginAddress));
+        if (mapping.mappingName != null && !mapping.mappingName.isEmpty()) {
+            builder.append("  ").append(mapping.mappingName);
+        }
+        builder.append('\n');
+        return builder.toString();
+    }
+
+    private static String getReadWriteDesc(int arch, TombstoneProtos.Thread thread) {
+        String registerName;
+        long writeMask;
+        switch (arch) {
+            case TombstoneProtos.ARM32:
+                registerName = "error_code";
+                writeMask = 1L << 11;
+                break;
+            case TombstoneProtos.ARM64:
+                registerName = "esr";
+                writeMask = 1L << 6;
+                break;
+            case TombstoneProtos.X86:
+            case TombstoneProtos.X86_64:
+                registerName = "err";
+                writeMask = 1L << 1;
+                break;
+            default:
+                return "";
+        }
+        if (thread.registers == null) {
+            return "";
+        }
+        for (TombstoneProtos.Register register : thread.registers) {
+            if (!registerName.equals(register.name)) {
+                continue;
+            }
+            return (register.u64 & writeMask) != 0 ? " (write)" : " (read)";
+        }
+        return "";
+    }
+
+    private static long untagAddress(int arch, long address) {
+        if (arch == TombstoneProtos.ARM64) {
+            return address & ((1L << 56) - 1);
+        }
+        return address;
+    }
+
+    private static String formatPlainAddress(TombstoneProtos.Tombstone tombstone, long address) {
+        return String.format(Locale.US, "%0" + (pointerWidth(tombstone) * 2) + "x", address);
+    }
+
+    private static String formatMapAddress(TombstoneProtos.Tombstone tombstone, long address) {
+        String formatted = formatPlainAddress(tombstone, address);
+        return formatted.length() == 16
+                ? formatted.substring(0, 8) + "'" + formatted.substring(8)
+                : formatted;
+    }
+
+    private static int pointerWidth(TombstoneProtos.Tombstone tombstone) {
+        switch (tombstone.arch) {
+            case TombstoneProtos.ARM32:
+            case TombstoneProtos.X86:
+                return 4;
+            case TombstoneProtos.ARM64:
+            case TombstoneProtos.RISCV64:
+            case TombstoneProtos.X86_64:
+            default:
+                return 8;
+        }
+    }
+}


### PR DESCRIPTION
GosCompatMapsScanTests installs `GosCompatCheckApp`, which itself has its own standalone UI so tests
can be run outside of the test harness and as a regular app. The tests runs the native maps scanner
in the app's separate `:maps_scan` process. This maps scanner is used by a library that is used by
several popular apps. There are two variants:

- direct JNI invocation from a Java worker thread
- reflective Java invocation followed by JNI from a Java worker thread

The separate process is not only for the standalone UI. It keeps both the UI and the instrumentation
process alive if the native scanner crashes, and it lets the test report the crash through
`ApplicationExitInfo` and the debuggerd tombstone instead of losing the whole test invocation.

The tests force-stop the helper between attempts so each scan runs with a newly created app process,
which better matches app startup behavior. The scan is triggered by a translucent activity because
shell-started background services are rejected by ActivityManager background start policy. That
trigger activity is protected by `android.permission.DUMP`, which shell holds, so it is exported for
shell-driven tests without being generally launchable by apps. Note that we don't intend the
GosCompatCheckApp to be preinstalled anywhere anyway; the app is installed by the test harness
normally.

Each variant must complete multiple scan attempts. Each attempt force-stops the helper app, starts a
fresh `:maps_scan` process, clears stale result state from inside that process, and stops at the
first failed attempt. The instrumentation reads the completion result with `run-as` instead of
polling the helper provider so it does not hold a binder dependency on a process that may be
crashing. If native code crashes, the failure includes the signal line, five memory-map entries
around the faulting mapping, and a backtrace. The test also reports formatted and raw tombstone
artifacts through Tradefed.

Test: `atest GosCompatMapsScanTests` after reverting the commit "avoid adding pthread_internal_t guard for main thread" from bionic results in both tests failing and reporting SEGV_ACCERR 

Test: `atest GosCompatMapsScanTests` with the fix in bionic results in both tests passing