### PR TITLE
SystemUI: run scroll capture tile handling on main thread

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/screenshot/scroll/ScrollCaptureController.java
+++ b/packages/SystemUI/src/com/android/systemui/screenshot/scroll/ScrollCaptureController.java
@@ -236,10 +236,11 @@ public class ScrollCaptureController {
             Log.d(TAG, "requestNextTile: CANCELLED");
             return;
         }
-        mTileFuture = mSession.requestTile(topPx);
-        mTileFuture.addListener(() -> {
+        ListenableFuture<CaptureResult> tileFuture = mSession.requestTile(topPx);
+        mTileFuture = tileFuture;
+        tileFuture.addListener(() -> {
             try {
-                onCaptureResult(mTileFuture.get());
+                onCaptureResult(tileFuture.get());
             } catch (CancellationException e) {
                 Log.e(TAG, "requestTile cancelled");
             } catch (InterruptedException | ExecutionException e) {
@@ -248,7 +249,7 @@ public class ScrollCaptureController {
                     mCaptureCompleter.setException(e);
                 }
             }
-        }, mBgExecutor);
+        }, mContext.getMainExecutor());
     }
 
     private void onCaptureResult(CaptureResult result) {


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7393

ImageTileSet is marked as UiThread and its addTile will post to main handler when not called on main thread. Run future listener on main thread to ensure addTile call in the listener is executed synchronously.

Test: manual on MTE device with long scroll screenshots (race condition so not deterministic; also likely requires app with custom `ScrollCaptureCallback`)
Test: atest SystemUITests:com.android.systemui.screenshot.scroll.ScrollCaptureControllerTest
Test: atest SystemUITests:com.android.systemui.screenshot.scroll.ScrollCaptureClientTest
Test: atest FrameworksCoreTests:android.view.ScrollCaptureConnectionTest
Test: atest FrameworksCoreTests:android.view.ViewGroupScrollCaptureTest
Test: atest FrameworksCoreTests:android.view.ScrollCaptureSearchResultsTest