### PR TITLE
Fix VPN app update disabling always on and leak blocking

### DIFF
--- a/services/core/java/com/android/server/VpnManagerService.java
+++ b/services/core/java/com/android/server/VpnManagerService.java
@@ -622,6 +622,9 @@ public class VpnManagerService extends IVpnManager.Stub {
                 logw("User " + userId + " has no Vpn configuration");
                 return false;
             }
+            if (!mUserManager.isUserUnlocked(userId)) {
+                return false;
+            }
             if (!vpn.setAlwaysOnPackage(packageName, lockdown, lockdownAllowlist)) {
                 return false;
             }
@@ -881,7 +884,7 @@ public class VpnManagerService extends IVpnManager.Stub {
         final int userId = UserHandle.getUserId(uid);
         synchronized (mVpns) {
             final Vpn vpn = mVpns.get(userId);
-            if (vpn == null) {
+            if (vpn == null || !mUserManager.isUserUnlocked(userId)) {
                 return;
             }
             // Legacy always-on VPN won't be affected since the package name is not set.

--- a/services/core/java/com/android/server/connectivity/Vpn.java
+++ b/services/core/java/com/android/server/connectivity/Vpn.java
@@ -1146,6 +1146,13 @@ public class Vpn {
      *     was no always-on VPN to start. {@code false} otherwise.
      */
     public boolean startAlwaysOnVpn() {
+        // If the user is locked and the always on package has not marked its VpnService as
+        // directBootAware then isAlwaysOnPackageSupported() will return false. As a result, the
+        // package will be removed as the always on package and in turn leak blocking will be
+        // disabled too.
+        if (!mUserManager.isUserUnlocked(mUserId)) {
+            throw new IllegalStateException("attempted to start VPN prior to unlocking user");
+        }
         final String alwaysOnPackage;
         synchronized (this) {
             alwaysOnPackage = getAlwaysOnPackage();


### PR DESCRIPTION
When a VPN app is updated and a user with that app set as the always-on VPN is started but not unlocked, then that app is removed as the always-on VPN for that user which in turn also removes leak blocking.

To reproduce this, one can install a VPN, set it as always on, restart the phone and update the package using adb install. After this process, the app will no longer have always on set. Alternatively, install the same VPN app in multiple users, set it as always on in the second user, restart the second user and then update the app in the primary user.

The issue is that `Vpn.startAlwaysOnVpn()` verifies that the package contains a VpnService, and this check doesn't work properly in BFU (unless the VpnService is marked as directBootAware).

Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/8023