### PR TITLE
separate GrapheneOS framework resource IDs from AOSP resource IDs

### DIFF
--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -28,5 +28,9 @@
         <public name="permgroupdesc_otherSensors"/>
         <public name="permlab_otherSensors"/>
         <public name="permdesc_otherSensors"/>
+        <public name="notification_action_dont_show_again"/>
+        <public name="notification_channel_missing_permission"/>
+        <public name="missing_sensors_permission_title"/>
+        <public name="missing_sensors_permission_message"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -16,6 +16,7 @@
         <public name="setting_default_restrict_memory_dyn_code_loading"/>
         <public name="setting_default_restrict_storage_dyn_code_loading"/>
         <public name="setting_default_restrict_webview_dyn_code_loading"/>
+        <public name="setting_default_force_app_memtag"/>
     </staging-public-group>
 
     <staging-public-group type="drawable" first-id="0x0194f000">

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -7,6 +7,8 @@
 
     <staging-public-group type="bool" first-id="0x018bf000">
         <public name="setting_default_allow_disabling_hardening_via_app_compat_config"/>
+        <public name="config_Google_apps_can_have_special_access_to_accelerators"/>
+        <public name="config_GoogleCamera_needs_seinfo_for_access_to_accelerators"/>
     </staging-public-group>
 
     <staging-public-group type="drawable" first-id="0x0194f000">

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -16,5 +16,6 @@
 
     <staging-public-group type="string" first-id="0x0198f000">
         <public name="config_first_party_app_source_package_name"/>
+        <public name="config_systemTelephonyPackage"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -48,5 +48,9 @@
         <public name="bg_dexopt_completed_notif_ch_title"/>
         <public name="bg_dexopt_completed_notif_title"/>
         <public name="bg_dexopt_completed_notif_text"/>
+        <public name="notif_channel_exploit_protection"/>
+        <public name="notif_text_tap_to_open_settings"/>
+        <public name="notif_text_tap_to_see_details"/>
+        <public name="notif_action_more_info"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -9,6 +9,7 @@
         <public name="setting_default_allow_disabling_hardening_via_app_compat_config"/>
         <public name="config_Google_apps_can_have_special_access_to_accelerators"/>
         <public name="config_GoogleCamera_needs_seinfo_for_access_to_accelerators"/>
+        <public name="setting_default_allow_native_debugging"/>
     </staging-public-group>
 
     <staging-public-group type="drawable" first-id="0x0194f000">

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <staging-public-group type="array" first-id="0x0195f000">
+        <public name="system_browser_package_names"/>
     </staging-public-group>
 
     <staging-public-group type="bool" first-id="0x018bf000">

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -34,5 +34,6 @@
         <public name="missing_sensors_permission_message"/>
         <public name="permgrouplab_network"/>
         <public name="permgroupdesc_network"/>
+        <public name="aerr_show_details"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -38,5 +38,6 @@
         <public name="permgroupdesc_network"/>
         <public name="aerr_show_details"/>
         <public name="config_gnssPsdsType"/>
+        <public name="bluetooth_auto_off_attribution_label"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -54,5 +54,10 @@
         <public name="notif_text_tap_to_see_details"/>
         <public name="notif_action_more_info"/>
         <public name="notif_native_debug_title"/>
+        <public name="notif_ch_system_journal"/>
+        <public name="process_crash_notif_title"/>
+        <public name="fsck_error_notif_title"/>
+        <public name="notif_memtag_crash_title"/>
+        <public name="notif_hmalloc_crash_title"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -15,5 +15,6 @@
     </staging-public-group>
 
     <staging-public-group type="string" first-id="0x0198f000">
+        <public name="config_first_party_app_source_package_name"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -1,31 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <staging-public-group type="array" first-id="0x0195f000">
+        <!-- @hide -->
         <public name="system_browser_package_names"/>
+        <!-- @hide -->
         <public name="config_httpsTimeUrls"/>
+        <!-- @hide -->
         <public name="system_pkgs_allowed_memory_dyn_code_loading_by_default"/>
+        <!-- @hide -->
         <public name="system_pkgs_allowed_storage_dyn_code_loading_by_default"/>
+        <!-- @hide -->
         <public name="system_pkgs_allowed_webview_dyn_code_loading_by_default"/>
