### PR TITLE
add GosCompatWifiScanTimeoutTests

### DIFF
--- a/tests/GosCompatTests/GosCompatWifiScanTimeoutTests/Android.bp
+++ b/tests/GosCompatTests/GosCompatWifiScanTimeoutTests/Android.bp
@@ -1,0 +1,16 @@
+android_test {
+    name: "GosCompatWifiScanTimeoutTests",
+    srcs: [
+        "src/**/*.java",
+    ],
+    manifest: "AndroidManifest.xml",
+    test_config: "AndroidTest.xml",
+    static_libs: [
+        "androidx.test.ext.junit",
+        "androidx.test.runner",
+        "truth",
+    ],
+    libs: ["android.test.runner.stubs"],
+    platform_apis: true,
+    test_suites: ["device-tests"],
+}

--- a/tests/GosCompatTests/GosCompatWifiScanTimeoutTests/AndroidManifest.xml
+++ b/tests/GosCompatTests/GosCompatWifiScanTimeoutTests/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="app.grapheneos.goscompat.wifiscantimeout.tests">
+
+    <uses-feature
+        android:name="android.hardware.wifi"
+        android:required="false" />
+
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
+    <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" />
+
+    <application
+        android:debuggable="true"
+        android:label="GOS Compat Wi-Fi Scan Timeout Tests">
+        <activity
+            android:name=".ForegroundScanActivity"
+            android:exported="false"
+            android:theme="@android:style/Theme.DeviceDefault.DayNight" />
+    </application>
+
+    <instrumentation
+        android:name="androidx.test.runner.AndroidJUnitRunner"
+        android:targetPackage="app.grapheneos.goscompat.wifiscantimeout.tests" />
+</manifest>

--- a/tests/GosCompatTests/GosCompatWifiScanTimeoutTests/AndroidTest.xml
+++ b/tests/GosCompatTests/GosCompatWifiScanTimeoutTests/AndroidTest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration description="Runs GosCompatWifiScanTimeoutTests">
+    <target_preparer class="com.android.tradefed.targetprep.suite.SuiteApkInstaller">
+        <option name="cleanup-apks" value="true" />
+        <option name="install-arg" value="-r" />
+        <option name="install-arg" value="-d" />
+        <option name="install-arg" value="-g" />
+        <option name="install-arg" value="-t" />
+        <option name="test-file-name" value="GosCompatWifiScanTimeoutTests.apk" />
+    </target_preparer>
+
+    <test class="com.android.tradefed.testtype.AndroidJUnitTest">
+        <option name="package" value="app.grapheneos.goscompat.wifiscantimeout.tests" />
+        <option name="runner" value="androidx.test.runner.AndroidJUnitRunner" />
+        <option name="hidden-api-checks" value="false" />
+    </test>
+</configuration>

--- a/tests/GosCompatTests/GosCompatWifiScanTimeoutTests/README.md
+++ b/tests/GosCompatTests/GosCompatWifiScanTimeoutTests/README.md
@@ -1,0 +1,21 @@
+# GosCompatWifiScanTimeoutTests
+
+This module is a targeted regression test for a Pixel `bcmdhd` scan timeout kernel KASAN MTE panic 
+in the `wl_escan_handler` path.
+
+Requirements:
+
+- The test uses the `gos-dhdutil` vendor debug helper to arm the driver timeout hook before the
+scan request via the Broadcom DHD `induce_error` iovar. This helper is only installed on 
+userdebug/eng builds (or you can revert the adevtool commit that restricts it to userdebug/eng),
+so this test will only work on builds with `gos-dhdutil`
+- Enable Wi-Fi and Location
+- Keep screen on since test uses a foreground Activity to do Wi-Fi scans
+- The KASAN panic only happens on devices with MTE, so 8th-gen Pixels and up would be able to 
+reproduce it without the kernel patch
+
+Run the module directly:
+
+```sh
+atest GosCompatWifiScanTimeoutTests
+```

--- a/tests/GosCompatTests/GosCompatWifiScanTimeoutTests/src/app/grapheneos/goscompat/wifiscantimeout/tests/ForegroundScanActivity.java
+++ b/tests/GosCompatTests/GosCompatWifiScanTimeoutTests/src/app/grapheneos/goscompat/wifiscantimeout/tests/ForegroundScanActivity.java
@@ -1,0 +1,13 @@
+package app.grapheneos.goscompat.wifiscantimeout.tests;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+public final class ForegroundScanActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setShowWhenLocked(true);
+        setTurnScreenOn(true);
+    }
+}

