### PR TITLE
start compat zygote at boot instead of starting it on-demand; exec spawning: skip redundant mount namespace setup

### DIFF
--- a/core/java/android/os/ZygoteProcess.java
+++ b/core/java/android/os/ZygoteProcess.java
@@ -145,6 +145,8 @@ public class ZygoteProcess implements IZygoteProcess {
 
         private final List<String> mAbiList;
 
+        boolean lazyPreloadCompleted;
+
         private boolean mClosed;
 
         private ZygoteState(LocalSocketAddress zygoteSocketAddress,
@@ -791,9 +793,23 @@ public class ZygoteProcess implements IZygoteProcess {
         synchronized(mLock) {
             // The USAP pool can not be used if the application will not use the systems graphics
             // driver.  If that driver is requested use the Zygote application start path.
-            return zygoteSendArgsAndGetResult(openZygoteSocketIfNeeded(abi, zygoteExtArgs.getZygoteSelectionMode()),
-                                              zygotePolicyFlags,
-                                              argsForZygote);
+
+            ZygoteState zygoteState = openZygoteSocketIfNeeded(abi, zygoteExtArgs.getZygoteSelectionMode());
+
+            if (zygoteState == mZygoteStates[ZygoteType.Compat.ordinal()] && !zygoteState.lazyPreloadCompleted) {
+                long start = SystemClock.elapsedRealtime();
+                try {
+                    if (!preloadDefault(zygoteState)) {
+                        throw new ZygoteStartFailedEx("compat zygote preloading failed");
+                    }
+                } catch (IOException e) {
+                    throw new ZygoteStartFailedEx("compat zygote preloading failed", e);
+                }
+                Log.i(LOG_TAG, "waited " + (SystemClock.elapsedRealtime() - start) + " ms for compat zygote preloading");
+                zygoteState.lazyPreloadCompleted = true;
+            }
+
+            return zygoteSendArgsAndGetResult(zygoteState, zygotePolicyFlags, argsForZygote);
         }
     }
 
@@ -1189,8 +1205,14 @@ public class ZygoteProcess implements IZygoteProcess {
     public boolean preloadDefault(String abi) throws ZygoteStartFailedEx, IOException {
         synchronized (mLock) {
             ZygoteState state = openZygoteSocketIfNeeded(abi,
-                    // preloadDefault() is called only for 32-bit zygote
+                    // preloadDefault(abi) is called only for 32-bit zygote
                     ZygoteSelectionMode.Regular);
+            return preloadDefault(state);
+        }
+    }
+
+    boolean preloadDefault(ZygoteState state) throws IOException {
+        synchronized (mLock) {
             // Each query starts with the argument count (1 in this case)
             state.mZygoteOutputWriter.write("1");
             state.mZygoteOutputWriter.newLine();

--- a/core/java/android/os/ZygoteProcess.java
+++ b/core/java/android/os/ZygoteProcess.java
@@ -895,6 +895,7 @@ public class ZygoteProcess implements IZygoteProcess {
         }
         if (Build.SUPPORTED_64_BIT_ABIS.length > 0) {
             bootCompleted(Build.SUPPORTED_64_BIT_ABIS[0], ZygoteSelectionMode.Regular);
+            bootCompleted(Build.SUPPORTED_64_BIT_ABIS[0], ZygoteSelectionMode.PreferCompatZygote);
         }
     }
 
@@ -1070,58 +1071,14 @@ public class ZygoteProcess implements IZygoteProcess {
             if (Log.isLoggable(LOG_TAG, Log.VERBOSE)) {
                 Log.v(LOG_TAG, "attemptConnectionToZygote " + type, new Throwable());
             }
-            if (type == ZygoteType.Compat) {
-                if (!"running".equals(SystemProperties.get("init.svc.zygote_compat", null))) {
-                    long start = SystemClock.elapsedRealtime();
-                    startCompatZygote();
-                    Log.d(LOG_TAG, "waited " + (SystemClock.elapsedRealtime() - start) + " ms for compat zygote");
-                }
-            }
             zygoteState =
                     ZygoteState.connect(mZygoteSocketAddresses[typeIdx], mUsapPoolSocketAddresses[typeIdx]);
             mZygoteStates[typeIdx] = zygoteState;
 
             maybeSetApiDenylistExemptions(zygoteState, false);
             maybeSetHiddenApiAccessLogSampleRate(zygoteState);
-            if (type == ZygoteType.Compat) {
-                // compat zygote is started on-demand, it might not be running when bootCompleted()
-                // is dispatched to other zygotes
-                bootCompleted(Build.SUPPORTED_64_BIT_ABIS[0], ZygoteSelectionMode.PreferCompatZygote);
-            }
         }
         return zygoteState;
-    }
-
-    @GuardedBy("mLock")
-    private void startCompatZygote() throws IOException {
-        SystemProperties.set("sys.start_compat_zygote", "1");
-        boolean started = false;
-        LocalSocketAddress zygoteSocketAddress = mZygoteSocketAddresses[ZygoteType.Compat.ordinal()];
-
-        try (var zygoteSocket = new LocalSocket()) {
-            // The following loop is a lighter-weight variant of waitForConnectionToZygote(). Note
-            // that both mLock and the global ActivityManagerService lock are held at this point.
-            // zygote_compat startup usually completes in under 2 seconds. Starting zygote_compat
-            // lazily saves ~200 MiB of RAM as of Android 16 QPR2 when zygote_compat isn't needed.
-            final int TIMEOUT_MS = 20_000;
-            final int RETRY_DELAY_MS = 10;
-            int numRetries = TIMEOUT_MS / RETRY_DELAY_MS;
-            for (int i = 0; i < numRetries; ++i) {
-                try {
-                    zygoteSocket.connect(zygoteSocketAddress);
-                    started = true;
-                    break;
-                } catch (IOException e) {
-                    if ((i % 50) == 0) {
-                        Log.d(LOG_TAG, "waiting for compat zygote to start");
-                    }
-                    SystemClock.sleep(RETRY_DELAY_MS);
-                }
-            }
-        }
-        if (!started) {
-            throw new RuntimeException("timed out while waiting for compat zygote");
-        }
     }
 
     /**

--- a/core/java/com/android/internal/os/ExecSpawning.java
+++ b/core/java/com/android/internal/os/ExecSpawning.java
@@ -133,6 +133,10 @@ public class ExecSpawning {
                 case "org.chromium.chrome.app.TrichromeZygotePreload":
                 case "org.chromium.content_public.app.ZygotePreload":
                 case "org.mozilla.gecko.process.ZygotePreload":
+                // VosZygotePreload is used by https://www.v-key.com/products/v-os-mobile-app-protection/
+                // Its checks don't pass for an unknown reason when exec spawning is used, but
+                // skipping them entirely works at least for some apps (e.g. for com.dbs.sg.dbsmbanking app)
+                case "vkey.android.vos.VosZygotePreload":
                     Log.i(TAG, "skipping Java ZygotePreload: " + zygotePreloadName);
                     return true;
                 default:

--- a/core/jni/com_android_internal_os_Zygote.cpp
+++ b/core/jni/com_android_internal_os_Zygote.cpp
@@ -2863,7 +2863,9 @@ static void com_android_internal_os_Zygote_nativeInitNativeState(JNIEnv* env, jc
    * Storage Initialization
    */
 
-  UnmountStorageOnInit(env);
+  if (!gIsExecSpawning) {
+    UnmountStorageOnInit(env);
+  }
 
   /*
    * Performance Initialization


### PR DESCRIPTION
Depends on: https://github.com/GrapheneOS/platform_system_core/pull/43