### PR TITLE
gmscompat: notify about missing POST_NOTIFICATIONS only for GmsCore

### DIFF
--- a/core/java/android/app/NotificationManager.java
+++ b/core/java/android/app/NotificationManager.java
@@ -923,7 +923,7 @@ public class NotificationManager {
             @CanBeALL @CanBeCURRENT UserHandle user)
     {
         if (GmsCompat.isEnabled()) {
-            if (!GmsCompat.hasPermission(Manifest.permission.POST_NOTIFICATIONS)) {
+            if (GmsCompat.isGmsCore() && !GmsCompat.hasPermission(Manifest.permission.POST_NOTIFICATIONS)) {
                 String pkg = GmsCompat.appContext().getPackageName();
                 try {
                     GmsCompatApp.iGms2Gca().showMissingPostNotifsPermissionNotification(pkg);


### PR DESCRIPTION
Other GMS components (e.g. Play Store) handle lack of POST_NOTIFICATIONS themselves.