+        <!-- @hide -->
         <public name="read_additional_security_state_known_signers"/>
     </staging-public-group>
 
     <staging-public-group type="bool" first-id="0x018bf000">
+        <!-- @hide -->
         <public name="setting_default_allow_disabling_hardening_via_app_compat_config"/>
+        <!-- @hide -->
         <public name="config_Google_apps_can_have_special_access_to_accelerators"/>
+        <!-- @hide -->
         <public name="config_GoogleCamera_needs_seinfo_for_access_to_accelerators"/>
+        <!-- @hide -->
         <public name="setting_default_allow_native_debugging"/>
+        <!-- @hide -->
         <public name="setting_default_restrict_memory_dyn_code_loading"/>
+        <!-- @hide -->
         <public name="setting_default_restrict_storage_dyn_code_loading"/>
+        <!-- @hide -->
         <public name="setting_default_restrict_webview_dyn_code_loading"/>
+        <!-- @hide -->
         <public name="setting_default_force_app_memtag"/>
+        <!-- @hide -->
         <public name="config_usbPortSecuritySupported"/>
+        <!-- @hide -->
         <public name="config_usb_port_security_applies_to_pogo_pins"/>        
+        <!-- @hide -->
         <public name="config_has_alternative_touchscreen_mode"/>
     </staging-public-group>
 
     <staging-public-group type="drawable" first-id="0x0194f000">
+        <!-- @hide -->
         <public name="ic_update"/>
+        <!-- @hide -->
         <public name="ic_pending"/>
+        <!-- @hide -->
         <public name="ic_error"/>
     </staging-public-group>
 
@@ -33,46 +53,87 @@
     </staging-public-group>
 
     <staging-public-group type="string" first-id="0x0198f000">
+        <!-- @hide -->
         <public name="config_first_party_app_source_package_name"/>
+        <!-- @hide -->
         <public name="config_systemTelephonyPackage"/>
+        <!-- @hide -->
         <public name="prototype_device_notification_title"/>
+        <!-- @hide -->
         <public name="prototype_device_notification_message"/>
+        <!-- @hide -->
         <public name="notification_channel_other_users"/>
+        <!-- @hide -->
         <public name="notification_channel_other_users_description"/>
+        <!-- @hide -->
         <public name="other_users_notification_title"/>
+        <!-- @hide -->
         <public name="other_users_notification_switch_user_action"/>
+        <!-- @hide -->
         <public name="permgrouplab_otherSensors"/>
+        <!-- @hide -->
         <public name="permgroupdesc_otherSensors"/>
+        <!-- @hide -->
         <public name="permlab_otherSensors"/>
+        <!-- @hide -->
         <public name="permdesc_otherSensors"/>
+        <!-- @hide -->
         <public name="notification_action_dont_show_again"/>
+        <!-- @hide -->
         <public name="notification_channel_missing_permission"/>
+        <!-- @hide -->
         <public name="missing_sensors_permission_title"/>
+        <!-- @hide -->
         <public name="missing_sensors_permission_message"/>
+        <!-- @hide -->
         <public name="permgrouplab_network"/>
+        <!-- @hide -->
         <public name="permgroupdesc_network"/>
+        <!-- @hide -->
         <public name="aerr_show_details"/>
+        <!-- @hide -->
         <public name="config_gnssPsdsType"/>
+        <!-- @hide -->
         <public name="bluetooth_auto_off_attribution_label"/>
+        <!-- @hide -->
         <public name="bg_dexopt_notif_ch_title"/>
+        <!-- @hide -->
         <public name="bg_dexopt_notif_title"/>
+        <!-- @hide -->
         <public name="bg_dexopt_notif_text"/>
+        <!-- @hide -->
         <public name="bg_dexopt_completed_notif_ch_title"/>
+        <!-- @hide -->
         <public name="bg_dexopt_completed_notif_title"/>
+        <!-- @hide -->
         <public name="bg_dexopt_completed_notif_text"/>
+        <!-- @hide -->
         <public name="notif_channel_exploit_protection"/>
+        <!-- @hide -->
         <public name="notif_text_tap_to_open_settings"/>
+        <!-- @hide -->
         <public name="notif_text_tap_to_see_details"/>
+        <!-- @hide -->
         <public name="notif_action_more_info"/>
+        <!-- @hide -->
         <public name="notif_native_debug_title"/>
+        <!-- @hide -->
         <public name="notif_ch_system_journal"/>
