### PR TITLE
don't decrease the max saved log size on user builds

### DIFF
--- a/services/core/java/com/android/server/BootReceiver.java
+++ b/services/core/java/com/android/server/BootReceiver.java
@@ -87,10 +87,8 @@ public class BootReceiver extends BroadcastReceiver {
 
     // Maximum size of a logged event (files get truncated if they're longer).
     // Give userdebug builds a larger max to capture extra debug, esp. for last_kmsg.
-    private static final int LOG_SIZE =
-        SystemProperties.getInt("ro.debuggable", 0) == 1 ? 98304 : 65536;
-    private static final int LASTK_LOG_SIZE =
-        SystemProperties.getInt("ro.debuggable", 0) == 1 ? 196608 : 65536;
+    private static final int LOG_SIZE = 196608;
+    private static final int LASTK_LOG_SIZE = 196608;
     private static final int GMSCORE_LASTK_LOG_SIZE = 196608;
 
     private static final String TAG_TOMBSTONE = "SYSTEM_TOMBSTONE";


### PR DESCRIPTION
Also increase LOG_SIZE to match LASTK_LOG_SIZE.