### PR TITLE
SettingsProvider: initialize display color mode to Natural

### DIFF
--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
@@ -3758,6 +3758,8 @@ public class SettingsProvider extends ContentProvider {
             UpgradeController upgrader = new UpgradeController(userId, deviceId);
             upgrader.upgradeIfNeededLocked();
 
+            initializeDisplayColorModeLocked(userId, deviceId);
+
             // Init immutable settings
             int[] typesToInit = userId == UserHandle.USER_SYSTEM ?
                     new int[] { SETTINGS_TYPE_GLOBAL, SETTINGS_TYPE_SECURE, SETTINGS_TYPE_SYSTEM, } :
@@ -3785,6 +3787,27 @@ public class SettingsProvider extends ContentProvider {
                 }
             }
             return true;
+        }
+
+        private void initializeDisplayColorModeLocked(int userId, int deviceId) {
+            if (deviceId != Context.DEVICE_ID_DEFAULT) {
+                return;
+            }
+
+            final SettingsState systemSettings = getSettingsLocked(
+                    SETTINGS_TYPE_SYSTEM, userId, deviceId);
+            if (systemSettings == null || !systemSettings.getSettingLocked(
+                    Settings.System.DISPLAY_COLOR_MODE).isNull()) {
+                return;
+            }
+
+            systemSettings.insertSettingOverrideableByRestoreLocked(
+                    Settings.System.DISPLAY_COLOR_MODE,
+                    Integer.toString(
+                            android.hardware.display.ColorDisplayManager.COLOR_MODE_NATURAL),
+                    /* tag= */ null,
+                    /* makeDefault= */ true,
+                    SettingsState.SYSTEM_PACKAGE_NAME);
         }
 
         private void ensureSettingsStateLocked(long key) {


### PR DESCRIPTION
Use Natural as the default display color mode.

ColorDisplayService falls back to `persist.sys.sf.native_mode` if `Settings.System.DISPLAY_COLOR_MODE` is unset. Pixel `config_accessibilityColorMode` selects Saturated for accessibility color transforms. Applying this mode changes the prop, so disabling the transform can leave the unset setting reading the temporary prop state instead of restoring Natural.

Materialize the default in `DISPLAY_COLOR_MODE` for each user's default device settings state if it is unset. Run this after upstream settings migrations to avoid consuming an upstream settings version while preserving explicit user choices.

Test: after fastboot flashall -w, `adb shell settings get system display_color_mode` shows 0 instead of null
Test: after fastboot flashall -w, Natural remains selected after toggling color inversion in accessibility settings