### PR TITLE
backport 17 QPR1 Beta 5 fix for widgets disappearing after reboot

### DIFF
--- a/services/appwidget/java/com/android/server/appwidget/AppWidgetServiceImpl.java
+++ b/services/appwidget/java/com/android/server/appwidget/AppWidgetServiceImpl.java
@@ -4191,21 +4191,19 @@ class AppWidgetServiceImpl extends IAppWidgetService.Stub implements WidgetBacku
             // provide widgets.
             flags |= PackageManager.MATCH_DEBUG_TRIAGED_MISSING;
 
-            // Widget hosts that are non-crypto aware may be hosting widgets
-            // from a profile that is still locked, so let them see those
-            // widgets.
-            if (isProfileWithUnlockedParent(userId)) {
-                flags |= PackageManager.MATCH_DIRECT_BOOT_AWARE
-                        | PackageManager.MATCH_DIRECT_BOOT_UNAWARE;
-            }
+            flags |= PackageManager.MATCH_DIRECT_BOOT_AWARE
+                    | PackageManager.MATCH_DIRECT_BOOT_UNAWARE;
 
             // Widgets referencing shared libraries need to have their
             // dependencies loaded.
             flags |= PackageManager.GET_SHARED_LIBRARY_FILES;
 
-            return mPackageManager.queryIntentReceivers(intent,
+            List<ResolveInfo> receivers = mPackageManager.queryIntentReceivers(intent,
                     intent.resolveTypeIfNeeded(mContext.getContentResolver()),
                     flags, userId).getList();
+            Slog.i(TAG, "queryIntentReceivers for user " + userId + " found: "
+                    + receivers.size() + " receivers.");
+            return receivers;
         } catch (RemoteException re) {
             Slog.w(TAG, "Failed to query intent receivers for user " + userId, re);
             return null;
@@ -4238,6 +4236,7 @@ class AppWidgetServiceImpl extends IAppWidgetService.Stub implements WidgetBacku
             Trace.traceEnd(Trace.TRACE_TAG_ACTIVITY_MANAGER);
 
             final int N = mProviders.size();
+            Slog.i(TAG, "handleUserUnlocked: " + userId + " mProviders size: " + N);
             for (int i = 0; i < N; i++) {
                 Provider provider = mProviders.get(i);
 
@@ -5258,18 +5257,6 @@ class AppWidgetServiceImpl extends IAppWidgetService.Stub implements WidgetBacku
             }
         } finally {
             Binder.restoreCallingIdentity(token);
-        }
-        return false;
-    }
-
-    private boolean isProfileWithUnlockedParent(int userId) {
-        UserInfo userInfo = mUserManager.getUserInfo(userId);
-        if (userInfo != null && userInfo.isProfile()) {
-            UserInfo parentInfo = mUserManager.getProfileParent(userId);
-            if (parentInfo != null
-                    && mUserManager.isUserUnlockingOrUnlocked(parentInfo.getUserHandle())) {
-                return true;
-            }
         }
         return false;
     }


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/8541

Before the parent user is unlocked, a widget host running from a direct boot aware component can call AppWidgetHost.stopListening() before user is unlocked, causing AppWidgetService to load provider state for the entire profile group. Without explicit direct boot match flags, PackageManager returns only direct boot aware providers and the reduced provider set is cached for the boot session. This bug also removes non-direct-boot-aware widgets from widgets picker.

Always query both direct boot aware and unaware widget providers, matching the 17 QPR1 Beta 5 fix. APIs returning widget/provider data still require the calling user to be unlocked.

Note that this doesn't seem to be easily reproducible without such a direct boot aware app calling
AppWidgetHost.stopListening()