+        <!-- @hide -->
         <public name="process_crash_notif_title"/>
+        <!-- @hide -->
         <public name="fsck_error_notif_title"/>
+        <!-- @hide -->
         <public name="notif_memtag_crash_title"/>
+        <!-- @hide -->
         <public name="notif_hmalloc_crash_title"/>
+        <!-- @hide -->
         <public name="notif_memory_dcl_title"/>
+        <!-- @hide -->
         <public name="notif_storage_dcl_title"/>
+        <!-- @hide -->
         <public name="usb_port_security_error_title"/>
+        <!-- @hide -->
         <public name="deprecated_abi_message_grapheneos"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -6,6 +6,7 @@
         <public name="system_pkgs_allowed_memory_dyn_code_loading_by_default"/>
         <public name="system_pkgs_allowed_storage_dyn_code_loading_by_default"/>
         <public name="system_pkgs_allowed_webview_dyn_code_loading_by_default"/>
+        <public name="read_additional_security_state_known_signers"/>
     </staging-public-group>
 
     <staging-public-group type="bool" first-id="0x018bf000">

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -12,6 +12,9 @@
     </staging-public-group>
 
     <staging-public-group type="drawable" first-id="0x0194f000">
+        <public name="ic_update"/>
+        <public name="ic_pending"/>
+        <public name="ic_error"/>
     </staging-public-group>
 
     <staging-public-group type="integer" first-id="0x018ef000">
@@ -39,5 +42,11 @@
         <public name="aerr_show_details"/>
         <public name="config_gnssPsdsType"/>
         <public name="bluetooth_auto_off_attribution_label"/>
+        <public name="bg_dexopt_notif_ch_title"/>
+        <public name="bg_dexopt_notif_title"/>
+        <public name="bg_dexopt_notif_text"/>
+        <public name="bg_dexopt_completed_notif_ch_title"/>
+        <public name="bg_dexopt_completed_notif_title"/>
+        <public name="bg_dexopt_completed_notif_text"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -53,5 +53,6 @@
         <public name="notif_text_tap_to_open_settings"/>
         <public name="notif_text_tap_to_see_details"/>
         <public name="notif_action_more_info"/>
+        <public name="notif_native_debug_title"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <staging-public-group type="array" first-id="0x0195f000">
+    </staging-public-group>
+
+    <staging-public-group type="bool" first-id="0x018bf000">
+    </staging-public-group>
+
+    <staging-public-group type="drawable" first-id="0x0194f000">
+    </staging-public-group>
+
+    <staging-public-group type="integer" first-id="0x018ef000">
+    </staging-public-group>
+
+    <staging-public-group type="string" first-id="0x0198f000">
+    </staging-public-group>
+</resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -3,6 +3,9 @@
     <staging-public-group type="array" first-id="0x0195f000">
         <public name="system_browser_package_names"/>
         <public name="config_httpsTimeUrls"/>
+        <public name="system_pkgs_allowed_memory_dyn_code_loading_by_default"/>
+        <public name="system_pkgs_allowed_storage_dyn_code_loading_by_default"/>
+        <public name="system_pkgs_allowed_webview_dyn_code_loading_by_default"/>
     </staging-public-group>
 
     <staging-public-group type="bool" first-id="0x018bf000">
@@ -10,6 +13,9 @@
         <public name="config_Google_apps_can_have_special_access_to_accelerators"/>
         <public name="config_GoogleCamera_needs_seinfo_for_access_to_accelerators"/>
         <public name="setting_default_allow_native_debugging"/>
+        <public name="setting_default_restrict_memory_dyn_code_loading"/>
+        <public name="setting_default_restrict_storage_dyn_code_loading"/>
+        <public name="setting_default_restrict_webview_dyn_code_loading"/>
     </staging-public-group>
 
     <staging-public-group type="drawable" first-id="0x0194f000">
@@ -59,5 +65,7 @@
         <public name="fsck_error_notif_title"/>
         <public name="notif_memtag_crash_title"/>
         <public name="notif_hmalloc_crash_title"/>
+        <public name="notif_memory_dcl_title"/>
+        <public name="notif_storage_dcl_title"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -24,5 +24,9 @@
         <public name="notification_channel_other_users_description"/>
         <public name="other_users_notification_title"/>
         <public name="other_users_notification_switch_user_action"/>
