### PR TITLE
add secure spawn file descriptor regression test

### DIFF
--- a/tests/GosCompatTests/GosCompatSecureSpawnTests/GosCompatSecureSpawnApp/src/app/grapheneos/goscompat/securespawn/SecureSpawnDeviceTest.java
+++ b/tests/GosCompatTests/GosCompatSecureSpawnTests/GosCompatSecureSpawnApp/src/app/grapheneos/goscompat/securespawn/SecureSpawnDeviceTest.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import app.grapheneos.goscompat.securespawn.shared.SecureSpawnDumpableCheck;
+import app.grapheneos.goscompat.securespawn.shared.SecureSpawnFileDescriptorCheck;
 import app.grapheneos.goscompat.securespawn.shared.SecureSpawnHiddenApiCheck;
 import app.grapheneos.goscompat.securespawn.shared.SecureSpawnReflectiveDumpCheck;
 import app.grapheneos.goscompat.securespawn.shared.SecureSpawnSmapsCheck;
@@ -60,6 +61,20 @@ public final class SecureSpawnDeviceTest {
                 .that(result.androidRuntimeSections()).isGreaterThan(0);
         assertWithMessage(failureMessage("expected isWithinMemoryBounds == true", result))
                 .that(result.isWithinMemoryBounds()).isTrue();
+    }
+
+    @Test
+    public void fdStateCheck() {
+        SecureSpawnCheck.ProcessState processState = SecureSpawnCheck.processState();
+        SecureSpawnFileDescriptorCheck.FileDescriptorState result =
+                SecureSpawnFileDescriptorCheck.run();
+        Log.i(TAG, "fdStateCheck\n" + processState + "\n" + result);
+        assertProcessState(processState);
+        assertDescriptorState("framework", result.framework(), result);
+        assertDescriptorState("sharedMemory", result.sharedMemory(), result);
+        assertWithMessage(failureMessage(
+                "expected detached mount ID regression == false", result))
+                .that(result.hasDetachedMountIdRegression()).isFalse();
     }
 
     @Test
