### PR TITLE
allow using any WebView provider on debuggable OS builds

### DIFF
--- a/services/core/java/com/android/server/webkit/WebViewUpdateServiceImpl2.java
+++ b/services/core/java/com/android/server/webkit/WebViewUpdateServiceImpl2.java
@@ -515,6 +515,9 @@ class WebViewUpdateServiceImpl2 {
                 return allProviders[n];
             }
         }
+        if (mSystemInterface.systemIsDebuggable()) {
+            return new WebViewProviderInfo(packageName, "Stub WebViewProviderInfo", false, false, null);
+        }
         return null;
     }
 


### PR DESCRIPTION
To change the WebView provider implementation, run
`adb shell cmd webviewupdate set-webview-implementation PACKAGE_NAME`.