### PR TITLE
workaround original-package issue with Vanadium manifest properties

### DIFF
--- a/services/core/java/com/android/server/pm/IPackageManagerBase.java
+++ b/services/core/java/com/android/server/pm/IPackageManagerBase.java
@@ -64,6 +64,7 @@ import android.util.Log;
 import com.android.internal.R;
 import com.android.internal.content.InstallLocationUtils;
 import com.android.internal.util.CollectionUtils;
+import com.android.server.pm.pkg.AndroidPackage;
 import com.android.server.pm.pkg.PackageStateInternal;
 import com.android.server.pm.verify.domain.DomainVerificationManagerInternal;
 import com.android.server.pm.verify.domain.proxy.DomainVerificationProxyV1;
@@ -719,7 +720,20 @@ public abstract class IPackageManagerBase extends IPackageManager.Stub {
         if (packageState == null) {
             return null;
         }
-        return mPackageProperty.getProperty(propertyName, packageName, className);
+        final PackageManager.Property property =
+                mPackageProperty.getProperty(propertyName, packageName, className);
+        // original-package changes Vanadium's effective package name, but Property retains the
+        // manifest package name used while parsing and PackageProperty indexes it by that name.
+        final String legacyVanadiumPkgName = "org.chromium.chrome";
+        final String realVanadiumPkgName = "app.vanadium.browser";
+        final AndroidPackage pkg = packageState.getPkg();
+        if (property == null && pkg != null
+                && legacyVanadiumPkgName.equals(packageName)
+                && legacyVanadiumPkgName.equals(pkg.getPackageName())
+                && realVanadiumPkgName.equals(pkg.getManifestPackageName())) {
+            return mPackageProperty.getProperty(propertyName, realVanadiumPkgName, className);
+        }
+        return property;
     }
 
     @Nullable

--- a/services/tests/PackageManagerServiceTests/host/src/com/android/server/pm/test/HostUtils.kt
+++ b/services/tests/PackageManagerServiceTests/host/src/com/android/server/pm/test/HostUtils.kt
@@ -89,12 +89,15 @@ internal fun retryUntilSuccess(block: () -> Boolean) {
 
 internal object HostUtils {
 
-    fun getDataDir(device: ITestDevice, pkgName: String) =
-            device.executeShellCommand("dumpsys package $pkgName")
-                    .lineSequence()
-                    .map(String::trim)
-                    .single { it.startsWith("dataDir=") }
-                    .removePrefix("dataDir=")
+    fun getDataDir(device: ITestDevice, pkgName: String): String {
+        val userHeader = "User ${device.currentUser}:"
+        return packageSection(device, pkgName)
+                .dropWhile { !it.startsWith(userHeader) }
+                .drop(1)
+                .takeWhile { !it.startsWith("User ") }
+                .single { it.startsWith("dataDir=") }
+                .removePrefix("dataDir=")
+    }
 
     fun makePathForApk(fileName: String, partition: Partition) =
             makePathForApk(File(fileName), partition)


### PR DESCRIPTION
Vanadium uses app.vanadium.browser as its manifest package while migrated installations retain
org.chromium.chrome as their effective package. PackageManager.Property retains the manifest name,
so PackageProperty indexes native service properties under app.vanadium.browser.

NativeApplicationThreadWrapper looks up the native service library with:

```java
PackageManager.Property libNameProperty =
        mMgr.getPackageManager()
                .getPropertyAsUser(
                        PackageManager.PROPERTY_NATIVE_SERVICE_LIBRARY_NAME,
                        info.packageName,
                        info.getComponentName().getClassName(),
                        userId);
if (libNameProperty != null) libName = libNameProperty.getString();
```

info is the ServiceInfo passed to scheduleCreateService() for the native service. Its packageName is
the effective org.chromium.chrome identity. Looking up the property with that name misses the entry
stored under app.vanadium.browser, leaving libName as libmain.so instead of libmonochrome_64.so.
Upstream original-package doesn't handle manifest properties.

Keep validating package installation and visibility with the effective name. Look up that property
key first, then retry with the manifest name only when both identities on the parsed package exactly
match migrated Vanadium. This keeps the workaround from affecting other package renames and
preserves an effective name property if one is present.

Test: manual, with Vanadium using old org.chromium.chrome app id, updating to a Vanadium APK with
app.vanadium.browser app id with javaless renderers enabled. Browser pages load instead of showing
errors logcat about failing to open libmain.so