@@ -153,6 +168,19 @@ public final class SecureSpawnDeviceTest {
                 .that(result.pid()).isGreaterThan(0);
         assertWithMessage(failureMessage("expected tid > 0", result))
                 .that(result.tid()).isGreaterThan(0);
+    }
+
+    private static void assertDescriptorState(
+            String name,
+            SecureSpawnFileDescriptorCheck.DescriptorState state,
+            SecureSpawnFileDescriptorCheck.FileDescriptorState result) {
+        if (!state.present()) {
+            return;
+        }
+        assertWithMessage(failureMessage("expected " + name + " fd >= 0", result))
+                .that(state.fd()).isAtLeast(0);
+        assertWithMessage(failureMessage("expected " + name + " mount ID > 0", result))
+                .that(state.mountId()).isGreaterThan(0);
     }
 
     private static String failureMessage(String expectation, Object result) {

--- a/tests/GosCompatTests/GosCompatSecureSpawnTests/GosCompatSecureSpawnApp/src/app/grapheneos/goscompat/securespawn/shared/SecureSpawnFileDescriptorCheck.java
+++ b/tests/GosCompatTests/GosCompatSecureSpawnTests/GosCompatSecureSpawnApp/src/app/grapheneos/goscompat/securespawn/shared/SecureSpawnFileDescriptorCheck.java
@@ -1,0 +1,184 @@
+package app.grapheneos.goscompat.securespawn.shared;
+
+import android.os.ParcelFileDescriptor;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public final class SecureSpawnFileDescriptorCheck {
+    private static final String FRAMEWORK_TARGET = "/system/framework/framework.jar";
+    private static final String SHARED_MEMORY_TARGET = "/dev/ashmem";
+    private static final String MOUNT_ID_LABEL = "mnt_id:";
+    private static final long FRAMEWORK_DETACHED_MOUNT_ID_LIMIT = 1024L;
+    private static final long SHARED_MEMORY_DETACHED_MOUNT_ID_LIMIT = 1280L;
+
+    private SecureSpawnFileDescriptorCheck() {
+    }
+
+    public static FileDescriptorState run() {
+        Descriptor framework = findDescriptor(FRAMEWORK_TARGET);
+        if (framework == null) {
+            return new FileDescriptorState(
+                    DescriptorState.absent(),
+                    DescriptorState.absent(),
+                    FRAMEWORK_DETACHED_MOUNT_ID_LIMIT,
+                    SHARED_MEMORY_DETACHED_MOUNT_ID_LIMIT);
+        }
+        Set<Long> visibleMountIds = readVisibleMountIds();
+        DescriptorState frameworkState = toState(framework, visibleMountIds);
+        Descriptor sharedMemory = frameworkState.mountIdInMountInfo()
+                ? findDescriptor(SHARED_MEMORY_TARGET) : null;
+        return new FileDescriptorState(
+                frameworkState,
+                toState(sharedMemory, visibleMountIds),
+                FRAMEWORK_DETACHED_MOUNT_ID_LIMIT,
+                SHARED_MEMORY_DETACHED_MOUNT_ID_LIMIT);
+    }
+
+    private static DescriptorState toState(Descriptor descriptor, Set<Long> visibleMountIds) {
+        if (descriptor == null) {
+            return DescriptorState.absent();
+        }
+        return new DescriptorState(
+                true,
+                descriptor.sourceFd(),
+                descriptor.mountId(),
+                visibleMountIds.contains(descriptor.mountId()));
+    }
+
+    private static Descriptor findDescriptor(String targetPrefix) {
+        File directory = new File("/proc/self/fd");
+        String[] names = directory.list();
+        if (names == null) {
+            throw new IllegalStateException("Unable to list " + directory);
+        }
+
+        ArrayList<Integer> descriptors = new ArrayList<>(names.length);
+        for (String name : names) {
+            try {
+                descriptors.add(Integer.parseInt(name));
+            } catch (NumberFormatException ignored) {
+                // procfs may grow non-numeric entries in the future.
+            }
+        }
+        Collections.sort(descriptors);
+
+        for (int sourceFd : descriptors) {
+            ParcelFileDescriptor snapshot;
+            try {
+                snapshot = ParcelFileDescriptor.fromFd(sourceFd);
+            } catch (IOException e) {
+                // Ignore descriptors which closed after the directory snapshot.
+                continue;
+            }
+
+            try (snapshot) {
+                int snapshotFd = snapshot.getFd();
+                File snapshotLink = new File(directory, Integer.toString(snapshotFd));
+                String target = Files.readSymbolicLink(snapshotLink.toPath()).toString();
+                if (target.startsWith(targetPrefix)) {
+                    return new Descriptor(sourceFd, readMountId(snapshotFd));
+                }
+            } catch (IOException e) {
+                throw new IllegalStateException(
+                        "Unable to inspect descriptor snapshot for fd " + sourceFd, e);
+            }
+        }
+
+        return null;
+    }
+
+    private static long readMountId(int fd) throws IOException {
+        File fdinfo = new File("/proc/self/fdinfo/" + fd);
+        try (BufferedReader reader = new BufferedReader(new FileReader(fdinfo))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.startsWith(MOUNT_ID_LABEL)) {
+                    return parseMountId(line.substring(MOUNT_ID_LABEL.length()), fdinfo);
+                }
+            }
+        }
+        throw new IllegalStateException("Mount ID not found in " + fdinfo);
+    }
+
+    private static Set<Long> readVisibleMountIds() {
+        File mountinfo = new File("/proc/self/mountinfo");
+        HashSet<Long> result = new HashSet<>();
+        try (BufferedReader reader = new BufferedReader(new FileReader(mountinfo))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                int separator = line.indexOf(' ');
+                if (separator <= 0) {
+                    throw new IllegalStateException("Malformed line in " + mountinfo);
+                }
+                result.add(parseMountId(line.substring(0, separator), mountinfo));
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to read " + mountinfo, e);
+        }
+        if (result.isEmpty()) {
+            throw new IllegalStateException("No mount IDs found in " + mountinfo);
+        }
+        return result;
+    }
+
+    private static long parseMountId(String value, File source) {
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("Invalid mount ID in " + source, e);
+        }
+    }
+
+    private record Descriptor(int sourceFd, long mountId) {}
+
+    public record DescriptorState(
+            boolean present,
+            int fd,
+            long mountId,
+            boolean mountIdInMountInfo) {
+        private static DescriptorState absent() {
+            return new DescriptorState(false, -1, -1, false);
+        }
+    }
+
+    public record FileDescriptorState(
+            DescriptorState framework,
+            DescriptorState sharedMemory,
+            long frameworkDetachedMountIdLimit,
+            long sharedMemoryDetachedMountIdLimit) {
+        public boolean hasDetachedMountIdRegression() {
+            if (!framework().present()) {
+                return false;
+            }
+            if (!framework().mountIdInMountInfo()) {
+                return framework().mountId() > frameworkDetachedMountIdLimit();
+            }
+            return sharedMemory().present()
+                    && !sharedMemory().mountIdInMountInfo()
+                    && sharedMemory().mountId() > sharedMemoryDetachedMountIdLimit();
+        }
+
+        @Override
+        public String toString() {
+            return "frameworkDescriptorPresent=" + framework().present()
+                    + "\nframeworkFd=" + framework().fd()
+                    + "\nframeworkMountId=" + framework().mountId()
+                    + "\nframeworkMountIdInMountInfo=" + framework().mountIdInMountInfo()
+                    + "\nsharedMemoryDescriptorPresent=" + sharedMemory().present()
+                    + "\nsharedMemoryFd=" + sharedMemory().fd()
+                    + "\nsharedMemoryMountId=" + sharedMemory().mountId()
+                    + "\nsharedMemoryMountIdInMountInfo=" + sharedMemory().mountIdInMountInfo()
+                    + "\nframeworkDetachedMountIdLimit=" + frameworkDetachedMountIdLimit()
+                    + "\nsharedMemoryDetachedMountIdLimit=" + sharedMemoryDetachedMountIdLimit()
+                    + "\nhasDetachedMountIdRegression=" + hasDetachedMountIdRegression();
+        }
+    }
+}

