### PR TITLE
gmscompat: add MODIFY_PHONE_STATE to Android Auto phone call permissions

### DIFF
--- a/services/core/java/com/android/server/pm/ext/AndroidAutoHooks.java
+++ b/services/core/java/com/android/server/pm/ext/AndroidAutoHooks.java
@@ -119,6 +119,7 @@ public class AndroidAutoHooks extends PackageHooks {
             case Manifest.permission.CALL_PHONE:
             case Manifest.permission.CALL_PRIVILEGED:
             case Manifest.permission.CONTROL_INCALL_EXPERIENCE:
+            case Manifest.permission.MODIFY_PHONE_STATE:
             // unprivileged permission
             case Manifest.permission.READ_PHONE_STATE:
             case Manifest.permission.READ_PRIVILEGED_PHONE_STATE_ANDROID_AUTO:


### PR DESCRIPTION
Recent Android Auto version use the AudioManager.setCommunicationDevice() method which is protected by this permission.