### PR TITLE
SettingsProvider: never discard TEXT_SHOW_PASSWORD during migration; run TEXT_SHOW_PASSWORD migration again

### DIFF
--- a/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
@@ -2132,9 +2132,6 @@ class DatabaseHelper extends SQLiteOpenHelper {
             loadIntegerSetting(stmt, Settings.System.POINTER_SPEED,
                     R.integer.def_pointer_speed);
 
-            loadBooleanSetting(stmt, Settings.System.TEXT_SHOW_PASSWORD,
-                    R.bool.def_text_show_password);
-
             /*
              * IMPORTANT: Do not add any more upgrade steps here as the global,
              * secure, and system settings are no longer stored in a database

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
@@ -4551,8 +4551,19 @@ public class SettingsProvider extends ContentProvider {
                         SETTINGS_TYPE_SECURE, mUserId, mDeviceId);
 
                 // Try an update from the current state.
-                final int oldVersion = secureSettings.getVersionLocked();
+                int oldVersion = secureSettings.getVersionLocked();
                 final int newVersion = SETTINGS_VERSION;
+
+                if (oldVersion == 236) {
+                     SettingsState systemSettings = getSystemSettingsLocked(mUserId, mDeviceId);
+                     if (systemSettings
+                            .getSettingLocked(Settings.System.TEXT_SHOW_PASSWORD)
+                            .isNull()) {
+                         Log.i(LOG_TAG, "Setting.System.TEXT_SHOW_PASSWORD is null, " +
+                                 "running adjusted 235 migration");
+                         oldVersion = 235;
+                     }
+                }
 
                 // If up do date - done.
                 if (oldVersion == newVersion) {
@@ -7201,10 +7212,23 @@ public class SettingsProvider extends ContentProvider {
                     currentVersion = 235;
                 }
 
-                // Version 235: Migrate the value of TEXT_SHOW_PASSWORD to TEXT_SHOW_PASSWORD_TOUCH.
+                // Version 235: Handle TEXT_SHOW_PASSWORD and TEXT_SHOW_PASSWORD_TOUCH.
                 if (currentVersion == 235) {
-                    final Setting showPasswordSetting =
+                    Setting showPasswordSetting =
                             systemSettings.getSettingLocked(Settings.System.TEXT_SHOW_PASSWORD);
+
+                    // Upstream variant of 235 migration discarded default value of TEXT_SHOW_PASSWORD
+                    if (showPasswordSetting.isNull()) {
+                        boolean defValue = resources.getBoolean(R.bool.def_text_show_password);
+                        systemSettings.insertSettingOverrideableByRestoreLocked(
+                                Settings.System.TEXT_SHOW_PASSWORD,
+                                defValue ? "1" : "0",
+                                null /* tag */,
+                                true /* makeDefault */,
+                                SettingsState.SYSTEM_PACKAGE_NAME);
+                        showPasswordSetting =
+                            systemSettings.getSettingLocked(Settings.System.TEXT_SHOW_PASSWORD);
+                    }
 
                     if (!showPasswordSetting.isNull()) {
                         final String lastUpdatedBy = showPasswordSetting.getPackageName();

--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
@@ -7208,11 +7208,7 @@ public class SettingsProvider extends ContentProvider {
 
                     if (!showPasswordSetting.isNull()) {
                         final String lastUpdatedBy = showPasswordSetting.getPackageName();
-                        if (SettingsState.SYSTEM_PACKAGE_NAME.equals(lastUpdatedBy)) {
-                            // Skip migration and clear setting: it was set by the system during the
-                            // version 230 upgrade, not by the user.
-                            systemSettings.deleteSettingLocked(Settings.System.TEXT_SHOW_PASSWORD);
-                        } else {
+                        if (!SettingsState.SYSTEM_PACKAGE_NAME.equals(lastUpdatedBy)) {
                             // Preserve the user's custom preference for TEXT_SHOW_PASSWORD by
                             // migrating it to TEXT_SHOW_PASSWORD_TOUCH.
                             String value = showPasswordSetting.getValue();


### PR DESCRIPTION
TEXT_SHOW_PASSWORD was split into TEXT_SHOW_PASSWORD_TOUCH and TEXT_SHOW_PASSWORD_PHYSICAL but framework still uses TEXT_SHOW_PASSWORD instead of TEXT_SHOW_PASSWORD_TOUCH for targetSdk < 37 apps.

This meant that by default, the "Settings > Security & privacy > Privacy controls > Show passwords for touchscreen" setting applied only to targetSdk >= 37 apps. The setting applied to all apps if it was manually changed before or after the Android 17 upgrade.