--- a/tests/GosCompatTests/GosCompatWifiScanTimeoutTests/src/app/grapheneos/goscompat/wifiscantimeout/tests/WifiScanTimeoutTests.java
+++ b/tests/GosCompatTests/GosCompatWifiScanTimeoutTests/src/app/grapheneos/goscompat/wifiscantimeout/tests/WifiScanTimeoutTests.java
@@ -1,0 +1,195 @@
+package app.grapheneos.goscompat.wifiscantimeout.tests;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assume.assumeTrue;
+
+import android.app.Activity;
+import android.app.Instrumentation;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.location.LocationManager;
+import android.net.wifi.WifiManager;
+import android.os.ParcelFileDescriptor;
+import android.os.SystemClock;
+import android.util.Log;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public final class WifiScanTimeoutTests {
+    private static final String TAG = "GosCompatWifiScanTimeout";
+    private static final String REQUEST_PROPERTY =
+            "vendor.gos.dhdutil.request";
+    private static final String RESULT_PROPERTY =
+            "vendor.gos.dhdutil.result";
+    private static final long FOREGROUND_SETTLE_MILLIS = 1_000;
+    private static final long HELPER_RESULT_TIMEOUT_MILLIS = 10_000;
+    private static final long HELPER_RESULT_INTERVAL_MILLIS = 100;
+    private static final long SCAN_TIMEOUT_BROADCAST_TIMEOUT_MILLIS = 60_000;
+
+    private Instrumentation mInstrumentation;
+    private Context mContext;
+    private WifiManager mWifiManager;
+    private Activity mForegroundActivity;
+    private boolean mInduceScanTimeoutArmed;
+
+    @Before
+    public void setUp() {
+        mInstrumentation = InstrumentationRegistry.getInstrumentation();
+        mContext = mInstrumentation.getContext();
+        mWifiManager = mContext.getSystemService(WifiManager.class);
+        LocationManager locationManager = mContext.getSystemService(LocationManager.class);
+
+        assumeTrue("Wi-Fi hardware is required",
+                mContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_WIFI));
+        assumeTrue("WifiManager is required", mWifiManager != null);
+        assumeTrue("LocationManager is required", locationManager != null);
+        assumeTrue("Wi-Fi must be enabled before running this scan timeout test",
+                mWifiManager.isWifiEnabled());
+        assumeTrue("Location must be enabled before running this scan timeout test",
+                locationManager.isLocationEnabled());
+    }
+
+    @After
+    public void tearDown() {
+        if (mInduceScanTimeoutArmed) {
+            clearInduceWlScanTimeout();
+        }
+
+        if (mForegroundActivity != null) {
+            mForegroundActivity.finish();
+            mInstrumentation.waitForIdleSync();
+        }
+    }
+
+    @Test
+    public void thirdPartyScanDoesNotPanicWhenWlScanTimeoutRuns() {
+        startForegroundActivity();
+        enableInduceWlScanTimeoutOrSkip();
+
+        CountDownLatch failedScanBroadcast = new CountDownLatch(1);
+        BroadcastReceiver receiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                if (WifiManager.SCAN_RESULTS_AVAILABLE_ACTION.equals(intent.getAction())
+                        && !intent.getBooleanExtra(WifiManager.EXTRA_RESULTS_UPDATED, true)) {
+                    Log.i(TAG, "Received failed scan broadcast after induced wl_scan_timeout");
+                    failedScanBroadcast.countDown();
+                }
+            }
+        };
+
+        mContext.registerReceiver(receiver,
+                new IntentFilter(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION),
+                Context.RECEIVER_EXPORTED);
+        try {
+            assertWithMessage("Wi-Fi scan request should be accepted")
+                    .that(mWifiManager.startScan()).isTrue();
+            Log.i(TAG, "Accepted induced scan timeout request");
+
+            // The kernel hook suppresses the normal scan completion so wl_scan_timeout() runs.
+            // A fixed driver reports the timed out scan as a failed framework scan broadcast.
+            assertWithMessage("induced wl_scan_timeout should report a failed scan")
+                    .that(await(failedScanBroadcast, SCAN_TIMEOUT_BROADCAST_TIMEOUT_MILLIS))
+                    .isTrue();
+        } finally {
+            mContext.unregisterReceiver(receiver);
+        }
+    }
+
+    private void enableInduceWlScanTimeoutOrSkip() {
+        // This asks the vendor helper to set Broadcom's "induce_error" iovar to
+        // DHD_INDUCE_SCAN_TIMEOUT. In kernel_pixel wl_cfgscan.c, that makes the next completed
+        // scan skip its normal completion event so the driver runs wl_scan_timeout() instead.
+        String output = setInduceWlScanTimeout(true);
+        assumeTrue("vendor wl_scan_timeout induction helper is unavailable: " + output,
+                !output.startsWith("timeout:"));
+        assertWithMessage(output).that(output).startsWith("ok:");
+        mInduceScanTimeoutArmed = true;
+    }
+
+    private String setInduceWlScanTimeout(boolean enabled) {
+        String token = (enabled ? "enable-" : "disable-")
+                + Long.toHexString(SystemClock.elapsedRealtimeNanos());
+        setVendorDebugWifiProperty(RESULT_PROPERTY, "pending:" + token + ":request");
+        setVendorDebugWifiProperty(REQUEST_PROPERTY,
+                "wifi-scan-timeout:" + (enabled ? "enable:" : "disable:") + token);
+
+        String output = waitForInduceWlScanTimeoutResult(token);
+        Log.i(TAG, "wl_scan_timeout induction " + (enabled ? "enable" : "disable")
+                + " output: " + output);
+        return output;
+    }
+
+    private String waitForInduceWlScanTimeoutResult(String token) {
+        long deadline = SystemClock.elapsedRealtime() + HELPER_RESULT_TIMEOUT_MILLIS;
+        String lastResult = "";
+
+        while (SystemClock.elapsedRealtime() < deadline) {
+            String result = getVendorDebugWifiProperty(RESULT_PROPERTY);
+            if (result.startsWith("ok:" + token + ":")
+                    || result.startsWith("error:" + token + ":")) {
+                return result;
+            }
+            lastResult = result;
+            SystemClock.sleep(HELPER_RESULT_INTERVAL_MILLIS);
+        }
+
+        return "timeout:" + token + ":last=" + lastResult;
+    }
+
+    private void setVendorDebugWifiProperty(String property, String value) {
+        executeShellCommand("setprop " + property + " " + value);
+    }
+
+    private String getVendorDebugWifiProperty(String property) {
+        return executeShellCommand("getprop " + property);
+    }
+
+    private void clearInduceWlScanTimeout() {
+        String output = setInduceWlScanTimeout(false);
+        if (!output.startsWith("ok:")) {
+            Log.w(TAG, "Unable to clear wl_scan_timeout induction: " + output);
+        }
+        mInduceScanTimeoutArmed = false;
+    }
+
+    private String executeShellCommand(String command) {
+        try (ParcelFileDescriptor pfd =
+                        mInstrumentation.getUiAutomation().executeShellCommand(command);
+                FileInputStream input = new FileInputStream(pfd.getFileDescriptor())) {
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8).trim();
+        } catch (IOException e) {
+            throw new AssertionError("Failed to execute shell command: " + command, e);
+        }
+    }
+
+    private void startForegroundActivity() {
+        Intent intent = new Intent(mContext, ForegroundScanActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        mForegroundActivity = mInstrumentation.startActivitySync(intent);
+        mInstrumentation.waitForIdleSync();
+        SystemClock.sleep(FOREGROUND_SETTLE_MILLIS);
+    }
+
+    private static boolean await(CountDownLatch latch, long timeoutMillis) {
+        try {
+            return latch.await(timeoutMillis, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for scan timeout broadcast", e);
+        }
+    }
+}

--- a/tests/GosCompatTests/TEST_MAPPING
+++ b/tests/GosCompatTests/TEST_MAPPING
@@ -8,6 +8,9 @@
     },
     {
       "name": "GosCompatDmaBufReleaseTests"
+    },
+    {
+      "name": "GosCompatWifiScanTimeoutTests"
     }
   ]
 }


### PR DESCRIPTION
See https://github.com/GrapheneOS/os-issue-tracker/issues/7799

Requires gos-dhdutil in adevtool

Kernel patches to fix: 
- https://gitlab.com/grapheneos/kernel_pixel/-/merge_requests/14
- https://gitlab.com/grapheneos/kernel_pixel/-/merge_requests/15
- https://gitlab.com/grapheneos/kernel_pixel_muzel/-/merge_requests/10

Test causes KASAN panic on caiman, tokay, shiba, tegu, akita, stallion, rango without the kernel patch, with same call trace/location as the linked issue