### PR TITLE
rebuild coarse locations from allowlisted fields

### DIFF
--- a/services/core/java/com/android/server/location/fudger/LocationFudger.java
+++ b/services/core/java/com/android/server/location/fudger/LocationFudger.java
@@ -175,16 +175,21 @@ public class LocationFudger {
         // update the offsets in use
         updateOffsets();
 
-        Location coarse = new Location(fine);
+        // Build the coarse location from an allowlist: start from a fresh location and copy only
+        // non-sensitive fields, so no present or future Location field can leak fine-grained data
+        // to coarse-only apps.
+        Location coarse = new Location(fine.getProvider());
+        coarse.setTime(fine.getTime());
+        coarse.setElapsedRealtimeNanos(fine.getElapsedRealtimeNanos());
+        if (fine.hasElapsedRealtimeUncertaintyNanos()) {
+            coarse.setElapsedRealtimeUncertaintyNanos(fine.getElapsedRealtimeUncertaintyNanos());
+        }
+        // The mock flag is not location data and must survive so mock locations stay identifiable
+        // (isMock()) and are cleared correctly when a test provider is removed.
+        coarse.setMock(fine.isMock());
 
-        // clear any fields that could leak more detailed location information
-        coarse.removeBearing();
-        coarse.removeSpeed();
-        coarse.removeAltitude();
-        coarse.setExtras(null);
-
-        double latitude = wrapLatitude(coarse.getLatitude());
-        double longitude = wrapLongitude(coarse.getLongitude());
+        double latitude = wrapLatitude(fine.getLatitude());
+        double longitude = wrapLongitude(fine.getLongitude());
 
         // add offsets - update longitude first using the non-offset latitude
         longitude += wrapLongitude(metersToDegreesLongitude(mLongitudeOffsetM, latitude));
@@ -221,7 +226,7 @@ public class LocationFudger {
 
         coarse.setLatitude(coarsened[LAT_INDEX]);
         coarse.setLongitude(coarsened[LNG_INDEX]);
-        coarse.setAccuracy(Math.max(accuracy, coarse.getAccuracy()));
+        coarse.setAccuracy(Math.max(accuracy, fine.getAccuracy()));
 
         synchronized (this) {
             mCachedFineLocation = fine;

--- a/services/tests/mockingservicestests/src/com/android/server/am/AsyncProcessStartTest.java
+++ b/services/tests/mockingservicestests/src/com/android/server/am/AsyncProcessStartTest.java
@@ -201,7 +201,7 @@ public class AsyncProcessStartTest {
             return null;
         }).when(thread).bindApplication(
                 any(), any(),
-                any(), any(), anyBoolean(),
+                any(), any(), any(), anyBoolean(),
                 any(), any(),
                 any(), any(),
                 any(),
@@ -262,7 +262,7 @@ public class AsyncProcessStartTest {
         mProcessList.handleProcessStartedLocked(app, app.getPid(), /* usingWrapper */ false,
                 /* expectedStartSeq */ 0, /* procAttached */ false);
 
-        app.getThread().bindApplication(PACKAGE, appInfo,
+        app.getThread().bindApplication(null, PACKAGE, appInfo,
                 null, null, false,
                 null,
                 null,

--- a/services/tests/mockingservicestests/src/com/android/server/am/ProcessObserverTest.java
+++ b/services/tests/mockingservicestests/src/com/android/server/am/ProcessObserverTest.java
@@ -206,7 +206,7 @@ public class ProcessObserverTest {
             return null;
         }).when(thread).bindApplication(
                 any(), any(),
-                any(), any(), anyBoolean(),
+                any(), any(), any(), anyBoolean(),
                 any(), any(),
                 any(), any(),
                 any(),
@@ -251,7 +251,7 @@ public class ProcessObserverTest {
         final ApplicationInfo appInfo = makeApplicationInfo(PACKAGE);
         mProcessList.handleProcessStartedLocked(app, app.getPid(), /* usingWrapper */ false,
                 /* expectedStartSeq */ 0, /* procAttached */ false);
-        app.getThread().bindApplication(PACKAGE, appInfo,
+        app.getThread().bindApplication(null, PACKAGE, appInfo,
                 null, null, false,
                 null,
                 null,

--- a/services/tests/mockingservicestests/src/com/android/server/location/fudger/LocationFudgerTest.java
+++ b/services/tests/mockingservicestests/src/com/android/server/location/fudger/LocationFudgerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 
 import android.location.Location;
 import android.location.flags.Flags;
+import android.os.Bundle;
 import android.platform.test.annotations.Presubmit;
 import android.util.Log;
 
@@ -76,20 +77,52 @@ public class LocationFudgerTest {
 
     @Test
     public void testCoarsen() {
-        // test that the coarsened location is not the same as the fine location and no leaks
+        // Coarsening must drop every position-sensitive field while carrying only the
+        // non-sensitive fields that downstream code and LocationResult.validate() rely on. Every
+        // sensitive field is set on the fine input, so a regression that copies any of them is
+        // caught here; fields Location gains in the future are covered by the allowlist
+        // construction itself rather than by this test.
         for (int i = 0; i < 100; i++) {
             Location fine = createLocation("test", mRandom);
+            fine.setElapsedRealtimeUncertaintyNanos(1);
             fine.setBearing(1);
+            fine.setBearingAccuracyDegrees(1);
             fine.setSpeed(1);
+            fine.setSpeedAccuracyMetersPerSecond(1);
             fine.setAltitude(1);
+            fine.setVerticalAccuracyMeters(1);
+            fine.setMslAltitudeMeters(1);
+            fine.setMslAltitudeAccuracyMeters(1);
+            fine.setMock(true);
+            Bundle extras = new Bundle();
+            extras.putString("secret", "leak");
+            fine.setExtras(extras);
 
             Location coarse = mFudger.createCoarse(fine);
 
             assertThat(coarse).isNotNull();
             assertThat(coarse).isNotSameInstanceAs(fine);
+
+            // No position-sensitive field may leak to coarse-only apps.
             assertThat(coarse.hasBearing()).isFalse();
+            assertThat(coarse.hasBearingAccuracy()).isFalse();
             assertThat(coarse.hasSpeed()).isFalse();
+            assertThat(coarse.hasSpeedAccuracy()).isFalse();
             assertThat(coarse.hasAltitude()).isFalse();
+            assertThat(coarse.hasVerticalAccuracy()).isFalse();
+            assertThat(coarse.hasMslAltitude()).isFalse();
+            assertThat(coarse.hasMslAltitudeAccuracy()).isFalse();
+            assertThat(coarse.getExtras()).isNull();
+
+            // Non-sensitive fields required for correctness must survive.
+            assertThat(coarse.getProvider()).isEqualTo(fine.getProvider());
+            assertThat(coarse.getTime()).isEqualTo(fine.getTime());
+            assertThat(coarse.getElapsedRealtimeNanos()).isEqualTo(fine.getElapsedRealtimeNanos());
+            assertThat(coarse.hasElapsedRealtimeUncertaintyNanos()).isTrue();
+            assertThat(coarse.getElapsedRealtimeUncertaintyNanos())
+                    .isEqualTo(fine.getElapsedRealtimeUncertaintyNanos());
+            assertThat(coarse.isMock()).isTrue();
+
             assertThat(coarse.getAccuracy()).isEqualTo(ACCURACY_M);
             assertThat(coarse.distanceTo(fine)).isGreaterThan(1F);
             assertThat(coarse).isNearby(fine, MAX_COARSE_FUDGE_DISTANCE_M);

--- a/services/tests/mockingservicestests/src/com/android/server/trust/TrustManagerServiceTest.java
+++ b/services/tests/mockingservicestests/src/com/android/server/trust/TrustManagerServiceTest.java
@@ -94,6 +94,7 @@ import android.view.WindowManagerGlobal;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.android.internal.infra.AndroidFuture;
+import com.android.internal.widget.LockDomain;
 import com.android.internal.widget.LockPatternUtils;
 import com.android.internal.widget.LockPatternUtils.StrongAuthTracker;
 import com.android.internal.widget.LockPatternUtils.StrongAuthTracker.StrongAuthFlags;
@@ -747,7 +748,7 @@ public class TrustManagerServiceTest {
                     ArgumentCaptor.forClass(LockSettingsStateListener.class);
             verify(mLockSettingsInternal).registerLockSettingsStateListener(captor.capture());
             LockSettingsStateListener listener = captor.getValue();
-            listener.onAuthenticationSucceeded(userId);
+            listener.onAuthenticationSucceeded(userId, LockDomain.Primary);
         } else {
             mTrustManager.reportUnlockAttempt(/* successful= */ true, userId);
         }
@@ -759,7 +760,7 @@ public class TrustManagerServiceTest {
                     ArgumentCaptor.forClass(LockSettingsStateListener.class);
             verify(mLockSettingsInternal).registerLockSettingsStateListener(captor.capture());
             LockSettingsStateListener listener = captor.getValue();
-            listener.onAuthenticationFailed(userId);
+            listener.onAuthenticationFailed(userId, LockDomain.Primary);
         } else {
             mTrustManager.reportUnlockAttempt(/* successful= */ false, userId);
         }


### PR DESCRIPTION
`LocationFudger.createCoarse()` scrubbed the coarse location handed to apps holding only `ACCESS_COARSE_LOCATION` via a blocklist: it copied the entire fine location and then removed bearing, speed, altitude, and extras. The blocklist missed the mean sea level altitude and its accuracy, leaking the fine vertical position to coarse-only apps. It also missed the vertical, bearing, and speed accuracy fields, which carry their own field-mask bits, and any `Location` field added in the future would leak the same way by default.

Switch the scrub to an allowlist. Construct a fresh `Location` and copy over only the non-sensitive fields: provider, Unix epoch time, elapsed realtime, elapsed realtime uncertainty, and the mock flag (required so mock locations stay identifiable and are cleared when a test provider is removed). The coarsened latitude, longitude, and accuracy are then set as before. Every other present or future field is dropped, so the scrub now fails closed.

Extend `LocationFudgerTest#testCoarsen` to set every position-sensitive field on the fine input (altitude, MSL altitude and accuracy, vertical accuracy, bearing and accuracy, speed and accuracy, extras) and assert none survive coarsening while the allowlisted fields do.

Verified end-to-end on a Pixel 8a: with a fine fix carrying `mslAlt`, an app holding only coarse location receives the coarsened lat/lng/accuracy and no altitude fields.

The two `fixup!` commits repair pre-existing compilation breakage of `FrameworksMockingServicesTests` on 17 (the `LockDomain` parameter on `LockSettingsStateListener` and the `bindApplication` signature change) so the test can run; they are marked `fixup!` against the commits that introduced the breakage.