--- a/tests/GosCompatTests/GosCompatSecureSpawnTests/src/app/grapheneos/goscompat/securespawn/tests/SecureSpawnDisabledHostTest.java
+++ b/tests/GosCompatTests/GosCompatSecureSpawnTests/src/app/grapheneos/goscompat/securespawn/tests/SecureSpawnDisabledHostTest.java
@@ -52,4 +52,14 @@ public final class SecureSpawnDisabledHostTest extends SecureSpawnHostTestBase {
                 new int[0]);
         runDeviceTest(MEMORY_ACCOUNTING_METHOD);
     }
+
+    @Test
+    public void hardenedMallocOffFdStateCheck() throws Exception {
+        resetPackageState();
+        editPackageState(
+                new int[] { GosPackageStateFlag.USE_HARDENED_MALLOC_NON_DEFAULT },
+                new int[] { GosPackageStateFlag.USE_HARDENED_MALLOC });
+        runDeviceTest("notExecSpawnedCompatZygote");
+        runDeviceTest(FD_STATE_METHOD);
+    }
 }

--- a/tests/GosCompatTests/GosCompatSecureSpawnTests/src/app/grapheneos/goscompat/securespawn/tests/SecureSpawnHostTestBase.java
+++ b/tests/GosCompatTests/GosCompatSecureSpawnTests/src/app/grapheneos/goscompat/securespawn/tests/SecureSpawnHostTestBase.java
@@ -34,6 +34,7 @@ abstract class SecureSpawnHostTestBase extends BaseHostJUnit4Test {
     private static final String ROOT_CAUSE_LOG_TAG_PROPERTY = "log.tag." + ROOT_CAUSE_LOG_TAG;
     protected static final String MEMORY_ACCOUNTING_METHOD =
             "runtimeMemoryAccountingCheck";
+    protected static final String FD_STATE_METHOD = "fdStateCheck";
     private static final String HIDDEN_API_METHOD =
             "hiddenApiEnforcementCheck";
     private static final String TEST_API_COMPAT_DEFAULT_METHOD =
@@ -95,6 +96,11 @@ abstract class SecureSpawnHostTestBase extends BaseHostJUnit4Test {
     @Test
     public void acyclicReflectiveDumpCheck() throws Exception {
         runCheckCase(ACYCLIC_REFLECTIVE_DUMP_METHOD);
+    }
+
+    @Test
+    public void fdStateCheck() throws Exception {
+        runCheckCase(FD_STATE_METHOD);
     }
 
     protected void runDeviceTest(String methodName) throws Exception {
@@ -228,6 +234,9 @@ abstract class SecureSpawnHostTestBase extends BaseHostJUnit4Test {
     private static String resultLogName(String methodName) {
         if (MEMORY_ACCOUNTING_METHOD.equals(methodName)) {
             return "memory_accounting";
+        }
+        if (FD_STATE_METHOD.equals(methodName)) {
+            return "fd_state";
         }
         if (HIDDEN_API_METHOD.equals(methodName)) {
             return "hidden_api";


### PR DESCRIPTION
Check framework and shared memory descriptor mount state under secure exec, primary zygote and compatibility zygote process startup. Select the compatibility zygote through the allocator package state instead of the umbrella compatibility mode.

Test: `atest GosCompatSecureSpawnTests:SecureSpawn{Enabled,Disabled}HostTest#fdStateCheck GosCompatSecureSpawnTests:SecureSpawnDisabledHostTest#hardenedMallocOffFdStateCheck`