### PR TITLE
Add Settings.Secure.HIDE_NAVIGATION_HANDLE setting

### DIFF
--- a/core/api/system-current.txt
+++ b/core/api/system-current.txt
@@ -5821,6 +5821,7 @@ package android.ext {
   }
 
   public interface KnownSystemPackage {
+    field public static final int LAUNCHER = 4; // 0x4
     field public static final int SETTINGS = 0; // 0x0
     field public static final int SETUP_WIZARD = 3; // 0x3
     field public static final int SHELL = 1; // 0x1

--- a/core/java/android/ext/KnownSystemPackage.java
+++ b/core/java/android/ext/KnownSystemPackage.java
@@ -13,6 +13,7 @@ public interface KnownSystemPackage {
     int SHELL = 1;
     int SYSTEM_UI = 2;
     int SETUP_WIZARD = 3;
+    int LAUNCHER = 4;
 
     /** @hide */
     @IntDef(value = {
@@ -20,6 +21,7 @@ public interface KnownSystemPackage {
             SHELL,
             SYSTEM_UI,
             SETUP_WIZARD,
+            LAUNCHER,
     })
     @Retention(RetentionPolicy.SOURCE)
     @interface Enum {}

--- a/core/java/android/ext/KnownSystemPackages.java
+++ b/core/java/android/ext/KnownSystemPackages.java
@@ -49,6 +49,7 @@ public final class KnownSystemPackages {
             case KnownSystemPackage.SHELL -> shell;
             case KnownSystemPackage.SYSTEM_UI -> systemUi;
             case KnownSystemPackage.SETUP_WIZARD -> setupWizard;
+            case KnownSystemPackage.LAUNCHER -> launcher;
             default -> throw new IllegalArgumentException();
         };
     }

--- a/core/java/android/ext/settings/ExtSettings.java
+++ b/core/java/android/ext/settings/ExtSettings.java
@@ -100,6 +100,9 @@ public class ExtSettings {
     public static final BoolSetting DISALLOW_DELAYED_LOCKING_ON_USER_STOP = new BoolSetting(
             Setting.Scope.PER_USER, Settings.Secure.DISALLOW_DELAYED_LOCKING_ON_USER_STOP, false);
 
+    public static final BoolSetting HIDE_NAVIGATION_HANDLE = new BoolSetting(
+            Setting.Scope.PER_USER, Settings.Secure.HIDE_NAVIGATION_HANDLE, false);
+
     private ExtSettings() {}
 
     public static Function<Context, Boolean> defaultBool(@BoolRes int res) {

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -7524,7 +7524,7 @@ public final class Settings {
         public static final String DISALLOW_DELAYED_LOCKING_ON_USER_STOP = "disallow_delayed_locking_on_user_stop";
 
         /** @hide */
-        @Protected(restrictReads = false, readWrite = KnownSystemPackage.SETTINGS)
+        @Protected(read = KnownSystemPackage.LAUNCHER, readWrite = KnownSystemPackage.SETTINGS)
         public static final String HIDE_NAVIGATION_HANDLE = "hide_navigation_handle";
 
         // ExtSettings END

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -12507,6 +12507,12 @@ public final class Settings {
                 "assist_touch_gesture_enabled";
 
         /**
+         * Whether the navigation hint pill is hidden in gesture navigation mode.
+         * @hide
+         */
+        public static final String HIDE_NAVIGATION_HANDLE = "hide_navigation_handle";
+
+        /**
          * Whether the assistant can be triggered by long-pressing the home button
          *
          * @hide

--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -7523,6 +7523,10 @@ public final class Settings {
         @Protected(readWrite = KnownSystemPackage.SETTINGS)
         public static final String DISALLOW_DELAYED_LOCKING_ON_USER_STOP = "disallow_delayed_locking_on_user_stop";
 
+        /** @hide */
+        @Protected(restrictReads = false, readWrite = KnownSystemPackage.SETTINGS)
+        public static final String HIDE_NAVIGATION_HANDLE = "hide_navigation_handle";
+
         // ExtSettings END
 
         // NOTE: If you add new settings here, be sure to add them to
@@ -12505,12 +12509,6 @@ public final class Settings {
          */
         public static final String ASSIST_TOUCH_GESTURE_ENABLED =
                 "assist_touch_gesture_enabled";
-
-        /**
-         * Whether the navigation hint pill is hidden in gesture navigation mode.
-         * @hide
-         */
-        public static final String HIDE_NAVIGATION_HANDLE = "hide_navigation_handle";
 
         /**
          * Whether the assistant can be triggered by long-pressing the home button


### PR DESCRIPTION
Adds a new secure setting, _hide_navigation_handle_, controlling whether the navigation handle in gesture navigation mode (the hint pill on the bottom of the screen) is drawn (default) or hidden.


This feature has been referenced as acceptable by the GrapheneOS team, by @thestinger in [#2760](https://github.com/GrapheneOS/os-issue-tracker/issues/2760#issuecomment-3046177708), it has been implemented in this PR as instructed: _"[It] should not remove the reserved space in apps without edge-to-edge support to avoid breaking app compatibility. It should only hide the navigation zone hint."_

This feature is implemented in 3 repos:
- Settings app: adds the user-facing toggle ([link](https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/448))
- Launcher3: consumes the setting and hides the handle ([link](https://github.com/GrapheneOS/platform_packages_apps_Launcher3/pull/83))

<img width="1280" height="760" alt="image" src="https://github.com/user-attachments/assets/bafd3856-b0c2-4f51-aa02-5597d698d8d9" />