+        <public name="permgrouplab_otherSensors"/>
+        <public name="permgroupdesc_otherSensors"/>
+        <public name="permlab_otherSensors"/>
+        <public name="permdesc_otherSensors"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -71,5 +71,6 @@
         <public name="notif_memory_dcl_title"/>
         <public name="notif_storage_dcl_title"/>
         <public name="usb_port_security_error_title"/>
+        <public name="deprecated_abi_message_grapheneos"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -19,5 +19,9 @@
         <public name="config_systemTelephonyPackage"/>
         <public name="prototype_device_notification_title"/>
         <public name="prototype_device_notification_message"/>
+        <public name="notification_channel_other_users"/>
+        <public name="notification_channel_other_users_description"/>
+        <public name="other_users_notification_title"/>
+        <public name="other_users_notification_switch_user_action"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -37,5 +37,6 @@
         <public name="permgrouplab_network"/>
         <public name="permgroupdesc_network"/>
         <public name="aerr_show_details"/>
+        <public name="config_gnssPsdsType"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -17,5 +17,7 @@
     <staging-public-group type="string" first-id="0x0198f000">
         <public name="config_first_party_app_source_package_name"/>
         <public name="config_systemTelephonyPackage"/>
+        <public name="prototype_device_notification_title"/>
+        <public name="prototype_device_notification_message"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -17,6 +17,8 @@
         <public name="setting_default_restrict_storage_dyn_code_loading"/>
         <public name="setting_default_restrict_webview_dyn_code_loading"/>
         <public name="setting_default_force_app_memtag"/>
+        <public name="config_usbPortSecuritySupported"/>
+        <public name="config_usb_port_security_applies_to_pogo_pins"/>        
     </staging-public-group>
 
     <staging-public-group type="drawable" first-id="0x0194f000">
@@ -68,5 +70,6 @@
         <public name="notif_hmalloc_crash_title"/>
         <public name="notif_memory_dcl_title"/>
         <public name="notif_storage_dcl_title"/>
+        <public name="usb_port_security_error_title"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -32,5 +32,7 @@
         <public name="notification_channel_missing_permission"/>
         <public name="missing_sensors_permission_title"/>
         <public name="missing_sensors_permission_message"/>
+        <public name="permgrouplab_network"/>
+        <public name="permgroupdesc_network"/>
     </staging-public-group>
 </resources>

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -6,6 +6,7 @@
     </staging-public-group>
 
     <staging-public-group type="bool" first-id="0x018bf000">
+        <public name="setting_default_allow_disabling_hardening_via_app_compat_config"/>
     </staging-public-group>
 
     <staging-public-group type="drawable" first-id="0x0194f000">

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -2,6 +2,7 @@
 <resources>
     <staging-public-group type="array" first-id="0x0195f000">
         <public name="system_browser_package_names"/>
+        <public name="config_httpsTimeUrls"/>
     </staging-public-group>
 
     <staging-public-group type="bool" first-id="0x018bf000">

--- a/core/res/res/values/public-ext.xml
+++ b/core/res/res/values/public-ext.xml
@@ -19,6 +19,7 @@
         <public name="setting_default_force_app_memtag"/>
         <public name="config_usbPortSecuritySupported"/>
         <public name="config_usb_port_security_applies_to_pogo_pins"/>        
+        <public name="config_has_alternative_touchscreen_mode"/>
     </staging-public-group>
 
     <staging-public-group type="drawable" first-id="0x0194f000">

--- a/core/res/res/values/public-final.xml
+++ b/core/res/res/values/public-final.xml
@@ -3192,8 +3192,6 @@
     <public type="string" name="config_systemTextIntelligence" id="0x01040036" />
     <!-- @hide @SystemApi -->
     <public type="string" name="config_systemVisualIntelligence" id="0x01040037" />
-    <!-- @hide -->
-    <public type="string" name="config_systemTelephonyPackage" id="0x010400ff" />
     <!-- @hide @SystemApi -->
     <public type="string" name="config_systemActivityRecognizer" id="0x01040038" />
     <!-- @hide @SystemApi -->


### PR DESCRIPTION
AOSP resource IDs must not be changed since packages that are extracted from the stock OS rely on them.

Test: `aapt2 dump resources framework-res.apk` for GrapheneOS and stock OS framework-res.apk. GrapheneOS APK no longer changes any stock OS framework resource IDs.

Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/8026
