### PR TITLE
fixup! add second factor UI

### DIFF
--- a/packages/SystemUI/src/com/android/keyguard/KeyguardAbsKeyInputViewController.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardAbsKeyInputViewController.java
@@ -365,7 +365,7 @@ public abstract class KeyguardAbsKeyInputViewController<T extends KeyguardAbsKey
         // immediately on BiometricSecondFactorPin bouncer after fingerprint auth succeeds with
         // primary bouncer already open.
         Duration lockoutEndTime = mLockPatternUtils.getLockoutEndTime(
-                mSelectedUserInteractor.getSelectedUserId());
+                mSelectedUserInteractor.getSelectedUserId(), mLockDomain);
         if (shouldLockout(lockoutEndTime)) {
             handleAttemptLockout(lockoutEndTime);
         }

--- a/packages/SystemUI/src/com/android/systemui/bouncer/shared/model/BouncerMessageStrings.kt
+++ b/packages/SystemUI/src/com/android/systemui/bouncer/shared/model/BouncerMessageStrings.kt
@@ -115,7 +115,16 @@ object BouncerMessageStrings {
             secureLockDevice() && secureLockDeviceEnabled ->
                 Pair(R.string.kg_prompt_title_after_secure_lock_device, wrongInputMessage)
             wrongInputMessage != 0 ->
-                Pair(wrongInputMessage, incorrectSecurityInputSecondaryMessage(fpAuthIsAllowed))
+                Pair(
+                    wrongInputMessage,
+                    // The second factor PIN bouncer is only reached after a biometric has already
+                    // succeeded, so fingerprint is never an alternative to it; don't suggest it.
+                    if (securityMode == BiometricSecondFactorPin) {
+                        0
+                    } else {
+                        incorrectSecurityInputSecondaryMessage(fpAuthIsAllowed)
+                    },
+                )
             else -> EmptyMessage
         }
     }


### PR DESCRIPTION
See previous from 16-qpr2:
https://github.com/GrapheneOS/platform_frameworks_base/commit/e38a7a0cb960c144a877522f270dc397159dd3fa#diff-011b32fdcd5ea1e2e73efc213d16ecc75b1882828437db6372ebf47fec388a7aR347-R354

Add back missing mLockDomain parameter (from 16-qpr2: https://github.com/GrapheneOS/platform_frameworks_base/blob/16-qpr2/packages/SystemUI/src/com/android/keyguard/KeyguardAbsKeyInputViewController.java#L351)

Adjust to new Android 17 changes from
https://github.com/GrapheneOS/platform_frameworks_base/commit/853fa2055aaae476eb636116b2533e2ae305afb31 to prevent showing incorrect message "Or unlock with fingerprint" when failing 2FA pin