### PR TITLE
gmscompat: use fresh file proxy fds for app opens

### DIFF
--- a/core/java/android/os/ParcelFileDescriptor.java
+++ b/core/java/android/os/ParcelFileDescriptor.java
@@ -354,7 +354,7 @@ public class ParcelFileDescriptor implements Parcelable, Closeable {
         final String path = file.getPath();
 
         if (GmsCoreFileServerClientHooks.isEnabled()) {
-            FileDescriptor override = GmsCoreFileServerClientHooks.openParcelFileDescriptorHook(path);
+            FileDescriptor override = GmsCoreFileServerClientHooks.openParcelFileDescriptorHook(path, flags);
             if (override != null) {
                 return override;
             }

--- a/core/java/com/android/internal/gmscompat/dynamite/GmsDynamiteClientHooks.java
+++ b/core/java/com/android/internal/gmscompat/dynamite/GmsDynamiteClientHooks.java
@@ -55,7 +55,7 @@ public final class GmsDynamiteClientHooks {
         return ApkAssets.loadFromFd(fd, path, flags, assets);
     }
 
-    // Replaces file paths of Dynamite modules with "/proc/self/fd" file descriptor references
+    // Replaces file paths of Dynamite modules with "/gmscompat_fd" file descriptor references
     // DelegateLastClassLoader#maybeModifyClassLoaderPath(String, Boolean)
     public static String maybeModifyClassLoaderPath(String path, Boolean nativeLibsPathB) {
         if (path == null) {

--- a/core/java/com/android/internal/gmscompat/dynamite/GmsDynamiteClientHooks.java
+++ b/core/java/com/android/internal/gmscompat/dynamite/GmsDynamiteClientHooks.java
@@ -44,10 +44,10 @@ public final class GmsDynamiteClientHooks {
 
     // ApkAssets#loadFromPath(String, int, AssetsProvider)
     public static ApkAssets loadAssetsFromPath(String path, int flags, AssetsProvider assets) throws IOException {
-        if (!GmsCoreFileServerClientHooks.isInGmsCoreDeDataDir(path)) {
+        if (!GmsCoreFileServerClientHooks.isInGmsCoreDeDataDirAndShouldCacheFds(path)) {
             return null;
         }
-        FileDescriptor fd = GmsCoreFileServerClientHooks.openFile(path);
+        FileDescriptor fd = GmsCoreFileServerClientHooks.openCachedFile(path);
         if (fd == null) {
             throw new IOException("unable to open " + path);
         }
@@ -70,7 +70,7 @@ public final class GmsDynamiteClientHooks {
 
         for (int i = 0; i < pathParts.length; ++i) {
             String pathPart = pathParts[i];
-            if (!GmsCoreFileServerClientHooks.isInGmsCoreDeDataDir(pathPart)) {
+            if (!GmsCoreFileServerClientHooks.isInGmsCoreDeDataDirAndShouldCacheFds(pathPart)) {
                 continue;
             }
             // defined in bionic/linker/linker_utils.cpp kZipFileSeparator
@@ -86,7 +86,7 @@ public final class GmsDynamiteClientHooks {
                 filePath = pathPart;
                 nativeLibRelPath = null;
             }
-            FileDescriptor fd = GmsCoreFileServerClientHooks.openFile(filePath);
+            FileDescriptor fd = GmsCoreFileServerClientHooks.openCachedFile(filePath);
             if (fd == null) {
                 throw new IllegalStateException("unable to open " + filePath);
             }

--- a/core/java/com/android/internal/gmscompat/fileservice/GmsCoreFileServerClientHooks.java
+++ b/core/java/com/android/internal/gmscompat/fileservice/GmsCoreFileServerClientHooks.java
@@ -9,8 +9,6 @@ import android.ext.PackageId;
 import android.os.IBinder;
 import android.os.ParcelFileDescriptor;
 import android.os.RemoteException;
-import android.system.ErrnoException;
-import android.system.Os;
 import android.util.ArrayMap;
 import android.util.Log;
 
@@ -22,8 +20,8 @@ import java.io.FileDescriptor;
 import java.util.ArrayList;
 
 import libcore.io.IoBridge;
+import libcore.io.IoUtils;
 
-import static android.system.OsConstants.F_DUPFD_CLOEXEC;
 import static android.system.OsConstants.O_ACCMODE;
 import static android.system.OsConstants.O_RDONLY;
 
@@ -59,13 +57,9 @@ public class GmsCoreFileServerClientHooks {
         File.lastModifiedHook = GmsCoreFileServerClientHooks::getFileLastModified;
         IoBridge.openFdInterceptor = new IoBridge.OpenFdInterceptor() {
             @Override
-            public FileDescriptor maybeInterceptOpenFd(String path, int flags) throws ErrnoException {
+            public FileDescriptor maybeInterceptOpenFd(String path, int flags) {
                 if (isInGmsCoreDataDir(path) && shouldProxyOpen(flags)) {
-                    FileDescriptor fd = openFile(path);
-                    if (fd == null) {
-                        return null;
-                    }
-                    return Os.dup(fd);
+                    return openFreshFileDescriptor(path);
                 }
                 return null;
             }
@@ -77,17 +71,38 @@ public class GmsCoreFileServerClientHooks {
         final String path = file.getPath();
 
         if (isInGmsCoreDataDir(path)) {
-            FileDescriptor fd = openFile(path);
-            if (fd != null) {
-                String fdPath = "/proc/self/fd/" + fd.getInt$();
-                return new File(fdPath).lastModified();
+            if (shouldCacheForLastModified(path)) {
+                FileDescriptor fd = openCachedFile(path);
+                return fd != null ? getFileLastModified(fd) : 0L;
+            }
+
+            ParcelFileDescriptor pfd = openFreshParcelFileDescriptor(path);
+            if (pfd != null) {
+                try {
+                    return getFileLastModified(pfd.getFileDescriptor());
+                } finally {
+                    IoUtils.closeQuietly(pfd);
+                }
             }
         }
         return 0L;
     }
 
-    public static boolean isInGmsCoreDeDataDir(String path) {
+    private static long getFileLastModified(FileDescriptor fd) {
+        return new File("/proc/self/fd/" + fd.getInt$()).lastModified();
+    }
+
+    public static boolean isInGmsCoreDeDataDirAndShouldCacheFds(String path) {
         return path.startsWith(gmsCoreDeDataPrefix);
+    }
+
+    private static boolean shouldCacheForLastModified(String path) {
+        // Use cache for Dynamite modules which are served as .apk files
+        return isInGmsCoreDeDataDirAndShouldCacheFds(path) && isApkContainerPath(path);
+    }
+
+    private static boolean isApkContainerPath(String path) {
+        return path.endsWith(".apk");
     }
 
     public static boolean isInGmsCoreDataDir(String path) {
@@ -99,28 +114,14 @@ public class GmsCoreFileServerClientHooks {
             return null;
         }
 
-        FileDescriptor fd = openFile(path);
-        if (fd == null) {
-            return null;
-        }
-
-        int dupFd;
-        try {
-            dupFd = Os.fcntlInt(fd, F_DUPFD_CLOEXEC, 0);
-        } catch (ErrnoException e) {
-            throw new RuntimeException(e);
-        }
-
-        var dupJfd = new FileDescriptor();
-        dupJfd.setInt$(dupFd);
-        return dupJfd;
+        return openFreshFileDescriptor(path);
     }
 
     // Returned file descriptor should never be closed because it may be accessed at any time by the native code
     @Nullable
-    public static FileDescriptor openFile(String path) {
+    public static FileDescriptor openCachedFile(String path) {
         if (DEBUG) {
-            Log.d(TAG, "path " + path, new Throwable());
+            Log.d(TAG, "cached path " + path, new Throwable());
         }
         try {
             ArrayMap<String, ParcelFileDescriptor> cache = pfdCache;
@@ -146,6 +147,36 @@ public class GmsCoreFileServerClientHooks {
 
     private static boolean shouldProxyOpen(int flags) {
         return (flags & O_ACCMODE) == O_RDONLY;
+    }
+
+    @Nullable
+    private static FileDescriptor openFreshFileDescriptor(String path) {
+        ParcelFileDescriptor pfd = openFreshParcelFileDescriptor(path);
+        if (pfd == null) {
+            return null;
+        }
+
+        FileDescriptor fd = new FileDescriptor();
+        fd.setInt$(pfd.detachFd());
+        return fd;
+    }
+
+    @Nullable
+    private static ParcelFileDescriptor openFreshParcelFileDescriptor(String path) {
+        if (DEBUG) {
+            Log.d(TAG, "fresh path " + path, new Throwable());
+        }
+        try {
+            IFileProxyService service;
+            synchronized (pfdCache) {
+                service = getFileProxyService();
+            }
+            return service.openFile(path);
+        } catch (RemoteException e) {
+            // FileProxyService never forwards exceptions to minimize the information leaks,
+            // this is a very rare "binder died" exception
+            throw e.rethrowAsRuntimeException();
+        }
     }
 
     @GuardedBy("pfdCache")

--- a/core/java/com/android/internal/gmscompat/fileservice/GmsCoreFileServerClientHooks.java
+++ b/core/java/com/android/internal/gmscompat/fileservice/GmsCoreFileServerClientHooks.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import libcore.io.IoBridge;
 
 import static android.system.OsConstants.F_DUPFD_CLOEXEC;
+import static android.system.OsConstants.O_ACCMODE;
+import static android.system.OsConstants.O_RDONLY;
 
 public class GmsCoreFileServerClientHooks {
     private static final String TAG = "GmsCoreFileServerClientHooks";
@@ -58,7 +60,7 @@ public class GmsCoreFileServerClientHooks {
         IoBridge.openFdInterceptor = new IoBridge.OpenFdInterceptor() {
             @Override
             public FileDescriptor maybeInterceptOpenFd(String path, int flags) throws ErrnoException {
-                if (path.startsWith(gmsCoreDeDataPrefix) || path.startsWith(gmsCoreCeDataPrefix)) {
+                if (isInGmsCoreDataDir(path) && shouldProxyOpen(flags)) {
                     FileDescriptor fd = openFile(path);
                     if (fd == null) {
                         return null;
@@ -92,8 +94,8 @@ public class GmsCoreFileServerClientHooks {
         return path.startsWith(gmsCoreDeDataPrefix) || path.startsWith(gmsCoreCeDataPrefix);
     }
 
-    public static FileDescriptor openParcelFileDescriptorHook(String path) {
-        if (!isInGmsCoreDataDir(path)) {
+    public static FileDescriptor openParcelFileDescriptorHook(String path, int flags) {
+        if (!isInGmsCoreDataDir(path) || !shouldProxyOpen(flags)) {
             return null;
         }
 
@@ -140,6 +142,10 @@ public class GmsCoreFileServerClientHooks {
             // this is a very rare "binder died" exception
             throw e.rethrowAsRuntimeException();
         }
+    }
+
+    private static boolean shouldProxyOpen(int flags) {
+        return (flags & O_ACCMODE) == O_RDONLY;
     }
 
     @GuardedBy("pfdCache")


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7978

Normal Java file opens such as FileInputStream and ParcelFileDescriptor.open() expect each
open to return a fresh descriptor owned and closed by the caller. The regular GMS data file
hooks instead returned dup()s of the cached descriptor used for Dynamite /gmscompat_fd_N
paths. dup() shares the same open file description, so repeated app reads can inherit another
reader's offset and parse truncated Phenotype snapshots. Keep the cache only for Dynamite and
open fresh read-only proxy fds for normal Java file opens.

Maestro / Pixel Buds app errors:

```
E Maestro_kph: Failed to parse snapshot from shared storage for com.google.android.apps.wearables.maestro.companion#com.google.android.apps.wearables.maestro.companion
E Maestro_kph: myz: While parsing a protocol message, the input ended unexpectedly in the middle of a field.  This could mean either that the input has been truncated or that an embedded message misreported its own length.
E Maestro_kph: 	at mxq.Y(PG:29)
E Maestro_kph: 	at mxq.j(PG:9)
E Maestro_kph: 	at mxq.o(PG:1)
E Maestro_kph: 	at kpy.b(PG:1)
E Maestro_kph: 	at krz.a(PG:377)
E Maestro_kph: 	at fmq.apply(PG:16)
E Maestro_kph: 	at lzn.e(PG:3)
E Maestro_kph: 	at lzo.run(PG:38)
E Maestro_kph: 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:520)
E Maestro_kph: 	at java.util.concurrent.FutureTask.run(FutureTask.java:328)
E Maestro_kph: 	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:323)
E Maestro_kph: 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1100)
E Maestro_kph: 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
E Maestro_kph: 	at java.lang.Thread.run(Thread.java:1572)
```